### PR TITLE
refactor: read compaction threshold from ChatPageInput

### DIFF
--- a/site/src/api/queries/chats.ts
+++ b/site/src/api/queries/chats.ts
@@ -2159,7 +2159,7 @@ export const updateUserChatPersonalModelOverride = (
 	},
 });
 
-const userCompactionThresholdsKey = [
+export const userCompactionThresholdsKey = [
 	...chatConfigKey,
 	"compaction-thresholds",
 	"me",

--- a/site/src/modules/aiModels/ModelSelector.tsx
+++ b/site/src/modules/aiModels/ModelSelector.tsx
@@ -35,7 +35,6 @@ export interface ModelSelectorOption {
 	model: string;
 	displayName: string;
 	contextLimit?: number;
-	compressionThreshold?: number;
 	reasoningEffortDefault?: string;
 	reasoningEfforts?: readonly string[];
 }

--- a/site/src/modules/aiModels/ModelSelector.tsx
+++ b/site/src/modules/aiModels/ModelSelector.tsx
@@ -35,6 +35,7 @@ export interface ModelSelectorOption {
 	model: string;
 	displayName: string;
 	contextLimit?: number;
+	compressionThreshold?: number;
 	reasoningEffortDefault?: string;
 	reasoningEfforts?: readonly string[];
 }

--- a/site/src/pages/AgentsPage/AgentChatPage.stories.tsx
+++ b/site/src/pages/AgentsPage/AgentChatPage.stories.tsx
@@ -20,6 +20,7 @@ import {
 	organizationChatModelsKey,
 	toChatListParams,
 	userChatProviderConfigsKey,
+	userCompactionThresholds,
 } from "#/api/queries/chats";
 import { preferenceSettingsKey } from "#/api/queries/users";
 import { workspaceByIdKey } from "#/api/queries/workspaces";
@@ -38,6 +39,7 @@ import {
 	MockGroup,
 	MockOrganizationMember,
 	MockOrganizationMember2,
+	MockUserChatCompactionThresholds,
 	MockUserOwner,
 	MockUserPreferenceSettings,
 	MockWorkspace,
@@ -385,6 +387,10 @@ const buildQueries = (
 		{
 			key: preferenceSettingsKey,
 			data: MockUserPreferenceSettings,
+		},
+		{
+			key: userCompactionThresholds().queryKey,
+			data: MockUserChatCompactionThresholds,
 		},
 	];
 };

--- a/site/src/pages/AgentsPage/AgentChatPage.stories.tsx
+++ b/site/src/pages/AgentsPage/AgentChatPage.stories.tsx
@@ -20,7 +20,7 @@ import {
 	organizationChatModelsKey,
 	toChatListParams,
 	userChatProviderConfigsKey,
-	userCompactionThresholds,
+	userCompactionThresholdsKey,
 } from "#/api/queries/chats";
 import { preferenceSettingsKey } from "#/api/queries/users";
 import { workspaceByIdKey } from "#/api/queries/workspaces";
@@ -389,7 +389,7 @@ const buildQueries = (
 			data: MockUserPreferenceSettings,
 		},
 		{
-			key: userCompactionThresholds().queryKey,
+			key: userCompactionThresholdsKey,
 			data: MockUserChatCompactionThresholds,
 		},
 	];

--- a/site/src/pages/AgentsPage/AgentChatPage.tsx
+++ b/site/src/pages/AgentsPage/AgentChatPage.tsx
@@ -1146,6 +1146,7 @@ const AgentChatPage: FC = () => {
 					effectiveSelectedModel={effectiveSelectedModel}
 					setSelectedModel={setSelectedModel}
 					modelOptions={modelOptions}
+					models={modelCatalog?.models}
 					modelSelectorPlaceholder={modelSelectorPlaceholder}
 					modelSelectorHelp={modelSelectorHelp}
 					modelCatalogError={modelsQuery.error}

--- a/site/src/pages/AgentsPage/AgentChatPage.tsx
+++ b/site/src/pages/AgentsPage/AgentChatPage.tsx
@@ -42,7 +42,6 @@ import {
 	updateChatWorkspace,
 	updateInfiniteChatsCache,
 	userChatDebugLogging,
-	userCompactionThresholds,
 } from "#/api/queries/chats";
 import { deploymentSSHConfig } from "#/api/queries/deployment";
 import { userSkills } from "#/api/queries/userSkills";
@@ -122,7 +121,6 @@ import {
 	getUsableDefaultModelIDForOrganization,
 	hasUserFixableProviders,
 	isUnavailableHistoricalModelID,
-	resolveCompactionThreshold,
 	resolveModelOptionId,
 	resolveModelSelector,
 } from "./utils/modelOptions";
@@ -228,7 +226,6 @@ const AgentChatPage: FC = () => {
 		...chatProviderConfigs(),
 		enabled: permissions.editDeploymentConfig,
 	});
-	const userThresholdsQuery = useQuery(userCompactionThresholds());
 	const userDebugLoggingQuery = useQuery(userChatDebugLogging());
 	const mcpServersQuery = useQuery({
 		...mcpServerConfigs(chatOrganizationId),
@@ -580,11 +577,6 @@ const AgentChatPage: FC = () => {
 			)
 		: undefined;
 
-	const compressionThreshold = resolveCompactionThreshold(
-		chatLastModelConfigID,
-		userThresholdsQuery.data?.thresholds,
-		models,
-	);
 	const modelSelectorPlaceholder = getModelSelectorPlaceholder(
 		modelOptions,
 		isModelDataPending,
@@ -1173,7 +1165,6 @@ const AgentChatPage: FC = () => {
 					hasModelOptions={hasModelOptions}
 					isModelCatalogLoading={isModelDataPending}
 					onPlanModeToggle={handlePlanModeToggle}
-					compressionThreshold={compressionThreshold}
 					isInputDisabled={isInputDisabled}
 					isSubmissionPending={isSubmissionPending}
 					isInterruptPending={isInterruptPending}

--- a/site/src/pages/AgentsPage/AgentChatPageView.stories.tsx
+++ b/site/src/pages/AgentsPage/AgentChatPageView.stories.tsx
@@ -13,7 +13,7 @@ import {
 } from "storybook/test";
 import { reactRouterParameters } from "storybook-addon-remix-react-router";
 import { API } from "#/api/api";
-import { userCompactionThresholds } from "#/api/queries/chats";
+import { userCompactionThresholdsKey } from "#/api/queries/chats";
 import { preferenceSettingsKey } from "#/api/queries/users";
 import type * as TypesGen from "#/api/typesGenerated";
 import type { ChatDiffStatus, ChatMessagePart } from "#/api/typesGenerated";
@@ -237,7 +237,7 @@ const meta: Meta<typeof AgentChatPageView> = {
 				data: MockUserPreferenceSettings,
 			},
 			{
-				key: userCompactionThresholds().queryKey,
+				key: userCompactionThresholdsKey,
 				data: MockUserChatCompactionThresholds,
 			},
 		],

--- a/site/src/pages/AgentsPage/AgentChatPageView.stories.tsx
+++ b/site/src/pages/AgentsPage/AgentChatPageView.stories.tsx
@@ -13,6 +13,10 @@ import {
 } from "storybook/test";
 import { reactRouterParameters } from "storybook-addon-remix-react-router";
 import { API } from "#/api/api";
+import {
+	organizationChatModelsKey,
+	userCompactionThresholds,
+} from "#/api/queries/chats";
 import { preferenceSettingsKey } from "#/api/queries/users";
 import type * as TypesGen from "#/api/typesGenerated";
 import type { ChatDiffStatus, ChatMessagePart } from "#/api/typesGenerated";
@@ -24,6 +28,7 @@ import {
 	MockGroup,
 	MockOrganizationMember,
 	MockOrganizationMember2,
+	MockUserChatCompactionThresholds,
 	MockUserOwner,
 	MockUserPreferenceSettings,
 	MockWorkspace,
@@ -168,7 +173,6 @@ const StoryAgentChatPageView: FC<StoryProps> = ({
 		modelOptions: defaultModelOptions,
 		modelSelectorPlaceholder: "Select a model",
 		hasModelOptions: true,
-		compressionThreshold: undefined as number | undefined,
 		isInputDisabled: false,
 		isSubmissionPending: false,
 		isInterruptPending: false,
@@ -233,6 +237,18 @@ const meta: Meta<typeof AgentChatPageView> = {
 			{
 				key: preferenceSettingsKey,
 				data: MockUserPreferenceSettings,
+			},
+			{
+				key: userCompactionThresholds().queryKey,
+				data: MockUserChatCompactionThresholds,
+			},
+			{
+				key: organizationChatModelsKey(MockChat.organization_id),
+				data: {
+					models: [],
+					providers: [],
+					unsupported_providers: [],
+				},
 			},
 		],
 		reactRouter: reactRouterParameters({

--- a/site/src/pages/AgentsPage/AgentChatPageView.stories.tsx
+++ b/site/src/pages/AgentsPage/AgentChatPageView.stories.tsx
@@ -168,6 +168,7 @@ const StoryAgentChatPageView: FC<StoryProps> = ({
 		effectiveSelectedModel: defaultModelID,
 		setSelectedModel: fn(),
 		modelOptions: defaultModelOptions,
+		models: [],
 		modelSelectorPlaceholder: "Select a model",
 		hasModelOptions: true,
 		isInputDisabled: false,

--- a/site/src/pages/AgentsPage/AgentChatPageView.stories.tsx
+++ b/site/src/pages/AgentsPage/AgentChatPageView.stories.tsx
@@ -13,10 +13,7 @@ import {
 } from "storybook/test";
 import { reactRouterParameters } from "storybook-addon-remix-react-router";
 import { API } from "#/api/api";
-import {
-	organizationChatModelsKey,
-	userCompactionThresholds,
-} from "#/api/queries/chats";
+import { userCompactionThresholds } from "#/api/queries/chats";
 import { preferenceSettingsKey } from "#/api/queries/users";
 import type * as TypesGen from "#/api/typesGenerated";
 import type { ChatDiffStatus, ChatMessagePart } from "#/api/typesGenerated";
@@ -241,14 +238,6 @@ const meta: Meta<typeof AgentChatPageView> = {
 			{
 				key: userCompactionThresholds().queryKey,
 				data: MockUserChatCompactionThresholds,
-			},
-			{
-				key: organizationChatModelsKey(MockChat.organization_id),
-				data: {
-					models: [],
-					providers: [],
-					unsupported_providers: [],
-				},
 			},
 		],
 		reactRouter: reactRouterParameters({

--- a/site/src/pages/AgentsPage/AgentChatPageView.tsx
+++ b/site/src/pages/AgentsPage/AgentChatPageView.tsx
@@ -138,7 +138,6 @@ interface AgentChatPageViewProps {
 	hasModelOptions: boolean;
 	isModelCatalogLoading?: boolean;
 	onPlanModeToggle?: (enabled: boolean) => void;
-	compressionThreshold: number | undefined;
 	isInputDisabled: boolean;
 	isSubmissionPending: boolean;
 	isInterruptPending: boolean;
@@ -306,7 +305,6 @@ export const AgentChatPageView: FC<AgentChatPageViewProps> = ({
 	hasModelOptions,
 	isModelCatalogLoading = false,
 	onPlanModeToggle,
-	compressionThreshold,
 	isInputDisabled,
 	isSubmissionPending,
 	isInterruptPending,
@@ -924,7 +922,6 @@ export const AgentChatPageView: FC<AgentChatPageViewProps> = ({
 								<ChatPageInput
 									chat={chat}
 									store={store}
-									compressionThreshold={compressionThreshold}
 									onSend={editing.handleSendFromInput}
 									onDeleteQueuedMessage={handleDeleteQueuedMessage}
 									onPromoteQueuedMessage={handlePromoteQueuedMessage}

--- a/site/src/pages/AgentsPage/AgentChatPageView.tsx
+++ b/site/src/pages/AgentsPage/AgentChatPageView.tsx
@@ -124,6 +124,7 @@ interface AgentChatPageViewProps {
 	effectiveSelectedModel: string;
 	setSelectedModel: (model: string) => void;
 	modelOptions: readonly ModelSelectorOption[];
+	models: readonly TypesGen.ChatModel[] | undefined;
 	modelSelectorPlaceholder: string;
 	modelSelectorHelp?: ReactNode;
 	modelCatalogError?: unknown;
@@ -291,6 +292,7 @@ export const AgentChatPageView: FC<AgentChatPageViewProps> = ({
 	effectiveSelectedModel,
 	setSelectedModel,
 	modelOptions,
+	models,
 	modelSelectorPlaceholder,
 	modelSelectorHelp,
 	modelCatalogError,
@@ -922,6 +924,7 @@ export const AgentChatPageView: FC<AgentChatPageViewProps> = ({
 								<ChatPageInput
 									chat={chat}
 									store={store}
+									models={models}
 									onSend={editing.handleSendFromInput}
 									onDeleteQueuedMessage={handleDeleteQueuedMessage}
 									onPromoteQueuedMessage={handlePromoteQueuedMessage}

--- a/site/src/pages/AgentsPage/components/ChatPageContent.stories.tsx
+++ b/site/src/pages/AgentsPage/components/ChatPageContent.stories.tsx
@@ -2,7 +2,10 @@ import { MessageScroller } from "@shadcn/react/message-scroller";
 import type { Meta, StoryObj } from "@storybook/react-vite";
 import type { FC } from "react";
 import { expect, fn, userEvent, waitFor, within } from "storybook/test";
-import { chatPromptsKey, userCompactionThresholds } from "#/api/queries/chats";
+import {
+	chatPromptsKey,
+	userCompactionThresholdsKey,
+} from "#/api/queries/chats";
 import { preferenceSettingsKey } from "#/api/queries/users";
 import type * as TypesGen from "#/api/typesGenerated";
 import { MockChat, MockChatQueuedMessage } from "#/testHelpers/chatEntities";
@@ -43,7 +46,7 @@ const meta = {
 				data: MockUserPreferenceSettings,
 			},
 			{
-				key: userCompactionThresholds().queryKey,
+				key: userCompactionThresholdsKey,
 				data: MockUserChatCompactionThresholds,
 			},
 		],
@@ -55,7 +58,7 @@ type Story = StoryObj<typeof meta>;
 
 const CHAT_ID = "chat-page-content-stories";
 
-const MockUserChatCompactionThresholdsWithOverride: TypesGen.UserChatCompactionThresholds =
+const mockUserChatCompactionThresholdsWithOverride: TypesGen.UserChatCompactionThresholds =
 	{
 		...MockUserChatCompactionThresholds,
 		thresholds: [
@@ -66,7 +69,7 @@ const MockUserChatCompactionThresholdsWithOverride: TypesGen.UserChatCompactionT
 		],
 	};
 
-const compactionModels: readonly TypesGen.ChatModel[] = [
+const mockCompactionModels: readonly TypesGen.ChatModel[] = [
 	{
 		...MockChatModel,
 		id: MockChat.last_model_config_id,
@@ -391,7 +394,7 @@ const CompactionChatPageInput: FC = () => {
 			<ChatPageInput
 				chat={MockChat}
 				store={store}
-				models={compactionModels}
+				models={mockCompactionModels}
 				onSend={fn()}
 				onDeleteQueuedMessage={fn()}
 				onPromoteQueuedMessage={fn()}
@@ -429,8 +432,8 @@ export const CompactsAtUserOverride: Story = {
 				data: MockUserPreferenceSettings,
 			},
 			{
-				key: userCompactionThresholds().queryKey,
-				data: MockUserChatCompactionThresholdsWithOverride,
+				key: userCompactionThresholdsKey,
+				data: mockUserChatCompactionThresholdsWithOverride,
 			},
 			{
 				key: chatPromptsKey(MockChat.id),
@@ -456,7 +459,7 @@ export const CompactsAtHistoricalModelDefault: Story = {
 				data: MockUserPreferenceSettings,
 			},
 			{
-				key: userCompactionThresholds().queryKey,
+				key: userCompactionThresholdsKey,
 				data: MockUserChatCompactionThresholds,
 			},
 			{

--- a/site/src/pages/AgentsPage/components/ChatPageContent.stories.tsx
+++ b/site/src/pages/AgentsPage/components/ChatPageContent.stories.tsx
@@ -2,18 +2,10 @@ import { MessageScroller } from "@shadcn/react/message-scroller";
 import type { Meta, StoryObj } from "@storybook/react-vite";
 import type { FC } from "react";
 import { expect, fn, userEvent, waitFor, within } from "storybook/test";
-import {
-	chatPromptsKey,
-	organizationChatModelsKey,
-	userCompactionThresholds,
-} from "#/api/queries/chats";
+import { chatPromptsKey, userCompactionThresholds } from "#/api/queries/chats";
 import { preferenceSettingsKey } from "#/api/queries/users";
 import type * as TypesGen from "#/api/typesGenerated";
 import { MockChat, MockChatQueuedMessage } from "#/testHelpers/chatEntities";
-import {
-	MockChatModel,
-	MockChatModelProviderDescriptor,
-} from "#/testHelpers/chatModels";
 import {
 	MockUserChatCompactionThresholds,
 	MockUserPreferenceSettings,
@@ -377,20 +369,6 @@ export const CompactsAtUserOverride: Story = {
 				} satisfies TypesGen.UserChatCompactionThresholds,
 			},
 			{
-				key: organizationChatModelsKey(MockChat.organization_id),
-				data: {
-					models: [
-						{
-							...MockChatModel,
-							id: MockChat.last_model_config_id,
-							compression_threshold: 70,
-						},
-					],
-					providers: [MockChatModelProviderDescriptor],
-					unsupported_providers: [],
-				} satisfies TypesGen.OrganizationChatModelsResponse,
-			},
-			{
 				key: chatPromptsKey(MockChat.id),
 				data: { prompts: [] } satisfies TypesGen.ChatPromptsResponse,
 			},
@@ -433,6 +411,7 @@ export const CompactsAtUserOverride: Story = {
 							provider: "openai",
 							model: "gpt-4o",
 							displayName: "GPT-4o",
+							compressionThreshold: 70,
 						},
 					]}
 					modelSelectorPlaceholder="Select model"

--- a/site/src/pages/AgentsPage/components/ChatPageContent.stories.tsx
+++ b/site/src/pages/AgentsPage/components/ChatPageContent.stories.tsx
@@ -428,7 +428,7 @@ export const CompactsAtUserOverride: Story = {
 	parameters: {
 		queries: [
 			{
-				key: preferenceSettings().queryKey,
+				key: preferenceSettingsKey,
 				data: MockUserPreferenceSettings,
 			},
 			{
@@ -455,7 +455,7 @@ export const CompactsAtHistoricalModelDefault: Story = {
 	parameters: {
 		queries: [
 			{
-				key: preferenceSettings().queryKey,
+				key: preferenceSettingsKey,
 				data: MockUserPreferenceSettings,
 			},
 			{

--- a/site/src/pages/AgentsPage/components/ChatPageContent.stories.tsx
+++ b/site/src/pages/AgentsPage/components/ChatPageContent.stories.tsx
@@ -2,10 +2,22 @@ import { MessageScroller } from "@shadcn/react/message-scroller";
 import type { Meta, StoryObj } from "@storybook/react-vite";
 import type { FC } from "react";
 import { expect, fn, userEvent, waitFor, within } from "storybook/test";
+import {
+	chatPromptsKey,
+	organizationChatModelsKey,
+	userCompactionThresholds,
+} from "#/api/queries/chats";
 import { preferenceSettingsKey } from "#/api/queries/users";
 import type * as TypesGen from "#/api/typesGenerated";
 import { MockChat, MockChatQueuedMessage } from "#/testHelpers/chatEntities";
-import { MockUserPreferenceSettings } from "#/testHelpers/entities";
+import {
+	MockChatModel,
+	MockChatModelProviderDescriptor,
+} from "#/testHelpers/chatModels";
+import {
+	MockUserChatCompactionThresholds,
+	MockUserPreferenceSettings,
+} from "#/testHelpers/entities";
 import { ChatWorkspaceContext } from "../context/ChatWorkspaceContext";
 import { createChatStore } from "./ChatConversation/chatStore";
 import { FIXTURE_NOW } from "./ChatConversation/storyFixtures";
@@ -37,6 +49,10 @@ const meta = {
 				key: preferenceSettingsKey,
 				data: MockUserPreferenceSettings,
 			},
+			{
+				key: userCompactionThresholds().queryKey,
+				data: MockUserChatCompactionThresholds,
+			},
 		],
 	},
 } satisfies Meta;
@@ -56,7 +72,6 @@ const StoryChatPageInput: FC<{
 		<ChatPageInput
 			chat={{ ...MockChat, id: "", organization_id: "" }}
 			store={store}
-			compressionThreshold={undefined}
 			onSend={fn()}
 			onDeleteQueuedMessage={fn()}
 			onPromoteQueuedMessage={fn()}
@@ -340,5 +355,104 @@ export const RunningShowsBusyComposer: Story = {
 		expect(canvas.getByText("Also rename the helpers")).toBeInTheDocument();
 		expect(canvas.getByRole("button", { name: "Stop" })).toBeEnabled();
 		expect(canvas.queryByRole("button", { name: "Send" })).toBeNull();
+	},
+};
+
+export const CompactsAtUserOverride: Story = {
+	parameters: {
+		queries: [
+			{
+				key: preferenceSettings().queryKey,
+				data: MockUserPreferenceSettings,
+			},
+			{
+				key: userCompactionThresholds().queryKey,
+				data: {
+					thresholds: [
+						{
+							model_config_id: MockChat.last_model_config_id,
+							threshold_percent: 60,
+						},
+					],
+				} satisfies TypesGen.UserChatCompactionThresholds,
+			},
+			{
+				key: organizationChatModelsKey(MockChat.organization_id),
+				data: {
+					models: [
+						{
+							...MockChatModel,
+							id: MockChat.last_model_config_id,
+							compression_threshold: 70,
+						},
+					],
+					providers: [MockChatModelProviderDescriptor],
+					unsupported_providers: [],
+				} satisfies TypesGen.OrganizationChatModelsResponse,
+			},
+			{
+				key: chatPromptsKey(MockChat.id),
+				data: { prompts: [] } satisfies TypesGen.ChatPromptsResponse,
+			},
+		],
+	},
+	render: () => {
+		const store = createChatStore();
+		store.replaceMessages([
+			buildMessage(1, "user", [{ type: "text", text: "Summarize the diff" }]),
+			{
+				...buildMessage(2, "assistant", [
+					{ type: "text", text: "The diff is a rename." },
+				]),
+				usage: {
+					input_tokens: 30_000,
+					output_tokens: 10_000,
+					context_limit: 128_000,
+				},
+			},
+		]);
+
+		return (
+			<div className="mx-auto w-full max-w-3xl p-4">
+				<ChatPageInput
+					chat={MockChat}
+					store={store}
+					onSend={fn()}
+					onDeleteQueuedMessage={fn()}
+					onPromoteQueuedMessage={fn()}
+					onInterrupt={fn()}
+					isInputDisabled={false}
+					isSendPending={false}
+					isInterruptPending={false}
+					hasModelOptions
+					selectedModel={MockChat.last_model_config_id}
+					onModelChange={fn()}
+					modelOptions={[
+						{
+							id: MockChat.last_model_config_id,
+							provider: "openai",
+							model: "gpt-4o",
+							displayName: "GPT-4o",
+						},
+					]}
+					modelSelectorPlaceholder="Select model"
+					canConfigureAgentSetup={false}
+					isEditing={false}
+					onCancelHistoryEdit={fn()}
+					workspaceOptions={[]}
+					isWorkspaceLoading={false}
+				/>
+			</div>
+		);
+	},
+	play: async ({ canvasElement }) => {
+		const canvas = within(canvasElement);
+		await userEvent.click(
+			await canvas.findByRole("button", { name: /Context usage/ }),
+		);
+		await waitFor(() => {
+			expect(within(document.body).getByText("Compacts at 60%")).toBeVisible();
+		});
+		expect(within(document.body).queryByText("Compacts at 70%")).toBeNull();
 	},
 };

--- a/site/src/pages/AgentsPage/components/ChatPageContent.stories.tsx
+++ b/site/src/pages/AgentsPage/components/ChatPageContent.stories.tsx
@@ -426,6 +426,7 @@ const openContextUsage = async (canvasElement: HTMLElement) => {
 
 export const CompactsAtUserOverride: Story = {
 	parameters: {
+		pixel: { exclude: true },
 		queries: [
 			{
 				key: preferenceSettingsKey,
@@ -453,6 +454,7 @@ export const CompactsAtUserOverride: Story = {
 
 export const CompactsAtHistoricalModelDefault: Story = {
 	parameters: {
+		pixel: { exclude: true },
 		queries: [
 			{
 				key: preferenceSettingsKey,

--- a/site/src/pages/AgentsPage/components/ChatPageContent.stories.tsx
+++ b/site/src/pages/AgentsPage/components/ChatPageContent.stories.tsx
@@ -6,6 +6,7 @@ import { chatPromptsKey, userCompactionThresholds } from "#/api/queries/chats";
 import { preferenceSettingsKey } from "#/api/queries/users";
 import type * as TypesGen from "#/api/typesGenerated";
 import { MockChat, MockChatQueuedMessage } from "#/testHelpers/chatEntities";
+import { MockChatModel } from "#/testHelpers/chatModels";
 import {
 	MockUserChatCompactionThresholds,
 	MockUserPreferenceSettings,
@@ -54,6 +55,24 @@ type Story = StoryObj<typeof meta>;
 
 const CHAT_ID = "chat-page-content-stories";
 
+const MockUserChatCompactionThresholdsWithOverride: TypesGen.UserChatCompactionThresholds =
+	{
+		...MockUserChatCompactionThresholds,
+		thresholds: [
+			{
+				model_config_id: MockChat.last_model_config_id,
+				threshold_percent: 60,
+			},
+		],
+	};
+
+const compactionModels: readonly TypesGen.ChatModel[] = [
+	{
+		...MockChatModel,
+		id: MockChat.last_model_config_id,
+	},
+];
+
 // Renders only the composer half of the chat page. Empty chat id and
 // organization keep the prompt-history and draft attachment queries disabled.
 const StoryChatPageInput: FC<{
@@ -64,6 +83,7 @@ const StoryChatPageInput: FC<{
 		<ChatPageInput
 			chat={{ ...MockChat, id: "", organization_id: "" }}
 			store={store}
+			models={[]}
 			onSend={fn()}
 			onDeleteQueuedMessage={fn()}
 			onPromoteQueuedMessage={fn()}
@@ -350,6 +370,57 @@ export const RunningShowsBusyComposer: Story = {
 	},
 };
 
+const CompactionChatPageInput: FC = () => {
+	const store = createChatStore();
+	store.replaceMessages([
+		buildMessage(1, "user", [{ type: "text", text: "Summarize the diff" }]),
+		{
+			...buildMessage(2, "assistant", [
+				{ type: "text", text: "The diff is a rename." },
+			]),
+			usage: {
+				input_tokens: 30_000,
+				output_tokens: 10_000,
+				context_limit: 128_000,
+			},
+		},
+	]);
+
+	return (
+		<div className="mx-auto w-full max-w-3xl p-4">
+			<ChatPageInput
+				chat={MockChat}
+				store={store}
+				models={compactionModels}
+				onSend={fn()}
+				onDeleteQueuedMessage={fn()}
+				onPromoteQueuedMessage={fn()}
+				onInterrupt={fn()}
+				isInputDisabled={false}
+				isSendPending={false}
+				isInterruptPending={false}
+				hasModelOptions={false}
+				selectedModel={MockChat.last_model_config_id}
+				onModelChange={fn()}
+				modelOptions={[]}
+				modelSelectorPlaceholder="Select model"
+				canConfigureAgentSetup={false}
+				isEditing={false}
+				onCancelHistoryEdit={fn()}
+				workspaceOptions={[]}
+				isWorkspaceLoading={false}
+			/>
+		</div>
+	);
+};
+
+const openContextUsage = async (canvasElement: HTMLElement) => {
+	const canvas = within(canvasElement);
+	await userEvent.click(
+		await canvas.findByRole("button", { name: /Context usage/ }),
+	);
+};
+
 export const CompactsAtUserOverride: Story = {
 	parameters: {
 		queries: [
@@ -359,14 +430,7 @@ export const CompactsAtUserOverride: Story = {
 			},
 			{
 				key: userCompactionThresholds().queryKey,
-				data: {
-					thresholds: [
-						{
-							model_config_id: MockChat.last_model_config_id,
-							threshold_percent: 60,
-						},
-					],
-				} satisfies TypesGen.UserChatCompactionThresholds,
+				data: MockUserChatCompactionThresholdsWithOverride,
 			},
 			{
 				key: chatPromptsKey(MockChat.id),
@@ -374,64 +438,38 @@ export const CompactsAtUserOverride: Story = {
 			},
 		],
 	},
-	render: () => {
-		const store = createChatStore();
-		store.replaceMessages([
-			buildMessage(1, "user", [{ type: "text", text: "Summarize the diff" }]),
-			{
-				...buildMessage(2, "assistant", [
-					{ type: "text", text: "The diff is a rename." },
-				]),
-				usage: {
-					input_tokens: 30_000,
-					output_tokens: 10_000,
-					context_limit: 128_000,
-				},
-			},
-		]);
-
-		return (
-			<div className="mx-auto w-full max-w-3xl p-4">
-				<ChatPageInput
-					chat={MockChat}
-					store={store}
-					onSend={fn()}
-					onDeleteQueuedMessage={fn()}
-					onPromoteQueuedMessage={fn()}
-					onInterrupt={fn()}
-					isInputDisabled={false}
-					isSendPending={false}
-					isInterruptPending={false}
-					hasModelOptions
-					selectedModel={MockChat.last_model_config_id}
-					onModelChange={fn()}
-					modelOptions={[
-						{
-							id: MockChat.last_model_config_id,
-							provider: "openai",
-							model: "gpt-4o",
-							displayName: "GPT-4o",
-							compressionThreshold: 70,
-						},
-					]}
-					modelSelectorPlaceholder="Select model"
-					canConfigureAgentSetup={false}
-					isEditing={false}
-					onCancelHistoryEdit={fn()}
-					workspaceOptions={[]}
-					isWorkspaceLoading={false}
-				/>
-			</div>
-		);
-	},
+	render: () => <CompactionChatPageInput />,
 	play: async ({ canvasElement }) => {
-		const canvas = within(canvasElement);
-		await userEvent.click(
-			await canvas.findByRole("button", { name: /Context usage/ }),
-		);
+		await openContextUsage(canvasElement);
 		await waitFor(() => {
 			expect(within(document.body).getByText("Compacts at 60%")).toBeVisible();
 		});
 		expect(within(document.body).queryByText("Compacts at 70%")).toBeNull();
+	},
+};
+
+export const CompactsAtHistoricalModelDefault: Story = {
+	parameters: {
+		queries: [
+			{
+				key: preferenceSettings().queryKey,
+				data: MockUserPreferenceSettings,
+			},
+			{
+				key: userCompactionThresholds().queryKey,
+				data: MockUserChatCompactionThresholds,
+			},
+			{
+				key: chatPromptsKey(MockChat.id),
+				data: { prompts: [] } satisfies TypesGen.ChatPromptsResponse,
+			},
+		],
+	},
+	render: () => <CompactionChatPageInput />,
+	play: async ({ canvasElement }) => {
+		await openContextUsage(canvasElement);
+		await waitFor(() => {
+			expect(within(document.body).getByText("Compacts at 70%")).toBeVisible();
+		});
 	},
 };

--- a/site/src/pages/AgentsPage/components/ChatPageContent.tsx
+++ b/site/src/pages/AgentsPage/components/ChatPageContent.tsx
@@ -4,7 +4,6 @@ import { useMutation, useQuery, useQueryClient } from "react-query";
 import { toast } from "sonner";
 import type { UrlTransform } from "streamdown";
 import {
-	chatModels,
 	chatPromptsQuery,
 	refreshChatContext,
 	userCompactionThresholds,
@@ -358,12 +357,11 @@ export const ChatPageInput: FC<ChatPageInputProps> = ({
 	const chatContext = chat.context;
 	const planModeEnabled = chat.plan_mode === "plan";
 	const selectedWorkspaceId = chat.workspace_id ?? null;
-	const modelsQuery = useQuery(chatModels(organizationId));
 	const thresholdsQuery = useQuery(userCompactionThresholds());
 	const compressionThreshold = resolveCompactionThreshold(
 		chat.last_model_config_id,
 		thresholdsQuery.data?.thresholds,
-		modelsQuery.data?.models ?? [],
+		modelOptions,
 	);
 	const messagesByID = useChatSelector(store, selectMessagesByID);
 	const orderedMessageIDs = useChatSelector(store, selectOrderedMessageIDs);

--- a/site/src/pages/AgentsPage/components/ChatPageContent.tsx
+++ b/site/src/pages/AgentsPage/components/ChatPageContent.tsx
@@ -3,14 +3,22 @@ import { type FC, Profiler, type ReactNode, useEffect, useRef } from "react";
 import { useMutation, useQuery, useQueryClient } from "react-query";
 import { toast } from "sonner";
 import type { UrlTransform } from "streamdown";
-import { chatPromptsQuery, refreshChatContext } from "#/api/queries/chats";
+import {
+	chatModels,
+	chatPromptsQuery,
+	refreshChatContext,
+	userCompactionThresholds,
+} from "#/api/queries/chats";
 import type * as TypesGen from "#/api/typesGenerated";
 import type { ModelSelectorOption } from "#/modules/aiModels/ModelSelector";
 import { useChatDraftAttachments } from "../hooks/useChatDraftAttachments";
 import { chatWidthClass, useChatFullWidth } from "../hooks/useChatFullWidth";
 import { useFileAttachments } from "../hooks/useFileAttachments";
 import { getChatFileURL } from "../utils/chatAttachments";
-import { getProviderForModelOption } from "../utils/modelOptions";
+import {
+	getProviderForModelOption,
+	resolveCompactionThreshold,
+} from "../utils/modelOptions";
 import { CHAT_SLASH_COMMANDS } from "../utils/slashCommands";
 import {
 	AgentChatInput,
@@ -239,7 +247,6 @@ export type PendingAttachment = {
 interface ChatPageInputProps {
 	chat: TypesGen.Chat;
 	store: ChatStoreHandle;
-	compressionThreshold: number | undefined;
 	onSend: (
 		message: string,
 		attachments?: readonly PendingAttachment[],
@@ -302,7 +309,6 @@ interface ChatPageInputProps {
 export const ChatPageInput: FC<ChatPageInputProps> = ({
 	chat,
 	store,
-	compressionThreshold,
 	onSend,
 	onDeleteQueuedMessage,
 	onPromoteQueuedMessage,
@@ -352,6 +358,13 @@ export const ChatPageInput: FC<ChatPageInputProps> = ({
 	const chatContext = chat.context;
 	const planModeEnabled = chat.plan_mode === "plan";
 	const selectedWorkspaceId = chat.workspace_id ?? null;
+	const modelsQuery = useQuery(chatModels(organizationId));
+	const thresholdsQuery = useQuery(userCompactionThresholds());
+	const compressionThreshold = resolveCompactionThreshold(
+		chat.last_model_config_id,
+		thresholdsQuery.data?.thresholds,
+		modelsQuery.data?.models ?? [],
+	);
 	const messagesByID = useChatSelector(store, selectMessagesByID);
 	const orderedMessageIDs = useChatSelector(store, selectOrderedMessageIDs);
 	const hasStreamState = useChatSelector(store, selectHasStreamState);

--- a/site/src/pages/AgentsPage/components/ChatPageContent.tsx
+++ b/site/src/pages/AgentsPage/components/ChatPageContent.tsx
@@ -246,6 +246,7 @@ export type PendingAttachment = {
 interface ChatPageInputProps {
 	chat: TypesGen.Chat;
 	store: ChatStoreHandle;
+	models: readonly TypesGen.ChatModel[] | undefined;
 	onSend: (
 		message: string,
 		attachments?: readonly PendingAttachment[],
@@ -308,6 +309,7 @@ interface ChatPageInputProps {
 export const ChatPageInput: FC<ChatPageInputProps> = ({
 	chat,
 	store,
+	models,
 	onSend,
 	onDeleteQueuedMessage,
 	onPromoteQueuedMessage,
@@ -361,7 +363,7 @@ export const ChatPageInput: FC<ChatPageInputProps> = ({
 	const compressionThreshold = resolveCompactionThreshold(
 		chat.last_model_config_id,
 		thresholdsQuery.data?.thresholds,
-		modelOptions,
+		models,
 	);
 	const messagesByID = useChatSelector(store, selectMessagesByID);
 	const orderedMessageIDs = useChatSelector(store, selectOrderedMessageIDs);

--- a/site/src/pages/AgentsPage/utils/modelOptions.test.ts
+++ b/site/src/pages/AgentsPage/utils/modelOptions.test.ts
@@ -463,7 +463,6 @@ describe("getModelOptionsFromModels", () => {
 				model: "gpt-4o",
 				displayName: "GPT-4o (Fast)",
 				contextLimit: 128_000,
-				compressionThreshold: 0,
 			},
 			expect.objectContaining({ id: "config-2" }),
 		]);
@@ -508,7 +507,6 @@ describe("getModelOptionsFromModels", () => {
 				model: "gpt-4o",
 				displayName: "GPT-4o",
 				contextLimit: 0,
-				compressionThreshold: 0,
 			},
 			{
 				id: "config-effort",
@@ -519,33 +517,10 @@ describe("getModelOptionsFromModels", () => {
 				model: "gpt-5",
 				displayName: "GPT-5",
 				contextLimit: 0,
-				compressionThreshold: 0,
 				reasoningEffortDefault: "medium",
 				reasoningEfforts: ["minimal", "low", "medium", "high", "xhigh"],
 			},
 		]);
-	});
-
-	it("copies compression_threshold onto the selector option", () => {
-		const models = [
-			createConfig({
-				id: "config-1",
-				ai_provider_id: "prov-openai",
-				model: "gpt-4o",
-				display_name: "GPT-4o",
-				compression_threshold: 90,
-			}),
-		];
-		const catalog = createCatalog([{ provider: "openai", available: true }]);
-
-		expect(
-			getModelOptionsFromModels(
-				models,
-				catalog,
-				providerInfoByID,
-				testOrganizationID,
-			)[0]?.compressionThreshold,
-		).toBe(90);
 	});
 
 	it("excludes models whose providers are unavailable", () => {
@@ -1194,21 +1169,19 @@ describe("resolveModelSelector", () => {
 				model: "gpt-4o",
 				displayName: "GPT-4o",
 				contextLimit: 128_000,
-				compressionThreshold: 0,
 			},
 		]);
 	});
 });
 
 describe("resolveCompactionThreshold", () => {
-	const modelOptions = [
-		{
+	const models = [
+		createConfig({
 			id: "config-1",
-			provider: "openai",
+			ai_provider_id: "prov-openai",
 			model: "gpt-4o",
-			displayName: "GPT-4o",
-			compressionThreshold: 70,
-		},
+			compression_threshold: 70,
+		}),
 	];
 
 	it("returns the user override when one is stored for the model", () => {
@@ -1216,18 +1189,24 @@ describe("resolveCompactionThreshold", () => {
 			resolveCompactionThreshold(
 				"config-1",
 				[{ model_config_id: "config-1", threshold_percent: 60 }],
-				modelOptions,
+				models,
 			),
 		).toBe(60);
 	});
 
-	it("returns the option threshold when no override is stored", () => {
-		expect(resolveCompactionThreshold("config-1", [], modelOptions)).toBe(70);
+	it("returns the model threshold when no override is stored", () => {
+		expect(resolveCompactionThreshold("config-1", [], models)).toBe(70);
 	});
 
-	it("returns undefined when the model is not in the options", () => {
-		expect(resolveCompactionThreshold("missing", [], modelOptions)).toBe(
-			undefined,
+	it("returns the threshold for a disabled historical model", () => {
+		const historicalModels = [{ ...models[0], enabled: false }];
+
+		expect(resolveCompactionThreshold("config-1", [], historicalModels)).toBe(
+			70,
 		);
+	});
+
+	it("returns undefined when the model is not in the catalog", () => {
+		expect(resolveCompactionThreshold("missing", [], models)).toBe(undefined);
 	});
 });

--- a/site/src/pages/AgentsPage/utils/modelOptions.test.ts
+++ b/site/src/pages/AgentsPage/utils/modelOptions.test.ts
@@ -25,6 +25,7 @@ import {
 	NIL_UUID,
 	providerInfoByIDFromUserConfigs,
 	providerTypeByIDFromUserConfigs,
+	resolveCompactionThreshold,
 	resolveModelOptionId,
 	resolveModelSelector,
 } from "./modelOptions";
@@ -462,6 +463,7 @@ describe("getModelOptionsFromModels", () => {
 				model: "gpt-4o",
 				displayName: "GPT-4o (Fast)",
 				contextLimit: 128_000,
+				compressionThreshold: 0,
 			},
 			expect.objectContaining({ id: "config-2" }),
 		]);
@@ -506,6 +508,7 @@ describe("getModelOptionsFromModels", () => {
 				model: "gpt-4o",
 				displayName: "GPT-4o",
 				contextLimit: 0,
+				compressionThreshold: 0,
 			},
 			{
 				id: "config-effort",
@@ -516,10 +519,33 @@ describe("getModelOptionsFromModels", () => {
 				model: "gpt-5",
 				displayName: "GPT-5",
 				contextLimit: 0,
+				compressionThreshold: 0,
 				reasoningEffortDefault: "medium",
 				reasoningEfforts: ["minimal", "low", "medium", "high", "xhigh"],
 			},
 		]);
+	});
+
+	it("copies compression_threshold onto the selector option", () => {
+		const models = [
+			createConfig({
+				id: "config-1",
+				ai_provider_id: "prov-openai",
+				model: "gpt-4o",
+				display_name: "GPT-4o",
+				compression_threshold: 90,
+			}),
+		];
+		const catalog = createCatalog([{ provider: "openai", available: true }]);
+
+		expect(
+			getModelOptionsFromModels(
+				models,
+				catalog,
+				providerInfoByID,
+				testOrganizationID,
+			)[0]?.compressionThreshold,
+		).toBe(90);
 	});
 
 	it("excludes models whose providers are unavailable", () => {
@@ -1168,7 +1194,40 @@ describe("resolveModelSelector", () => {
 				model: "gpt-4o",
 				displayName: "GPT-4o",
 				contextLimit: 128_000,
+				compressionThreshold: 0,
 			},
 		]);
+	});
+});
+
+describe("resolveCompactionThreshold", () => {
+	const modelOptions = [
+		{
+			id: "config-1",
+			provider: "openai",
+			model: "gpt-4o",
+			displayName: "GPT-4o",
+			compressionThreshold: 70,
+		},
+	];
+
+	it("returns the user override when one is stored for the model", () => {
+		expect(
+			resolveCompactionThreshold(
+				"config-1",
+				[{ model_config_id: "config-1", threshold_percent: 60 }],
+				modelOptions,
+			),
+		).toBe(60);
+	});
+
+	it("returns the option threshold when no override is stored", () => {
+		expect(resolveCompactionThreshold("config-1", [], modelOptions)).toBe(70);
+	});
+
+	it("returns undefined when the model is not in the options", () => {
+		expect(resolveCompactionThreshold("missing", [], modelOptions)).toBe(
+			undefined,
+		);
 	});
 });

--- a/site/src/pages/AgentsPage/utils/modelOptions.ts
+++ b/site/src/pages/AgentsPage/utils/modelOptions.ts
@@ -250,7 +250,6 @@ export const getModelOptionsFromModels = (
 
 		const displayName = model.display_name.trim() || modelName;
 		const contextLimit = asNumber(model.context_limit);
-		const compressionThreshold = asNumber(model.compression_threshold);
 		const reasoningEffort = model.model_config?.reasoning_effort;
 		const reasoningEffortDefault = asString(reasoningEffort?.default).trim();
 		const reasoningEfforts = model.reasoning_efforts ?? [];
@@ -263,7 +262,6 @@ export const getModelOptionsFromModels = (
 			model: modelName,
 			displayName,
 			...(contextLimit !== undefined ? { contextLimit } : {}),
-			...(compressionThreshold !== undefined ? { compressionThreshold } : {}),
 			...(reasoningEffortDefault ? { reasoningEffortDefault } : {}),
 			...(reasoningEfforts.length > 0 ? { reasoningEfforts } : {}),
 		});
@@ -326,13 +324,13 @@ export { formatProviderLabel } from "#/utils/aiProviders";
 export function resolveCompactionThreshold(
 	modelID: string | undefined,
 	userThresholds: readonly TypesGen.UserChatCompactionThreshold[] | undefined,
-	modelOptions: readonly ModelSelectorOption[] | null | undefined,
+	models: readonly TypesGen.ChatModel[] | null | undefined,
 ): number | undefined {
-	if (!modelID || !Array.isArray(modelOptions)) {
+	if (!modelID || !Array.isArray(models)) {
 		return undefined;
 	}
-	const option = modelOptions.find((modelOption) => modelOption.id === modelID);
-	if (!option) {
+	const model = models.find((model) => model.id === modelID);
+	if (!model) {
 		return undefined;
 	}
 	const userOverride = userThresholds?.find(
@@ -341,7 +339,7 @@ export function resolveCompactionThreshold(
 	if (userOverride) {
 		return userOverride.threshold_percent;
 	}
-	return option.compressionThreshold;
+	return model.compression_threshold;
 }
 
 export const getModelSelectorPlaceholder = (

--- a/site/src/pages/AgentsPage/utils/modelOptions.ts
+++ b/site/src/pages/AgentsPage/utils/modelOptions.ts
@@ -250,6 +250,7 @@ export const getModelOptionsFromModels = (
 
 		const displayName = model.display_name.trim() || modelName;
 		const contextLimit = asNumber(model.context_limit);
+		const compressionThreshold = asNumber(model.compression_threshold);
 		const reasoningEffort = model.model_config?.reasoning_effort;
 		const reasoningEffortDefault = asString(reasoningEffort?.default).trim();
 		const reasoningEfforts = model.reasoning_efforts ?? [];
@@ -262,6 +263,7 @@ export const getModelOptionsFromModels = (
 			model: modelName,
 			displayName,
 			...(contextLimit !== undefined ? { contextLimit } : {}),
+			...(compressionThreshold !== undefined ? { compressionThreshold } : {}),
 			...(reasoningEffortDefault ? { reasoningEffortDefault } : {}),
 			...(reasoningEfforts.length > 0 ? { reasoningEfforts } : {}),
 		});
@@ -324,13 +326,13 @@ export { formatProviderLabel } from "#/utils/aiProviders";
 export function resolveCompactionThreshold(
 	modelID: string | undefined,
 	userThresholds: readonly TypesGen.UserChatCompactionThreshold[] | undefined,
-	models: readonly TypesGen.ChatModel[] | null | undefined,
+	modelOptions: readonly ModelSelectorOption[] | null | undefined,
 ): number | undefined {
-	if (!modelID || !Array.isArray(models)) {
+	if (!modelID || !Array.isArray(modelOptions)) {
 		return undefined;
 	}
-	const config = models.find((c) => c.id === modelID);
-	if (!config) {
+	const option = modelOptions.find((modelOption) => modelOption.id === modelID);
+	if (!option) {
 		return undefined;
 	}
 	const userOverride = userThresholds?.find(
@@ -339,7 +341,7 @@ export function resolveCompactionThreshold(
 	if (userOverride) {
 		return userOverride.threshold_percent;
 	}
-	return config.compression_threshold;
+	return option.compressionThreshold;
 }
 
 export const getModelSelectorPlaceholder = (

--- a/site/src/testHelpers/entities.ts
+++ b/site/src/testHelpers/entities.ts
@@ -513,6 +513,11 @@ export const MockUserPreferenceSettings: TypesGen.UserPreferenceSettings = {
 	agent_chat_send_shortcut: "enter",
 };
 
+export const MockUserChatCompactionThresholds: TypesGen.UserChatCompactionThresholds =
+	{
+		thresholds: [],
+	};
+
 export const MockUserOwner: TypesGen.User = {
 	id: "test-user",
 	username: "TestUser",


### PR DESCRIPTION
ChatPageInput now loads compaction thresholds itself instead of taking compressionThreshold from AgentChatPage and the view. It resolves chat.last_model_config_id against the shared chatModels cache and userCompactionThresholds, the same query settings already uses.

Depends on #29069

- Drop compressionThreshold from AgentChatPage and AgentChatPageView
- ChatPageInput reads userCompactionThresholds through resolveCompactionThreshold
- CompactsAtUserOverride opens the context ring and asserts the user override wins over the model default
