### PR TITLE
chore(.github/workflows): clarify dogfood deployment configuration

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -75,8 +75,8 @@ jobs:
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@e6de054238d6b7531b4efff3b6587d9aade6a06c # v6.2.3
         with:
-          # dogfood.cdr.dev uses a separate AWS account from dev.coder.com.
-          role-to-assume: arn:aws:iam::153844979634:role/dogfood-coder-repo-ci
+          # This role must target the AWS account hosting dogfood.cdr.dev.
+          role-to-assume: ${{ vars.AWS_DOGFOOD_DEPLOY_ROLE }}
           aws-region: ${{ vars.AWS_DOGFOOD_DEPLOY_REGION }}
 
       - name: Get Cluster Credentials

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -9,8 +9,7 @@ on:
         required: true
         type: string
 
-permissions:
-  contents: read
+permissions: {}
 
 concurrency:
   group: ${{ github.workflow }} # no per-branch concurrency
@@ -21,6 +20,8 @@ jobs:
   should-deploy:
     name: should-deploy
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     outputs:
       verdict: ${{ steps.check.outputs.verdict }} # DEPLOY or NOOP
     steps:
@@ -74,7 +75,8 @@ jobs:
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@e6de054238d6b7531b4efff3b6587d9aade6a06c # v6.2.3
         with:
-          role-to-assume: ${{ vars.AWS_DOGFOOD_DEPLOY_ROLE }}
+          # dogfood.cdr.dev uses a separate AWS account from dev.coder.com.
+          role-to-assume: arn:aws:iam::153844979634:role/dogfood-coder-repo-ci
           aws-region: ${{ vars.AWS_DOGFOOD_DEPLOY_REGION }}
 
       - name: Get Cluster Credentials


### PR DESCRIPTION
Keep the deployment role configurable through `AWS_DOGFOOD_DEPLOY_ROLE` and document that it must target the AWS account hosting `dogfood.cdr.dev`. Scope checkout permissions to individual jobs without changing their effective permissions.

The deployment target will be switched separately by @dannykopping updating the GitHub variable. This PR does not change the deployment target itself.

<details>
<summary>Investigation</summary>

The linked job in run 34145739738 authenticated to the old dogfood AWS account and failed while reconciling a suspended Flux kustomization. Both environments use cluster name `dogfood` in `us-east-2`; the account is selected through the deployment role. No live deployment or repository-variable changes were performed.

</details>

Generated by Coder Agents on behalf of @dannykopping.