### PR TITLE
fix(site): polish the workspace filter combobox

### DIFF
--- a/site/src/components/Filter/FilterCombobox/FilterCombobox.tsx
+++ b/site/src/components/Filter/FilterCombobox/FilterCombobox.tsx
@@ -98,7 +98,7 @@ export function FilterCombobox({
 				label={placeholder}
 			>
 				<FilterComboboxInputGroup className={className}>
-					<InputGroupAddon className="min-h-10 self-start">
+					<InputGroupAddon className="min-h-10 self-start pt-1">
 						<SearchIcon aria-hidden className="size-icon-sm" />
 					</InputGroupAddon>
 					<FilterComboboxChips>
@@ -158,7 +158,7 @@ export function FilterCombobox({
 							aria-label="Toggle filters"
 							aria-expanded={open}
 							aria-haspopup="listbox"
-							className="min-h-10 w-10 min-w-10 shrink-0 rounded-none rounded-r-md px-0 [&>svg]:p-0"
+							className="min-h-10 w-10 min-w-10 shrink-0 rounded-none rounded-r-md px-0 pt-2.5 [&>svg]:p-0"
 							onMouseDown={(event) => {
 								// Prevent the button from taking focus on pointer open.
 								// toggleFilterMenu focuses the combobox input next so

--- a/site/src/components/Filter/FilterCombobox/FilterCombobox.tsx
+++ b/site/src/components/Filter/FilterCombobox/FilterCombobox.tsx
@@ -299,12 +299,12 @@ function TypeaheadList({
 						{category.icon && (
 							<span
 								aria-hidden
-								className="flex size-icon-sm shrink-0 items-center justify-center text-content-secondary [&>svg]:size-icon-sm"
+								className="flex size-icon-sm shrink-0 items-center justify-center [&>svg]:size-icon-sm"
 							>
 								{category.icon}
 							</span>
 						)}
-						<span className="text-content-primary">{category.label}</span>
+						{category.label}
 					</FilterComboboxItem>
 				))}
 				{[...valueSuggestionsByCategory.entries()].map(
@@ -321,9 +321,7 @@ function TypeaheadList({
 									{suggestion.option.startIcon ? (
 										<span aria-hidden>{suggestion.option.startIcon}</span>
 									) : null}
-									<span className="text-content-primary">
-										{suggestion.option.label}
-									</span>
+									{suggestion.option.label}
 								</FilterComboboxItem>
 							))}
 						</FilterComboboxGroup>
@@ -341,9 +339,7 @@ function TypeaheadList({
 							>
 								<ResultIcon result={result} />
 								<span className="flex min-w-0 flex-col">
-									<span className="truncate text-content-primary">
-										{result.label}
-									</span>
+									<span className="truncate">{result.label}</span>
 									{result.subtitle && (
 										<span className="truncate text-xs text-content-secondary">
 											{result.subtitle}
@@ -448,7 +444,7 @@ function CategoryOptionsList({
 									{option.startIcon ? (
 										<span aria-hidden>{option.startIcon}</span>
 									) : null}
-									<span className="text-content-primary">{option.label}</span>
+									{option.label}
 								</FilterComboboxItem>
 							);
 						})}

--- a/site/src/components/Filter/FilterCombobox/FilterCombobox.tsx
+++ b/site/src/components/Filter/FilterCombobox/FilterCombobox.tsx
@@ -98,7 +98,7 @@ export function FilterCombobox({
 				label={placeholder}
 			>
 				<FilterComboboxInputGroup className={className}>
-					<InputGroupAddon className="min-h-10">
+					<InputGroupAddon className="min-h-10 self-start">
 						<SearchIcon aria-hidden className="size-icon-sm" />
 					</InputGroupAddon>
 					<FilterComboboxChips>
@@ -150,7 +150,7 @@ export function FilterCombobox({
 					</FilterComboboxChips>
 					<InputGroupAddon
 						align="inline-end"
-						className="w-10 items-center self-stretch border-0 border-l border-solid border-border p-0"
+						className="w-10 items-start self-stretch border-0 border-l border-solid border-border p-0"
 					>
 						<InputGroupButton
 							type="button"

--- a/site/src/components/Filter/FilterCombobox/primitives.tsx
+++ b/site/src/components/Filter/FilterCombobox/primitives.tsx
@@ -297,7 +297,7 @@ export const FilterComboboxInputGroup: FC<FilterComboboxInputGroupProps> = ({
 		<PopoverAnchor asChild>
 			<InputGroup
 				ref={anchorRef ?? undefined}
-				className={cn("h-auto min-h-10 w-full items-center", className)}
+				className={cn("h-auto min-h-10 w-full items-start", className)}
 				{...props}
 			/>
 		</PopoverAnchor>
@@ -355,7 +355,10 @@ export const FilterComboboxChip: FC<FilterComboboxChipProps> = ({
 		<Badge
 			data-slot="combobox-chip"
 			svgSize="sm"
-			className={cn("font-medium text-content-secondary hover:text-content-primary", className)}
+			className={cn(
+				"font-medium text-content-secondary hover:text-content-primary",
+				className,
+			)}
 			{...props}
 		>
 			{children}

--- a/site/src/components/Filter/FilterCombobox/primitives.tsx
+++ b/site/src/components/Filter/FilterCombobox/primitives.tsx
@@ -314,7 +314,7 @@ export const FilterComboboxChips: FC<FilterComboboxChipsProps> = ({
 		<div
 			data-slot="combobox-chips"
 			className={cn(
-				"flex min-h-10 min-w-0 flex-1 flex-wrap content-center items-center gap-1 py-1",
+				"flex min-h-10 min-w-0 flex-1 flex-wrap content-center items-center gap-1 py-2 pr-2",
 				className,
 			)}
 			{...props}

--- a/site/src/components/Filter/FilterCombobox/primitives.tsx
+++ b/site/src/components/Filter/FilterCombobox/primitives.tsx
@@ -355,7 +355,7 @@ export const FilterComboboxChip: FC<FilterComboboxChipProps> = ({
 		<Badge
 			data-slot="combobox-chip"
 			svgSize="sm"
-			className={cn("font-medium text-content-primary", className)}
+			className={cn("font-medium text-content-secondary hover:text-content-primary", className)}
 			{...props}
 		>
 			{children}
@@ -365,7 +365,7 @@ export const FilterComboboxChip: FC<FilterComboboxChipProps> = ({
 					data-slot="combobox-chip-remove"
 					aria-label={resolvedRemoveLabel}
 					className={cn(
-						"inline-flex shrink-0 items-center justify-center rounded-sm border-0 bg-transparent p-0 text-content-secondary hover:text-content-primary",
+						"inline-flex shrink-0 items-center justify-center rounded-sm border-0 bg-transparent p-0",
 					)}
 					onMouseDown={(event) => event.preventDefault()}
 					onClick={(event) => {

--- a/site/src/components/Filter/FilterCombobox/primitives.tsx
+++ b/site/src/components/Filter/FilterCombobox/primitives.tsx
@@ -160,7 +160,7 @@ export const FilterComboboxContent: FC<FilterComboboxContentProps> = ({
 				}
 			}}
 			className={cn(
-				"group/combobox-content w-(--radix-popover-trigger-width) p-0 max-h-[min(24rem,var(--radix-popper-available-height))]",
+				"group/combobox-content flex w-(--radix-popover-trigger-width) max-h-[min(24rem,var(--radix-popper-available-height))] flex-col overflow-y-hidden p-0",
 				className,
 			)}
 			{...props}
@@ -183,7 +183,7 @@ export const FilterComboboxList: FC<FilterComboboxListProps> = ({
 			data-slot="combobox-list"
 			data-empty={isEmpty ? "" : undefined}
 			className={cn(
-				"max-h-96 scroll-py-1 overflow-y-auto overscroll-contain p-1",
+				"min-h-0 scroll-py-1 overflow-y-auto overscroll-contain p-1",
 				className,
 			)}
 			{...props}

--- a/site/src/components/Filter/FilterCombobox/primitives.tsx
+++ b/site/src/components/Filter/FilterCombobox/primitives.tsx
@@ -354,6 +354,7 @@ export const FilterComboboxChip: FC<FilterComboboxChipProps> = ({
 	return (
 		<Badge
 			data-slot="combobox-chip"
+			svgSize="sm"
 			className={cn("font-medium text-content-primary", className)}
 			{...props}
 		>
@@ -364,7 +365,7 @@ export const FilterComboboxChip: FC<FilterComboboxChipProps> = ({
 					data-slot="combobox-chip-remove"
 					aria-label={resolvedRemoveLabel}
 					className={cn(
-						"inline-flex size-4 shrink-0 items-center justify-center rounded-sm border-0 bg-transparent p-0 text-content-secondary hover:text-content-primary",
+						"inline-flex shrink-0 items-center justify-center rounded-sm border-0 bg-transparent p-0 text-content-secondary hover:text-content-primary",
 					)}
 					onMouseDown={(event) => event.preventDefault()}
 					onClick={(event) => {
@@ -374,7 +375,7 @@ export const FilterComboboxChip: FC<FilterComboboxChipProps> = ({
 						}
 					}}
 				>
-					<XIcon aria-hidden className="size-icon-xs" />
+					<XIcon aria-hidden />
 				</button>
 			)}
 		</Badge>

--- a/site/src/pages/WorkspacesPage/filter/WorkspacesFilter.tsx
+++ b/site/src/pages/WorkspacesPage/filter/WorkspacesFilter.tsx
@@ -1,9 +1,9 @@
 import {
 	Building2Icon,
 	CircleDotIcon,
-	UserIcon,
 	LayoutPanelTopIcon,
 	TagsIcon,
+	UserIcon,
 } from "lucide-react";
 import { type FC, useCallback, useMemo } from "react";
 import { useQueryClient } from "react-query";

--- a/site/src/pages/WorkspacesPage/filter/WorkspacesFilter.tsx
+++ b/site/src/pages/WorkspacesPage/filter/WorkspacesFilter.tsx
@@ -1,7 +1,6 @@
 import {
 	Building2Icon,
 	CircleDotIcon,
-	SlidersHorizontalIcon,
 	UserIcon,
 	LayoutPanelTopIcon,
 	TagsIcon,

--- a/site/src/pages/WorkspacesPage/filter/WorkspacesFilter.tsx
+++ b/site/src/pages/WorkspacesPage/filter/WorkspacesFilter.tsx
@@ -4,6 +4,7 @@ import {
 	SlidersHorizontalIcon,
 	UserIcon,
 	LayoutPanelTopIcon,
+	TagsIcon,
 } from "lucide-react";
 import { type FC, useCallback, useMemo } from "react";
 import { useQueryClient } from "react-query";
@@ -72,7 +73,7 @@ export const WorkspacesFilter: FC<WorkspaceFilterProps> = ({
 			{
 				key: "attributes",
 				label: "Attributes",
-				icon: <SlidersHorizontalIcon />,
+				icon: <TagsIcon />,
 				// Boolean workspace filters live under their own keys, so the
 				// category owns them for chip parsing.
 				chipKeys: ATTRIBUTE_CHIP_KEYS,

--- a/site/src/pages/WorkspacesPage/filter/WorkspacesFilter.tsx
+++ b/site/src/pages/WorkspacesPage/filter/WorkspacesFilter.tsx
@@ -1,9 +1,9 @@
 import {
 	Building2Icon,
 	CircleDotIcon,
-	LayoutGridIcon,
 	SlidersHorizontalIcon,
 	UserIcon,
+	LayoutPanelTopIcon,
 } from "lucide-react";
 import { type FC, useCallback, useMemo } from "react";
 import { useQueryClient } from "react-query";
@@ -66,7 +66,7 @@ export const WorkspacesFilter: FC<WorkspaceFilterProps> = ({
 			{
 				key: "template",
 				label: "Template",
-				icon: <LayoutGridIcon />,
+				icon: <LayoutPanelTopIcon />,
 				getOptions: (query) => getTemplateFilterOptions(query, queryClient),
 			},
 			{


### PR DESCRIPTION
A pile of visual nits from design review on the unified workspace filter. Nothing functional, just making the thing look like the Figma mock.

- dropdown rows stay content-secondary until hover/highlight, then icon and label go primary together
- only the suggestion list scrolls, so we don't get two scrollbars
- search and filter icons stick to the first chip row when tokens wrap
- chip area padding is 8px top/right/bottom, 4px between tokens
- bigger dismiss X on chips (why is this a prop?????)
- Template icon uses `LayoutPanelTopIcon`, Attributes icon uses `TagsIcon`

| Old | New |
| --- | --- |
| <img width="533" height="104" alt="COMBOBOX_INPUT_OLD" src="https://github.com/user-attachments/assets/ef0ce112-fa42-4242-aafb-2b1a86895cc2" /> | <img width="533" height="115" alt="COMBOBOX_INPUT_NEW" src="https://github.com/user-attachments/assets/0797b172-258f-4276-bc23-2ae870ce704a" /> |
| <img width="535" height="349" alt="COMBOBOX_DROPDOWN_OLD" src="https://github.com/user-attachments/assets/db5cc856-7005-4433-a2e0-03746a09b58d" /> | <img width="537" height="361" alt="COMBOBOX_DROPDOWN_NEW" src="https://github.com/user-attachments/assets/f5f24a56-52b0-4a4c-89f5-9328ffe4d57b" /> |