### PR TITLE
fix(.github/workflows): use canonical dogfood deployment URL

### DIFF
--- a/.github/workflows/dogfood.yaml
+++ b/.github/workflows/dogfood.yaml
@@ -314,7 +314,7 @@ jobs:
           terraform apply -auto-approve
         env:
           # Consumed by coderd provider
-          CODER_URL: https://dev.coder.com
+          CODER_URL: https://dogfood.cdr.dev
           CODER_SESSION_TOKEN: ${{ secrets.CODER_SESSION_TOKEN }}
           # Template source & details
           TF_VAR_CODER_DOGFOOD_ANTHROPIC_API_KEY: ${{ secrets.CODER_DOGFOOD_ANTHROPIC_API_KEY }}


### PR DESCRIPTION
Use `https://dogfood.cdr.dev` directly when deploying dogfood templates. The legacy hostname returns a 301 redirect, converting upload POST requests into GET requests that fail with HTTP 405.

Refs https://github.com/coder/coder/actions/runs/34145739247/job/101967393279

<details>
<summary>Diagnosis evidence</summary>

The job failed uploading all three template archives after Terraform validation and authenticated reads succeeded. An unauthenticated empty POST to the legacy upload URL confirmed the 301 redirect to the canonical hostname. This change avoids that redirect without changing the provider or template configuration.

</details>

Generated by Coder Agents on behalf of @dannykopping.