### PR TITLE
refactor(site/src/pages/AgentsPage): read parent chat from ChatTopBar

### DIFF
--- a/site/src/pages/AgentsPage/AgentChatPage.tsx
+++ b/site/src/pages/AgentsPage/AgentChatPage.tsx
@@ -22,7 +22,6 @@ import { chatProviderConfigs } from "#/api/queries/aiProviders";
 import { checkAuthorization } from "#/api/queries/authCheck";
 import { buildOptimisticEditedMessage } from "#/api/queries/chatMessageEdits";
 import {
-	chat as chatById,
 	chatMessagesForInfiniteScroll,
 	chatModels,
 	chatQueueConvergence,
@@ -206,12 +205,6 @@ const AgentChatPage: FC = () => {
 	const chatMessagesQuery = useInfiniteQuery(
 		chatMessagesForInfiniteScroll(agentId),
 	);
-	const parentChatID = getParentChatID(chatQuery.data);
-	const parentChatQuery = useQuery({
-		...chatById(parentChatID ?? ""),
-		enabled: Boolean(parentChatID),
-	});
-	const parentChat = parentChatQuery.data;
 	const workspaceId = chatQuery.data?.workspace_id;
 	const chatAgentId = chatQuery.data?.agent_id;
 	const workspaceQuery = useQuery({
@@ -1135,7 +1128,6 @@ const AgentChatPage: FC = () => {
 				<AgentChatPageView
 					key={agentId}
 					chat={chat}
-					parentChat={parentChat}
 					persistedError={persistedError}
 					canShareChat={canShareChat}
 					workspace={workspace}

--- a/site/src/pages/AgentsPage/AgentChatPageView.stories.tsx
+++ b/site/src/pages/AgentsPage/AgentChatPageView.stories.tsx
@@ -13,7 +13,10 @@ import {
 } from "storybook/test";
 import { reactRouterParameters } from "storybook-addon-remix-react-router";
 import { API } from "#/api/api";
-import { userCompactionThresholdsKey } from "#/api/queries/chats";
+import {
+	chatEntityKey,
+	userCompactionThresholdsKey,
+} from "#/api/queries/chats";
 import { preferenceSettingsKey } from "#/api/queries/users";
 import type * as TypesGen from "#/api/typesGenerated";
 import type { ChatDiffStatus, ChatMessagePart } from "#/api/typesGenerated";
@@ -164,7 +167,6 @@ const StoryAgentChatPageView: FC<StoryProps> = ({
 	const props = {
 		chat: buildChat(chat),
 		persistedError: undefined as ChatDetailError | undefined,
-		parentChat: undefined as TypesGen.Chat | undefined,
 		effectiveSelectedModel: defaultModelID,
 		setSelectedModel: fn(),
 		modelOptions: defaultModelOptions,
@@ -525,11 +527,31 @@ export const NotQueuedForCapacity: Story = {
 
 /** Shows the parent chat link in the top bar when a parent exists. */
 export const WithParentChat: Story = {
+	parameters: {
+		queries: [
+			{
+				key: preferenceSettings().queryKey,
+				data: MockUserPreferenceSettings,
+			},
+			{
+				key: userCompactionThresholds().queryKey,
+				data: MockUserChatCompactionThresholds,
+			},
+			{
+				key: chatEntityKey("parent-chat-1"),
+				data: buildChat({ id: "parent-chat-1", title: "Root agent" }),
+			},
+		],
+	},
 	render: () => (
-		<StoryAgentChatPageView
-			parentChat={buildChat({ id: "parent-chat-1", title: "Root agent" })}
-		/>
+		<StoryAgentChatPageView chat={{ parent_chat_id: "parent-chat-1" }} />
 	),
+	play: async ({ canvasElement }) => {
+		const canvas = within(canvasElement);
+		const parentLink = await canvas.findByRole("link", { name: "Root agent" });
+		expect(parentLink).toHaveAttribute("href", "/agents/parent-chat-1");
+		expect(canvas.getByText("Help me refactor")).toBeInTheDocument();
+	},
 };
 
 /** Persisted error reason shown in the timeline area. */

--- a/site/src/pages/AgentsPage/AgentChatPageView.stories.tsx
+++ b/site/src/pages/AgentsPage/AgentChatPageView.stories.tsx
@@ -530,11 +530,11 @@ export const WithParentChat: Story = {
 	parameters: {
 		queries: [
 			{
-				key: preferenceSettings().queryKey,
+				key: preferenceSettingsKey,
 				data: MockUserPreferenceSettings,
 			},
 			{
-				key: userCompactionThresholds().queryKey,
+				key: userCompactionThresholdsKey,
 				data: MockUserChatCompactionThresholds,
 			},
 			{
@@ -550,7 +550,6 @@ export const WithParentChat: Story = {
 		const canvas = within(canvasElement);
 		const parentLink = await canvas.findByRole("link", { name: "Root agent" });
 		expect(parentLink).toHaveAttribute("href", "/agents/parent-chat-1");
-		expect(canvas.getByText("Help me refactor")).toBeInTheDocument();
 	},
 };
 

--- a/site/src/pages/AgentsPage/AgentChatPageView.tsx
+++ b/site/src/pages/AgentsPage/AgentChatPageView.tsx
@@ -105,7 +105,6 @@ interface EditingState {
 
 interface AgentChatPageViewProps {
 	chat: TypesGen.Chat;
-	parentChat: TypesGen.Chat | undefined;
 	persistedError: ChatDetailError | undefined;
 	canShareChat: boolean;
 	workspaceAgent?: TypesGen.WorkspaceAgent;
@@ -278,7 +277,6 @@ const UserTabContent: FC<UserTabContentProps> = ({
 
 export const AgentChatPageView: FC<AgentChatPageViewProps> = ({
 	chat,
-	parentChat,
 	persistedError,
 	canShareChat,
 	workspaceAgent,
@@ -820,7 +818,6 @@ export const AgentChatPageView: FC<AgentChatPageViewProps> = ({
 								<ChatTopBar
 									chat={chat}
 									liveChatStatus={liveChatStatus}
-									parentChat={parentChat}
 									panel={{
 										showSidebarPanel,
 										onToggleSidebar: () =>

--- a/site/src/pages/AgentsPage/components/ChatTopBar.stories.tsx
+++ b/site/src/pages/AgentsPage/components/ChatTopBar.stories.tsx
@@ -16,13 +16,7 @@ const AgentsSearchProbe = () => {
 	return <div data-testid="agents-search">{location.search}</div>;
 };
 
-const defaultChat: TypesGen.Chat = {
-	...MockChat,
-	id: "chat-1",
-	title: "Build authentication feature",
-};
-
-const parentChat: TypesGen.Chat = {
+const mockParentChat = {
 	...MockChat,
 	id: "parent-chat-1",
 	title: "Set up CI/CD pipeline",
@@ -120,25 +114,24 @@ export const WithPanelOpen: Story = {
 export const WithParentChat: Story = {
 	args: {
 		chat: {
-			...defaultChat,
-			parent_chat_id: parentChat.id,
+			...MockChat,
+			parent_chat_id: mockParentChat.id,
 		},
 	},
 	parameters: {
 		queries: [
 			{
-				key: chatEntityKey(parentChat.id),
-				data: parentChat,
+				key: chatEntityKey(mockParentChat.id),
+				data: mockParentChat,
 			},
 		],
 	},
 	play: async ({ canvasElement }) => {
 		const canvas = within(canvasElement);
 		const parentLink = await canvas.findByRole("link", {
-			name: parentChat.title,
+			name: mockParentChat.title,
 		});
-		expect(parentLink).toHaveAttribute("href", `/agents/${parentChat.id}`);
-		expect(canvas.getByText(defaultChat.title)).toBeInTheDocument();
+		expect(parentLink).toHaveAttribute("href", `/agents/${mockParentChat.id}`);
 	},
 };
 
@@ -434,16 +427,16 @@ export const UnpinAgentItem: Story = {
 export const ChildChatHidesPinAndArchiveActions: Story = {
 	args: {
 		chat: {
-			...defaultChat,
-			parent_chat_id: parentChat.id,
+			...MockChat,
+			parent_chat_id: mockParentChat.id,
 			workspace_id: "workspace-1",
 		},
 	},
 	parameters: {
 		queries: [
 			{
-				key: chatEntityKey(parentChat.id),
-				data: parentChat,
+				key: chatEntityKey(mockParentChat.id),
+				data: mockParentChat,
 			},
 		],
 	},
@@ -470,16 +463,17 @@ export const ChildChatHidesPinAndArchiveActions: Story = {
 export const ArchivedChildChatHasNoActionsMenu: Story = {
 	args: {
 		chat: {
-			...defaultChat,
-			parent_chat_id: parentChat.id,
+			...MockChat,
+			title: "Build authentication feature",
+			parent_chat_id: mockParentChat.id,
 			archived: true,
 		},
 	},
 	parameters: {
 		queries: [
 			{
-				key: chatEntityKey(parentChat.id),
-				data: parentChat,
+				key: chatEntityKey(mockParentChat.id),
+				data: mockParentChat,
 			},
 		],
 	},

--- a/site/src/pages/AgentsPage/components/ChatTopBar.stories.tsx
+++ b/site/src/pages/AgentsPage/components/ChatTopBar.stories.tsx
@@ -2,6 +2,7 @@ import type { Meta, StoryObj } from "@storybook/react-vite";
 import { Outlet, useLocation } from "react-router";
 import { expect, fn, userEvent, waitFor, within } from "storybook/test";
 import { reactRouterParameters } from "storybook-addon-remix-react-router";
+import { chatEntityKey } from "#/api/queries/chats";
 import type * as TypesGen from "#/api/typesGenerated";
 import { PopoverContent } from "#/components/Popover/Popover";
 import { MockChat } from "#/testHelpers/chatEntities";
@@ -13,6 +14,18 @@ import { ChatTopBar } from "./ChatTopBar";
 const AgentsSearchProbe = () => {
 	const location = useLocation();
 	return <div data-testid="agents-search">{location.search}</div>;
+};
+
+const defaultChat: TypesGen.Chat = {
+	...MockChat,
+	id: "chat-1",
+	title: "Build authentication feature",
+};
+
+const parentChat: TypesGen.Chat = {
+	...MockChat,
+	id: "parent-chat-1",
+	title: "Set up CI/CD pipeline",
 };
 
 const requestArchiveAgent = fn<(chatId: string) => void>();
@@ -106,11 +119,26 @@ export const WithPanelOpen: Story = {
 
 export const WithParentChat: Story = {
 	args: {
-		parentChat: {
-			...MockChat,
-			id: "parent-chat-1",
-			title: "Set up CI/CD pipeline",
+		chat: {
+			...defaultChat,
+			parent_chat_id: parentChat.id,
 		},
+	},
+	parameters: {
+		queries: [
+			{
+				key: chatEntityKey(parentChat.id),
+				data: parentChat,
+			},
+		],
+	},
+	play: async ({ canvasElement }) => {
+		const canvas = within(canvasElement);
+		const parentLink = await canvas.findByRole("link", {
+			name: parentChat.title,
+		});
+		expect(parentLink).toHaveAttribute("href", `/agents/${parentChat.id}`);
+		expect(canvas.getByText(defaultChat.title)).toBeInTheDocument();
 	},
 };
 
@@ -406,10 +434,18 @@ export const UnpinAgentItem: Story = {
 export const ChildChatHidesPinAndArchiveActions: Story = {
 	args: {
 		chat: {
-			...MockChat,
-			parent_chat_id: "parent-chat-1",
+			...defaultChat,
+			parent_chat_id: parentChat.id,
 			workspace_id: "workspace-1",
 		},
+	},
+	parameters: {
+		queries: [
+			{
+				key: chatEntityKey(parentChat.id),
+				data: parentChat,
+			},
+		],
 	},
 	play: async ({ canvasElement }) => {
 		const canvas = within(canvasElement);
@@ -434,11 +470,18 @@ export const ChildChatHidesPinAndArchiveActions: Story = {
 export const ArchivedChildChatHasNoActionsMenu: Story = {
 	args: {
 		chat: {
-			...MockChat,
-			title: "Build authentication feature",
-			parent_chat_id: "parent-chat-1",
+			...defaultChat,
+			parent_chat_id: parentChat.id,
 			archived: true,
 		},
+	},
+	parameters: {
+		queries: [
+			{
+				key: chatEntityKey(parentChat.id),
+				data: parentChat,
+			},
+		],
 	},
 	play: async ({ canvasElement }) => {
 		const canvas = within(canvasElement);

--- a/site/src/pages/AgentsPage/components/ChatTopBar.tsx
+++ b/site/src/pages/AgentsPage/components/ChatTopBar.tsx
@@ -10,7 +10,9 @@ import {
 	UsersIcon,
 } from "lucide-react";
 import { type FC, Fragment, type ReactNode, useState } from "react";
+import { useQuery } from "react-query";
 import { Link, useLocation, useOutletContext } from "react-router";
+import { chat as chatById } from "#/api/queries/chats";
 import type * as TypesGen from "#/api/typesGenerated";
 import { Button } from "#/components/Button/Button";
 import {
@@ -28,6 +30,7 @@ import {
 	chatFamilyAllowsArchive,
 	chatHasMenuActions,
 } from "./ChatActionsMenuItems";
+import { getParentChatID } from "./ChatConversation/chatHelpers";
 import { useEmbedContext } from "./EmbedContext";
 import { PrStateIcon } from "./GitPanel/GitPanel";
 
@@ -43,7 +46,6 @@ type ChatSharingTopBarButtonProps = {
 type ChatTopBarProps = {
 	chat?: TypesGen.Chat;
 	liveChatStatus?: TypesGen.ChatStatus | null;
-	parentChat?: TypesGen.Chat;
 	panel: SidebarPanelState;
 	renderChatSharingContent?: (open: boolean) => ReactNode;
 };
@@ -84,12 +86,17 @@ const ChatSharingTopBarButton: FC<ChatSharingTopBarButtonProps> = ({
 export const ChatTopBar: FC<ChatTopBarProps> = ({
 	chat,
 	liveChatStatus,
-	parentChat,
 	panel,
 	renderChatSharingContent,
 }) => {
 	const { isEmbedded } = useEmbedContext();
 	const location = useLocation();
+	const parentChatID = getParentChatID(chat);
+	const parentChatQuery = useQuery({
+		...chatById(parentChatID ?? ""),
+		enabled: Boolean(parentChatID),
+	});
+	const parentChat = parentChatQuery.data;
 	const {
 		isSidebarCollapsed,
 		onToggleSidebarCollapsed,


### PR DESCRIPTION
> 🤖 This PR was modified by Coder Agents on behalf of Jake Howell.

ChatTopBar now loads the parent chat itself instead of taking `parentChat` from AgentChatPage and the view. The page no longer queries `chatById` for the parent.

- Drop `parentChat` from AgentChatPage and AgentChatPageView
- Let ChatTopBar read `chatById` when the chat has a parent ID
- Seed the parent entity in Storybook and assert the breadcrumb link
