### PR TITLE
DNM: feat: prototype MCP gateway vertical slice

### DIFF
--- a/coderd/coderd.go
+++ b/coderd/coderd.go
@@ -945,6 +945,12 @@ func New(options *Options) *API {
 					options.PrometheusRegistry,
 				)
 			}
+			// With the experiment on, chatd reaches external MCP servers
+			// only through the gateway.
+			var chatMCPGateway http.Handler
+			if api.Experiments.Enabled(codersdk.ExperimentMCPGateway) {
+				chatMCPGateway = api.mcpGateway.Handler()
+			}
 			api.chatDaemon = chatd.New(options.Pubsub, chatd.Config{
 				Logger:                         options.Logger.Named("chatd"),
 				Database:                       options.Database,
@@ -969,6 +975,7 @@ func New(options *Options) *API {
 				AgentCapacityUnlock:            options.ChatAgentCapacityUnlock,
 				OIDCTokenSource:                oidcMCPSrc,
 				MCPHTTPClient:                  api.mcpHTTPClient,
+				MCPGateway:                     chatMCPGateway,
 				NotificationsEnqueuer:          options.NotificationsEnqueuer,
 				Auditor:                        &api.Auditor,
 			})

--- a/coderd/coderd.go
+++ b/coderd/coderd.go
@@ -104,6 +104,7 @@ import (
 	"github.com/coder/coder/v2/coderd/x/chatd/chatprovider"
 	"github.com/coder/coder/v2/coderd/x/chatd/mcpclient"
 	"github.com/coder/coder/v2/coderd/x/gitsync"
+	"github.com/coder/coder/v2/coderd/x/mcpgateway"
 	"github.com/coder/coder/v2/codersdk"
 	"github.com/coder/coder/v2/codersdk/drpcsdk"
 	"github.com/coder/coder/v2/codersdk/healthsdk"
@@ -881,6 +882,24 @@ func New(options *Options) *API {
 	}
 	api.agentProvider = stn
 
+	var oidcMCPSrc mcpclient.UserOIDCTokenSource
+	if options.OIDCConfig != nil {
+		oidcMCPSrc = newOIDCMCPTokenSource(
+			options.Database,
+			options.OIDCConfig,
+			options.Logger.Named("mcp-user-oidc"),
+		)
+	}
+
+	// The gateway is cheap to build. The route is only mounted when the
+	// experiment is enabled.
+	api.mcpGateway = mcpgateway.New(mcpgateway.Options{
+		Logger:          options.Logger.Named("mcpgateway"),
+		Database:        options.Database,
+		HTTPClient:      api.mcpHTTPClient,
+		OIDCTokenSource: oidcMCPSrc,
+	})
+
 	{ // Chat daemon and git sync worker initialization.
 		maxChatsPerAcquire := options.DeploymentValues.AI.Chat.AcquireBatchSize.Value()
 		if maxChatsPerAcquire > math.MaxInt32 {
@@ -890,14 +909,6 @@ func New(options *Options) *API {
 			maxChatsPerAcquire = math.MinInt32
 		}
 
-		var oidcMCPSrc mcpclient.UserOIDCTokenSource
-		if options.OIDCConfig != nil {
-			oidcMCPSrc = newOIDCMCPTokenSource(
-				options.Database,
-				options.OIDCConfig,
-				options.Logger.Named("mcp-user-oidc"),
-			)
-		}
 		providerAPIKeys := ChatProviderAPIKeysFromDeploymentValues(options.DeploymentValues)
 		if options.ChatProviderAPIKeys != nil {
 			providerAPIKeys = *options.ChatProviderAPIKeys
@@ -1385,6 +1396,10 @@ func New(options *Options) *API {
 			r.Route("/{organization}", func(r chi.Router) {
 				r.Use(httpmw.ExtractOrganizationParam(options.Database))
 				api.registerOrganizationChatRoutes(r, chatAPIPrefixExperimental)
+				r.Route("/mcp-gateway", func(r chi.Router) {
+					r.Use(httpmw.RequireExperiment(api.Experiments, codersdk.ExperimentMCPGateway))
+					r.Mount("/", api.mcpGateway.Handler())
+				})
 				r.Route("/members/{user}", func(r chi.Router) {
 					r.Use(httpmw.ExtractOrganizationMemberParam(options.Database))
 					api.registerOrganizationMemberChatRoutes(r)
@@ -2231,6 +2246,7 @@ type API struct {
 
 	*Options
 	mcpHTTPClient *http.Client
+	mcpGateway    *mcpgateway.Gateway
 	// ID is a uniquely generated ID on initialization.
 	// This is used to associate objects with a specific
 	// Coder API instance, like workspace agents to a

--- a/coderd/mcpgateway_test.go
+++ b/coderd/mcpgateway_test.go
@@ -1,0 +1,142 @@
+package coderd_test
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+	"github.com/stretchr/testify/require"
+
+	"github.com/coder/coder/v2/coderd/coderdtest"
+	"github.com/coder/coder/v2/coderd/database"
+	"github.com/coder/coder/v2/coderd/database/dbgen"
+	"github.com/coder/coder/v2/codersdk"
+	"github.com/coder/coder/v2/testutil"
+)
+
+// newGatewayUpstream starts a fake upstream MCP server exposing one "echo" tool.
+func newGatewayUpstream(t *testing.T) *httptest.Server {
+	t.Helper()
+	srv := mcp.NewServer(&mcp.Implementation{Name: "upstream", Version: "1.0.0"}, nil)
+	srv.AddTool(&mcp.Tool{
+		Name:        "echo",
+		Description: "Echoes the input",
+		InputSchema: map[string]any{
+			"type":       "object",
+			"properties": map[string]any{"input": map[string]any{"type": "string"}},
+		},
+	}, func(_ context.Context, req *mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+		var args map[string]any
+		if err := json.Unmarshal(req.Params.Arguments, &args); err != nil {
+			return nil, err
+		}
+		input, _ := args["input"].(string)
+		return &mcp.CallToolResult{Content: []mcp.Content{&mcp.TextContent{Text: "echo: " + input}}}, nil
+	})
+	ts := httptest.NewServer(mcp.NewStreamableHTTPHandler(
+		func(*http.Request) *mcp.Server { return srv },
+		&mcp.StreamableHTTPOptions{Stateless: true},
+	))
+	t.Cleanup(ts.Close)
+	return ts
+}
+
+// gatewayPost sends a raw JSON-RPC request to the gateway route as a "cURL"
+// client would, and returns the status and the JSON-RPC payload.
+func gatewayPost(ctx context.Context, t *testing.T, baseURL, token string, orgID uuid.UUID, body string) (int, string) {
+	t.Helper()
+	url := baseURL + "/api/experimental/organizations/" + orgID.String() + "/mcp-gateway"
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, bytes.NewBufferString(body))
+	require.NoError(t, err)
+	req.Header.Set(codersdk.SessionTokenHeader, token)
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Accept", "application/json, text/event-stream")
+
+	//nolint:bodyclose // Closed below.
+	res, err := http.DefaultClient.Do(req)
+	require.NoError(t, err)
+	defer res.Body.Close()
+	raw, err := io.ReadAll(res.Body)
+	require.NoError(t, err)
+	return res.StatusCode, extractJSONRPC(string(raw))
+}
+
+// extractJSONRPC returns the JSON-RPC payload from either a plain JSON body or
+// an SSE stream.
+func extractJSONRPC(body string) string {
+	if !strings.Contains(body, "data:") {
+		return body
+	}
+	for _, line := range strings.Split(body, "\n") {
+		if after, ok := strings.CutPrefix(strings.TrimSpace(line), "data:"); ok {
+			return strings.TrimSpace(after)
+		}
+	}
+	return body
+}
+
+const initializeBody = `{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-03-26","capabilities":{},"clientInfo":{"name":"curl","version":"0"}}}`
+
+func TestMCPGateway(t *testing.T) {
+	t.Parallel()
+
+	t.Run("CURL", func(t *testing.T) {
+		t.Parallel()
+
+		dv := coderdtest.DeploymentValues(t)
+		dv.Experiments = []string{string(codersdk.ExperimentMCPGateway)}
+		client, db := coderdtest.NewWithDatabase(t, &coderdtest.Options{DeploymentValues: dv})
+		first := coderdtest.CreateFirstUser(t, client)
+		ctx := testutil.Context(t, testutil.WaitLong)
+
+		upstream := newGatewayUpstream(t)
+		cfg := dbgen.MCPServerConfig(t, db, database.MCPServerConfig{
+			OrganizationID: first.OrganizationID,
+			Slug:           "up",
+			Url:            upstream.URL,
+			Enabled:        true,
+		})
+
+		status, _ := gatewayPost(ctx, t, client.URL.String(), client.SessionToken(), first.OrganizationID, initializeBody)
+		require.Equal(t, http.StatusOK, status)
+
+		status, body := gatewayPost(ctx, t, client.URL.String(), client.SessionToken(), first.OrganizationID,
+			`{"jsonrpc":"2.0","id":2,"method":"tools/list"}`)
+		require.Equal(t, http.StatusOK, status)
+		require.Contains(t, body, cfg.Slug+"__echo")
+	})
+
+	t.Run("ExperimentDisabled", func(t *testing.T) {
+		t.Parallel()
+
+		client := coderdtest.New(t, nil)
+		first := coderdtest.CreateFirstUser(t, client)
+		ctx := testutil.Context(t, testutil.WaitShort)
+
+		status, _ := gatewayPost(ctx, t, client.URL.String(), client.SessionToken(), first.OrganizationID, initializeBody)
+		require.Equal(t, http.StatusForbidden, status)
+	})
+
+	t.Run("NotOrgMember", func(t *testing.T) {
+		t.Parallel()
+
+		dv := coderdtest.DeploymentValues(t)
+		dv.Experiments = []string{string(codersdk.ExperimentMCPGateway)}
+		client, db := coderdtest.NewWithDatabase(t, &coderdtest.Options{DeploymentValues: dv})
+		first := coderdtest.CreateFirstUser(t, client)
+		ctx := testutil.Context(t, testutil.WaitShort)
+
+		other := dbgen.Organization(t, db, database.Organization{})
+		member, _ := coderdtest.CreateAnotherUser(t, client, first.OrganizationID)
+
+		status, _ := gatewayPost(ctx, t, client.URL.String(), member.SessionToken(), other.ID, initializeBody)
+		require.Contains(t, []int{http.StatusForbidden, http.StatusNotFound}, status)
+	})
+}

--- a/coderd/x/chatd/chatd.go
+++ b/coderd/x/chatd/chatd.go
@@ -186,6 +186,7 @@ type Server struct {
 	allowBYOK                      bool
 	oidcTokenSource                mcpclient.UserOIDCTokenSource
 	mcpHTTPClient                  *http.Client
+	mcpGateway                     http.Handler
 	debugSvc                       *chatdebug.Service
 	debugSvcFactory                func() *chatdebug.Service
 	debugSvcReady                  atomic.Bool
@@ -2974,6 +2975,11 @@ type Config struct {
 	// using user_oidc will then send no Authorization header.
 	OIDCTokenSource mcpclient.UserOIDCTokenSource
 	MCPHTTPClient   *http.Client
+	// MCPGateway, when non-nil, makes chatd reach every external MCP
+	// server through the MCP Gateway handler in-process instead of
+	// connecting to the upstreams itself. Nil unless the mcp-gateway
+	// experiment is enabled.
+	MCPGateway http.Handler
 
 	NotificationsEnqueuer notifications.Enqueuer
 	Auditor               *atomic.Pointer[audit.Auditor]
@@ -3057,6 +3063,7 @@ func New(ps pubsub.Pubsub, cfg Config) *Server {
 		allowBYOK:                      allowBYOK,
 		oidcTokenSource:                cfg.OIDCTokenSource,
 		mcpHTTPClient:                  mcpHTTPClient,
+		mcpGateway:                     cfg.MCPGateway,
 		debugSvcFactory: func() *chatdebug.Service {
 			debugSvc := chatdebug.NewService(
 				cfg.Database,

--- a/coderd/x/chatd/generation_preparer.go
+++ b/coderd/x/chatd/generation_preparer.go
@@ -361,14 +361,29 @@ func (server *Server) prepareGeneration(
 		resolvedUserPrompt = server.resolveUserPrompt(ctx, chat.OwnerID)
 		return nil
 	})
+	// The gateway aggregates every upstream the owner may reach and
+	// holds their credentials, so chatd connects to it alone.
+	mcpHTTPClient := server.mcpHTTPClient
+	viaMCPGateway := server.mcpGateway != nil && len(mcpConnectConfigs) > 0
+	if viaMCPGateway {
+		gatewayClient, gatewayErr := server.mcpGatewayClient(ctx, chat.OwnerID)
+		if gatewayErr != nil {
+			cleanup()
+			return generationPrepared{}, gatewayErr
+		}
+		mcpConnectConfigs = []database.MCPServerConfig{mcpGatewayConfig(chat.OrganizationID)}
+		mcpHTTPClient = gatewayClient
+	}
 	if len(mcpConnectConfigs) > 0 {
 		g2.Go(func() error {
-			var tokenErr error
-			mcpTokens, tokenErr = server.db.GetMCPServerUserTokensByUserID(ctx, chat.OwnerID)
-			if tokenErr != nil {
-				logger.Warn(ctx, "failed to load MCP user tokens", slog.Error(tokenErr))
+			if !viaMCPGateway {
+				var tokenErr error
+				mcpTokens, tokenErr = server.db.GetMCPServerUserTokensByUserID(ctx, chat.OwnerID)
+				if tokenErr != nil {
+					logger.Warn(ctx, "failed to load MCP user tokens", slog.Error(tokenErr))
+				}
+				mcpTokens = server.refreshExpiredMCPTokens(ctx, logger, mcpConnectConfigs, mcpTokens)
 			}
-			mcpTokens = server.refreshExpiredMCPTokens(ctx, logger, mcpConnectConfigs, mcpTokens)
 			mcpTools, mcpSummaries, mcpCleanup = mcpclient.ConnectAll(
 				ctx,
 				logger,
@@ -377,7 +392,7 @@ func (server *Server) prepareGeneration(
 				chat.OwnerID,
 				server.oidcTokenSource,
 				chatprovider.CoderHeaders(chat),
-				server.mcpHTTPClient,
+				mcpHTTPClient,
 			)
 			return nil
 		})

--- a/coderd/x/chatd/mcpclient/export_test.go
+++ b/coderd/x/chatd/mcpclient/export_test.go
@@ -41,7 +41,7 @@ func ConnectAllForTest(
 
 // BuildAuthHeadersForTest exposes buildAuthHeaders for external
 // tests.
-var BuildAuthHeadersForTest = buildAuthHeaders
+var BuildAuthHeadersForTest = BuildAuthHeaders
 
 // SummaryErrorForTest exposes summaryError for external tests.
 var SummaryErrorForTest = summaryError

--- a/coderd/x/chatd/mcpclient/mcpclient.go
+++ b/coderd/x/chatd/mcpclient/mcpclient.go
@@ -334,7 +334,7 @@ func connectOne(
 	timeout time.Duration,
 	hooks connectHooks,
 ) ([]fantasy.AgentTool, *mcp.ClientSession, error) {
-	headers := buildAuthHeaders(ctx, logger, cfg, tokensByConfigID, userID, oidcSrc)
+	headers := BuildAuthHeaders(ctx, logger, cfg, tokensByConfigID, userID, oidcSrc)
 
 	// When opted-in, merge Coder identity headers BEFORE the
 	// transport is created so any auth header already set above
@@ -357,7 +357,7 @@ func connectOne(
 		}
 	}
 
-	tr, err := createTransport(cfg, headers, httpClient)
+	tr, err := CreateTransport(cfg, headers, httpClient)
 	if err != nil {
 		return nil, nil, xerrors.Errorf(
 			"create transport: %w", err,
@@ -433,7 +433,7 @@ func connectOne(
 
 	var tools []fantasy.AgentTool
 	for _, mcpTool := range toolsResult.Tools {
-		if !isToolAllowed(
+		if !IsToolAllowed(
 			mcpTool.Name,
 			cfg.ToolAllowList,
 			cfg.ToolDenyList,
@@ -462,7 +462,7 @@ func connectOne(
 	return tools, session, nil
 }
 
-func createTransport(
+func CreateTransport(
 	cfg database.MCPServerConfig,
 	headers map[string]string,
 	baseHTTPClient *http.Client,
@@ -488,9 +488,9 @@ func createTransport(
 	}
 }
 
-// buildAuthHeaders constructs HTTP headers for authenticating
+// BuildAuthHeaders constructs HTTP headers for authenticating
 // with the MCP server based on the configured auth type.
-func buildAuthHeaders(
+func BuildAuthHeaders(
 	ctx context.Context,
 	logger slog.Logger,
 	cfg database.MCPServerConfig,
@@ -607,13 +607,13 @@ func buildAuthHeaders(
 	return headers
 }
 
-// isToolAllowed checks a tool name against the allow and deny
+// IsToolAllowed checks a tool name against the allow and deny
 // lists. When the allow list is non-empty only tools in it are
 // permitted and the deny list is ignored. When the allow list
 // is empty and the deny list is non-empty, tools in the deny
 // list are rejected. Both lists use exact string matching
 // against the original (non-prefixed) tool name.
-func isToolAllowed(
+func IsToolAllowed(
 	toolName string,
 	allowList []string,
 	denyList []string,

--- a/coderd/x/chatd/mcpgateway_test.go
+++ b/coderd/x/chatd/mcpgateway_test.go
@@ -1,0 +1,170 @@
+package chatd_test
+
+// Prototype coverage for the MCP Gateway experiment: with the
+// experiment on, chatd must reach upstream MCP servers only through the
+// gateway, as a plain MCP client.
+
+import (
+	"context"
+	"encoding/json"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/stretchr/testify/require"
+
+	"cdr.dev/slog/v3/sloggers/slogtest"
+	"github.com/coder/coder/v2/coderd/coderdtest"
+	"github.com/coder/coder/v2/coderd/database"
+	"github.com/coder/coder/v2/coderd/database/dbauthz"
+	"github.com/coder/coder/v2/coderd/database/dbgen"
+	"github.com/coder/coder/v2/coderd/database/dbtestutil"
+	"github.com/coder/coder/v2/coderd/httpmw"
+	"github.com/coder/coder/v2/coderd/rbac"
+	"github.com/coder/coder/v2/coderd/x/chatd"
+	"github.com/coder/coder/v2/coderd/x/chatd/chattest"
+	"github.com/coder/coder/v2/coderd/x/mcpgateway"
+	"github.com/coder/coder/v2/codersdk"
+	"github.com/coder/coder/v2/testutil"
+)
+
+// TestGeneration_ThroughMCPGateway drives a full generation with the
+// mcp-gateway experiment on. The model must be offered the double
+// prefixed gw__<slug>__<tool> name, the upstream must receive exactly
+// one forwarded tools/call, and its result must reach the model.
+func TestGeneration_ThroughMCPGateway(t *testing.T) {
+	t.Parallel()
+
+	db, ps := dbtestutil.NewDB(t)
+	ctx := testutil.Context(t, testutil.WaitLong)
+
+	var upstreamCalls atomic.Int32
+	upstream := newTestMCPServer("gateway-upstream")
+	upstream.AddTool(&mcp.Tool{
+		Name:        "echo",
+		Description: "Echoes the input",
+		InputSchema: map[string]any{
+			"type": "object",
+			"properties": map[string]any{
+				"input": map[string]any{"type": "string"},
+			},
+			"required": []string{"input"},
+		},
+	}, func(_ context.Context, req *mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+		upstreamCalls.Add(1)
+		var args map[string]any
+		_ = json.Unmarshal(req.Params.Arguments, &args)
+		input, _ := args["input"].(string)
+		return &mcp.CallToolResult{
+			Content: []mcp.Content{&mcp.TextContent{Text: "echo: " + input}},
+		}, nil
+	})
+	upstreamSrv := httptest.NewServer(testMCPHTTPHandler(upstream))
+	t.Cleanup(upstreamSrv.Close)
+
+	var (
+		mu            sync.Mutex
+		offeredTools  [][]string
+		modelMessages [][]chattest.OpenAIMessage
+		streamedCalls atomic.Int32
+	)
+	openAIURL := chattest.NewOpenAI(t, func(req *chattest.OpenAIRequest) chattest.OpenAIResponse {
+		if !req.Stream {
+			return chattest.OpenAINonStreamingResponse("title")
+		}
+		names := make([]string, 0, len(req.Tools))
+		for _, tool := range req.Tools {
+			names = append(names, openAIToolName(tool))
+		}
+		mu.Lock()
+		offeredTools = append(offeredTools, names)
+		modelMessages = append(modelMessages, append([]chattest.OpenAIMessage(nil), req.Messages...))
+		mu.Unlock()
+
+		if streamedCalls.Add(1) == 1 {
+			return chattest.OpenAIStreamingResponse(
+				chattest.OpenAIToolCallChunk("gw__up__echo", `{"input":"hi"}`),
+			)
+		}
+		return chattest.OpenAIStreamingResponse(chattest.OpenAITextChunks("done")...)
+	})
+
+	user, org, model := seedChatDependenciesWithProvider(t, db, "openai-compat", openAIURL)
+	mcpConfig := dbgen.MCPServerConfig(t, db, database.MCPServerConfig{
+		OrganizationID: org.ID,
+		DisplayName:    "Upstream",
+		Slug:           "up",
+		Url:            upstreamSrv.URL,
+		Enabled:        true,
+		CreatedBy:      uuid.NullUUID{UUID: user.ID, Valid: true},
+		UpdatedBy:      uuid.NullUUID{UUID: user.ID, Valid: true},
+	})
+
+	logger := slogtest.Make(t, &slogtest.Options{IgnoreErrors: true})
+	// The gateway relies on the dbauthz post-filter for MCP server ACLs.
+	authzDB := dbauthz.New(
+		db,
+		rbac.NewStrictCachingAuthorizer(prometheus.NewRegistry()),
+		logger,
+		coderdtest.AccessControlStorePointer(),
+	)
+	gateway := mcpgateway.New(mcpgateway.Options{
+		Logger:     logger,
+		Database:   authzDB,
+		HTTPClient: testMCPHTTPClient(),
+	})
+
+	server := newActiveTestServer(t, authzDB, ps, func(cfg *chatd.Config) {
+		withoutMCPToolSearch(cfg)
+		require.True(t, cfg.Experiments.Enabled(codersdk.ExperimentMCPGateway))
+		cfg.MCPGateway = gateway.Handler()
+		cfg.AIBridgeTransportFactory = chatAIGatewayTransportFactoryPointer(chattest.NewMockAIBridgeTransport(t, openAIURL))
+	})
+
+	// CreateChat authorizes against the caller; the worker uses its own actor.
+	ownerSubject, _, err := httpmw.UserRBACSubject(dbauthz.AsSystemRestricted(ctx), db, user.ID, rbac.ScopeAll)
+	require.NoError(t, err)
+
+	chat, err := server.CreateChat(dbauthz.As(ctx, ownerSubject), chatd.CreateOptions{
+		OrganizationID: org.ID,
+		OwnerID:        user.ID,
+		Title:          "mcp-gateway",
+		ModelConfigID:  model.ID,
+		MCPServerIDs:   []uuid.UUID{mcpConfig.ID},
+		InitialUserContent: []codersdk.ChatMessagePart{
+			codersdk.ChatMessageText("echo hi"),
+		},
+	})
+	require.NoError(t, err)
+	waitForChatProcessed(ctx, t, db, chat.ID, server)
+
+	result, err := db.GetChatByID(ctx, chat.ID)
+	require.NoError(t, err)
+	if result.Status == database.ChatStatusError {
+		require.FailNowf(t, "chat failed", "last_error=%q", chatLastErrorMessage(result.LastError))
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+	require.NotEmpty(t, offeredTools)
+	require.Contains(t, offeredTools[0], "gw__up__echo",
+		"the gateway's tools must reach the model under the gateway slug")
+	require.NotContains(t, offeredTools[0], "up__echo",
+		"chatd must not connect to the upstream directly")
+	require.Equal(t, int32(1), upstreamCalls.Load(),
+		"the upstream must receive exactly one forwarded tools/call")
+
+	require.GreaterOrEqual(t, len(modelMessages), 2)
+	var sawResult bool
+	for _, msg := range modelMessages[len(modelMessages)-1] {
+		if msg.Role == "tool" && strings.Contains(msg.Content, "echo: hi") {
+			sawResult = true
+		}
+	}
+	require.True(t, sawResult, "the upstream result must reach the model: %+v", modelMessages[len(modelMessages)-1])
+}

--- a/coderd/x/chatd/mcpgateway_transport.go
+++ b/coderd/x/chatd/mcpgateway_transport.go
@@ -1,0 +1,73 @@
+package chatd
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+
+	"github.com/go-chi/chi/v5"
+	"github.com/google/uuid"
+	"golang.org/x/xerrors"
+
+	"github.com/coder/coder/v2/coderd/database"
+	"github.com/coder/coder/v2/coderd/database/dbauthz"
+	"github.com/coder/coder/v2/coderd/httpmw"
+	"github.com/coder/coder/v2/coderd/rbac"
+)
+
+// mcpGatewayHost is a placeholder host for in-process gateway requests.
+// It is never dialed: mcpGatewayRoundTripper serves the request.
+const mcpGatewayHost = "http://mcp-gateway.internal"
+
+// mcpGatewayConfig returns the synthetic MCP server config that makes
+// the gateway look like an ordinary upstream to mcpclient.ConnectAll,
+// so the tools it aggregates arrive as gw__<slug>__<tool>.
+func mcpGatewayConfig(orgID uuid.UUID) database.MCPServerConfig {
+	return database.MCPServerConfig{
+		Slug:      "gw",
+		Url:       mcpGatewayHost + "/organizations/" + orgID.String() + "/mcp-gateway",
+		Transport: "streamable_http",
+		AuthType:  "none",
+		Enabled:   true,
+	}
+}
+
+// mcpGatewayClient returns an HTTP client that serves every request
+// with the gateway handler in-process under the chat owner's actor.
+// chatd holds no user credential, so a loopback HTTP call would have
+// nothing to authenticate with.
+func (server *Server) mcpGatewayClient(ctx context.Context, ownerID uuid.UUID) (*http.Client, error) {
+	//nolint:gocritic // Resolving a user's RBAC subject requires system access.
+	owner, _, err := httpmw.UserRBACSubject(dbauthz.AsSystemRestricted(ctx), server.db, ownerID, rbac.ScopeAll)
+	if err != nil {
+		return nil, xerrors.Errorf("resolve chat owner RBAC subject: %w", err)
+	}
+
+	router := chi.NewRouter()
+	router.Route("/organizations/{organization}", func(r chi.Router) {
+		r.Use(httpmw.ExtractOrganizationParam(server.db))
+		r.Mount("/mcp-gateway", server.mcpGateway)
+	})
+	return &http.Client{Transport: &mcpGatewayRoundTripper{
+		handler: router,
+		actor:   owner,
+	}}, nil
+}
+
+// mcpGatewayRoundTripper serves requests with an http.Handler instead
+// of dialing. The actor is injected here because the gateway and the
+// organization middleware both authorize from the request context.
+type mcpGatewayRoundTripper struct {
+	handler http.Handler
+	actor   rbac.Subject
+}
+
+func (rt *mcpGatewayRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
+	// Stateless gateway responses are one JSON body or a short SSE
+	// stream that ends with the response, so buffering is enough.
+	recorder := httptest.NewRecorder()
+	rt.handler.ServeHTTP(recorder, req.WithContext(dbauthz.As(req.Context(), rt.actor)))
+	res := recorder.Result()
+	res.Request = req
+	return res, nil
+}

--- a/coderd/x/mcpgateway/gateway.go
+++ b/coderd/x/mcpgateway/gateway.go
@@ -17,7 +17,6 @@ import (
 	"golang.org/x/xerrors"
 
 	"cdr.dev/slog/v3"
-
 	"github.com/coder/coder/v2/buildinfo"
 	"github.com/coder/coder/v2/coderd/database"
 	"github.com/coder/coder/v2/coderd/database/dbauthz"

--- a/coderd/x/mcpgateway/gateway.go
+++ b/coderd/x/mcpgateway/gateway.go
@@ -1,0 +1,49 @@
+// Package mcpgateway is a prototype MCP Gateway. It exposes one MCP endpoint
+// per organization that aggregates the MCP servers the requesting user may
+// read, filters tools by the per-server allow and deny lists, and proxies tool
+// calls to the upstream servers with the user's stored credentials.
+//
+// This is a proof of feasibility. It connects to every upstream on every
+// request and keeps no state between requests.
+package mcpgateway
+
+import (
+	"net/http"
+
+	"cdr.dev/slog/v3"
+
+	"github.com/coder/coder/v2/coderd/database"
+	"github.com/coder/coder/v2/coderd/x/chatd/mcpclient"
+)
+
+// Options configures a Gateway.
+type Options struct {
+	Logger slog.Logger
+	// Database must be dbauthz-wrapped. Config reads are post-filtered by
+	// the actor in the request context, which is how server-level ACLs are
+	// enforced.
+	Database database.Store
+	// HTTPClient is the base client for upstream MCP connections.
+	HTTPClient *http.Client
+	// OIDCTokenSource resolves user_oidc upstream credentials. May be nil.
+	OIDCTokenSource mcpclient.UserOIDCTokenSource
+}
+
+// Gateway serves an aggregated MCP endpoint.
+type Gateway struct {
+	opts Options
+}
+
+// New returns a Gateway.
+func New(opts Options) *Gateway {
+	return &Gateway{opts: opts}
+}
+
+// Handler returns the streamable HTTP handler. The request context must carry
+// a dbauthz actor for the requesting user. The organization comes from
+// httpmw.OrganizationParam.
+func (g *Gateway) Handler() http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		http.Error(w, "not implemented", http.StatusNotImplemented)
+	})
+}

--- a/coderd/x/mcpgateway/gateway.go
+++ b/coderd/x/mcpgateway/gateway.go
@@ -8,13 +8,27 @@
 package mcpgateway
 
 import (
+	"context"
 	"net/http"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+	"golang.org/x/xerrors"
 
 	"cdr.dev/slog/v3"
 
+	"github.com/coder/coder/v2/buildinfo"
 	"github.com/coder/coder/v2/coderd/database"
+	"github.com/coder/coder/v2/coderd/database/dbauthz"
+	"github.com/coder/coder/v2/coderd/httpapi"
+	"github.com/coder/coder/v2/coderd/httpmw"
 	"github.com/coder/coder/v2/coderd/x/chatd/mcpclient"
+	"github.com/coder/coder/v2/codersdk"
 )
+
+// connectTimeout bounds the connect and list sequence for one upstream.
+const connectTimeout = 10 * time.Second
 
 // Options configures a Gateway.
 type Options struct {
@@ -43,7 +57,149 @@ func New(opts Options) *Gateway {
 // a dbauthz actor for the requesting user. The organization comes from
 // httpmw.OrganizationParam.
 func (g *Gateway) Handler() http.Handler {
-	return http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		http.Error(w, "not implemented", http.StatusNotImplemented)
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		ctx := r.Context()
+		org := httpmw.OrganizationParam(r)
+
+		userID, err := requestUserID(r)
+		if err != nil {
+			httpapi.Write(ctx, w, http.StatusUnauthorized, codersdk.Response{
+				Message: "No user in request context.",
+				Detail:  err.Error(),
+			})
+			return
+		}
+
+		server, closeUpstreams, err := g.buildServer(ctx, org.ID, userID)
+		if err != nil {
+			httpapi.Write(ctx, w, http.StatusInternalServerError, codersdk.Response{
+				Message: "Failed to build MCP gateway server.",
+				Detail:  err.Error(),
+			})
+			return
+		}
+		defer closeUpstreams()
+
+		mcp.NewStreamableHTTPHandler(
+			func(*http.Request) *mcp.Server { return server },
+			&mcp.StreamableHTTPOptions{Stateless: true},
+		).ServeHTTP(w, r)
 	})
+}
+
+// requestUserID resolves the calling user. HTTP callers come through
+// apiKeyMiddleware; in-process callers only have a dbauthz actor.
+func requestUserID(r *http.Request) (uuid.UUID, error) {
+	if key, ok := httpmw.APIKeyOptional(r); ok {
+		return key.UserID, nil
+	}
+	actor, ok := dbauthz.ActorFromContext(r.Context())
+	if !ok {
+		return uuid.Nil, xerrors.New("no actor in request context")
+	}
+	userID, err := uuid.Parse(actor.ID)
+	if err != nil {
+		return uuid.Nil, xerrors.Errorf("parse actor id %q: %w", actor.ID, err)
+	}
+	return userID, nil
+}
+
+// buildServer connects to every MCP server the actor may read and registers
+// their allowed tools on a fresh server. An upstream that fails is logged and
+// skipped so one bad server cannot break the whole request.
+func (g *Gateway) buildServer(
+	ctx context.Context,
+	orgID uuid.UUID,
+	userID uuid.UUID,
+) (*mcp.Server, func(), error) {
+	configs, err := g.opts.Database.GetEnabledMCPServerConfigsByOrganization(ctx, orgID)
+	if err != nil {
+		return nil, nil, xerrors.Errorf("get MCP server configs: %w", err)
+	}
+	tokens, err := g.opts.Database.GetMCPServerUserTokensByUserID(ctx, userID)
+	if err != nil {
+		return nil, nil, xerrors.Errorf("get MCP server user tokens: %w", err)
+	}
+	tokensByConfigID := make(map[uuid.UUID]database.MCPServerUserToken, len(tokens))
+	for _, token := range tokens {
+		tokensByConfigID[token.MCPServerConfigID] = token
+	}
+
+	server := mcp.NewServer(&mcp.Implementation{
+		Name:    "coder-mcp-gateway",
+		Version: buildinfo.Version(),
+	}, nil)
+
+	var sessions []*mcp.ClientSession
+	for _, cfg := range configs {
+		session, tools, err := g.connect(ctx, cfg, tokensByConfigID, userID)
+		if err != nil {
+			g.opts.Logger.Warn(ctx, "skipping unreachable MCP server",
+				slog.F("server_slug", cfg.Slug),
+				slog.F("server_url", mcpclient.RedactURL(cfg.Url)),
+				slog.Error(err),
+			)
+			continue
+		}
+		sessions = append(sessions, session)
+
+		for _, tool := range tools {
+			if !mcpclient.IsToolAllowed(tool.Name, cfg.ToolAllowList, cfg.ToolDenyList) {
+				continue
+			}
+			gatewayTool := *tool
+			gatewayTool.Name = cfg.Slug + "__" + tool.Name
+			server.AddTool(&gatewayTool, forwardTool(session, tool.Name))
+		}
+	}
+
+	return server, func() {
+		for _, session := range sessions {
+			_ = session.Close()
+		}
+	}, nil
+}
+
+// connect opens a session to one upstream and lists its tools.
+func (g *Gateway) connect(
+	ctx context.Context,
+	cfg database.MCPServerConfig,
+	tokensByConfigID map[uuid.UUID]database.MCPServerUserToken,
+	userID uuid.UUID,
+) (*mcp.ClientSession, []*mcp.Tool, error) {
+	headers := mcpclient.BuildAuthHeaders(
+		ctx, g.opts.Logger, cfg, tokensByConfigID, userID, g.opts.OIDCTokenSource,
+	)
+	transport, err := mcpclient.CreateTransport(cfg, headers, g.opts.HTTPClient)
+	if err != nil {
+		return nil, nil, xerrors.Errorf("create transport: %w", err)
+	}
+
+	connectCtx, cancel := context.WithTimeout(ctx, connectTimeout)
+	defer cancel()
+
+	client := mcp.NewClient(&mcp.Implementation{
+		Name:    "coder-mcp-gateway",
+		Version: buildinfo.Version(),
+	}, nil)
+	session, err := client.Connect(connectCtx, transport, nil)
+	if err != nil {
+		return nil, nil, xerrors.Errorf("connect: %w", err)
+	}
+	result, err := session.ListTools(connectCtx, nil)
+	if err != nil {
+		_ = session.Close()
+		return nil, nil, xerrors.Errorf("list tools: %w", err)
+	}
+	return session, result.Tools, nil
+}
+
+// forwardTool proxies a call to the upstream session under its original name.
+func forwardTool(session *mcp.ClientSession, upstreamName string) mcp.ToolHandler {
+	return func(ctx context.Context, req *mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+		return session.CallTool(ctx, &mcp.CallToolParams{
+			Name:      upstreamName,
+			Arguments: req.Params.Arguments,
+		})
+	}
 }

--- a/coderd/x/mcpgateway/gateway_test.go
+++ b/coderd/x/mcpgateway/gateway_test.go
@@ -1,0 +1,242 @@
+package mcpgateway_test
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"net/netip"
+	"testing"
+
+	"github.com/go-chi/chi/v5"
+	"github.com/google/uuid"
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/stretchr/testify/require"
+
+	"cdr.dev/slog/v3/sloggers/slogtest"
+	"github.com/coder/coder/v2/coderd/coderdtest"
+	"github.com/coder/coder/v2/coderd/database"
+	"github.com/coder/coder/v2/coderd/database/dbauthz"
+	"github.com/coder/coder/v2/coderd/database/dbgen"
+	"github.com/coder/coder/v2/coderd/database/dbtestutil"
+	"github.com/coder/coder/v2/coderd/httpmw"
+	"github.com/coder/coder/v2/coderd/rbac"
+	"github.com/coder/coder/v2/coderd/rbac/policy"
+	"github.com/coder/coder/v2/coderd/x/mcpgateway"
+	"github.com/coder/coder/v2/testutil"
+	"github.com/coder/safedial"
+)
+
+// TestGateway proves the gateway aggregates the upstream MCP servers a user
+// may read, hides tools on the deny list, and hides servers the user's ACL
+// does not grant.
+func TestGateway(t *testing.T) {
+	t.Parallel()
+
+	logger := slogtest.Make(t, &slogtest.Options{IgnoreErrors: true})
+	db, _ := dbtestutil.NewDB(t)
+
+	org := dbgen.Organization(t, db, database.Organization{})
+	owner := dbgen.User(t, db, database.User{})
+	other := dbgen.User(t, db, database.User{})
+	for _, id := range []uuid.UUID{owner.ID, other.ID} {
+		dbgen.OrganizationMember(t, db, database.OrganizationMember{
+			OrganizationID: org.ID,
+			UserID:         id,
+		})
+	}
+
+	upstreamA := newTestMCPServer(t, textTool("echo"), textTool("secret"))
+	upstreamB := newTestMCPServer(t, textTool("x"))
+
+	dbgen.MCPServerConfig(t, db, database.MCPServerConfig{
+		OrganizationID: org.ID,
+		Slug:           "a",
+		Url:            upstreamA.URL,
+		Enabled:        true,
+		ToolDenyList:   []string{"secret"},
+		CreatedBy:      uuid.NullUUID{UUID: owner.ID, Valid: true},
+	})
+	// Only "other" may read this server.
+	dbgen.MCPServerConfig(t, db, database.MCPServerConfig{
+		OrganizationID: org.ID,
+		Slug:           "b",
+		Url:            upstreamB.URL,
+		Enabled:        true,
+		GroupACL:       database.ChatACL{},
+		UserACL: database.ChatACL{
+			other.ID.String(): {Permissions: []policy.Action{policy.ActionRead}},
+		},
+		CreatedBy: uuid.NullUUID{UUID: owner.ID, Valid: true},
+	})
+
+	authzDB := dbauthz.New(
+		db,
+		rbac.NewStrictCachingAuthorizer(prometheus.NewRegistry()),
+		logger,
+		coderdtest.AccessControlStorePointer(),
+	)
+	gateway := mcpgateway.New(mcpgateway.Options{
+		Logger:     logger,
+		Database:   authzDB,
+		HTTPClient: testHTTPClient(),
+	})
+
+	t.Run("Owner", func(t *testing.T) {
+		t.Parallel()
+		ctx := testutil.Context(t, testutil.WaitLong)
+		session := connect(ctx, t, db, authzDB, gateway, org, owner.ID)
+
+		tools, err := session.ListTools(ctx, nil)
+		require.NoError(t, err)
+		require.Equal(t, []string{"a__echo"}, toolNames(tools))
+
+		res, err := session.CallTool(ctx, &mcp.CallToolParams{
+			Name:      "a__echo",
+			Arguments: map[string]any{"input": "hi"},
+		})
+		require.NoError(t, err)
+		require.False(t, res.IsError)
+		require.Equal(t, "echo: hi", textContent(t, res))
+
+		// Denied tool and ACL-hidden server must not be callable.
+		for _, name := range []string{"a__secret", "b__x"} {
+			res, err := session.CallTool(ctx, &mcp.CallToolParams{Name: name})
+			if err == nil {
+				require.True(t, res.IsError, "expected %s to fail", name)
+			}
+		}
+	})
+
+	t.Run("Other", func(t *testing.T) {
+		t.Parallel()
+		ctx := testutil.Context(t, testutil.WaitLong)
+		session := connect(ctx, t, db, authzDB, gateway, org, other.ID)
+
+		tools, err := session.ListTools(ctx, nil)
+		require.NoError(t, err)
+		require.ElementsMatch(t, []string{"a__echo", "b__x"}, toolNames(tools))
+
+		res, err := session.CallTool(ctx, &mcp.CallToolParams{
+			Name:      "b__x",
+			Arguments: map[string]any{"input": "yo"},
+		})
+		require.NoError(t, err)
+		require.False(t, res.IsError)
+		require.Equal(t, "x: yo", textContent(t, res))
+	})
+}
+
+// connect serves the gateway over HTTP with the request context carrying
+// userID's actor and the organization param, then dials it with an MCP client.
+func connect(
+	ctx context.Context,
+	t *testing.T,
+	db database.Store,
+	authzDB database.Store,
+	gateway *mcpgateway.Gateway,
+	org database.Organization,
+	userID uuid.UUID,
+) *mcp.ClientSession {
+	t.Helper()
+
+	subject, _, err := httpmw.UserRBACSubject(
+		dbauthz.AsSystemRestricted(ctx), db, userID, rbac.ScopeAll,
+	)
+	require.NoError(t, err)
+
+	router := chi.NewRouter()
+	router.Use(func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			next.ServeHTTP(w, r.WithContext(dbauthz.As(r.Context(), subject)))
+		})
+	})
+	router.Route("/organizations/{organization}", func(r chi.Router) {
+		r.Use(httpmw.ExtractOrganizationParam(authzDB))
+		r.Mount("/mcp-gateway", gateway.Handler())
+	})
+	srv := httptest.NewServer(router)
+	t.Cleanup(srv.Close)
+
+	client := mcp.NewClient(&mcp.Implementation{Name: "test-client", Version: "1.0.0"}, nil)
+	session, err := client.Connect(ctx, &mcp.StreamableClientTransport{
+		Endpoint:   srv.URL + "/organizations/" + org.ID.String() + "/mcp-gateway",
+		HTTPClient: srv.Client(),
+	}, nil)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = session.Close() })
+	return session
+}
+
+func newTestMCPServer(t *testing.T, tools ...toolPair) *httptest.Server {
+	t.Helper()
+	srv := mcp.NewServer(&mcp.Implementation{Name: "test-server", Version: "1.0.0"}, nil)
+	for _, tool := range tools {
+		srv.AddTool(tool.tool, tool.handler)
+	}
+	ts := httptest.NewServer(mcp.NewStreamableHTTPHandler(
+		func(*http.Request) *mcp.Server { return srv },
+		&mcp.StreamableHTTPOptions{Stateless: true},
+	))
+	t.Cleanup(ts.Close)
+	return ts
+}
+
+type toolPair struct {
+	tool    *mcp.Tool
+	handler mcp.ToolHandler
+}
+
+// textTool returns a tool that echoes "<name>: <input>".
+func textTool(name string) toolPair {
+	return toolPair{
+		tool: &mcp.Tool{
+			Name:        name,
+			Description: name + " tool",
+			InputSchema: map[string]any{
+				"type": "object",
+				"properties": map[string]any{
+					"input": map[string]any{"type": "string"},
+				},
+			},
+		},
+		handler: func(_ context.Context, req *mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+			var args map[string]any
+			if len(req.Params.Arguments) > 0 {
+				if err := json.Unmarshal(req.Params.Arguments, &args); err != nil {
+					return nil, err
+				}
+			}
+			input, _ := args["input"].(string)
+			return &mcp.CallToolResult{
+				Content: []mcp.Content{&mcp.TextContent{Text: name + ": " + input}},
+			}, nil
+		},
+	}
+}
+
+func toolNames(res *mcp.ListToolsResult) []string {
+	names := make([]string, 0, len(res.Tools))
+	for _, tool := range res.Tools {
+		names = append(names, tool.Name)
+	}
+	return names
+}
+
+func textContent(t *testing.T, res *mcp.CallToolResult) string {
+	t.Helper()
+	require.Len(t, res.Content, 1)
+	text, ok := res.Content[0].(*mcp.TextContent)
+	require.True(t, ok, "expected text content, got %T", res.Content[0])
+	return text.Text
+}
+
+// testHTTPClient allows loopback upstreams, which the production SSRF-safe
+// client blocks.
+func testHTTPClient() *http.Client {
+	return safedial.NewHTTPClient(nil, safedial.WithAllowedPrefixes(
+		netip.MustParsePrefix("127.0.0.0/8"),
+		netip.MustParsePrefix("::1/128"),
+	))
+}

--- a/codersdk/deployment.go
+++ b/codersdk/deployment.go
@@ -5477,6 +5477,7 @@ const (
 	ExperimentWorkspaceUsage            Experiment = "workspace-usage"             // Enables the new workspace usage tracking.
 	ExperimentOAuth2                    Experiment = "oauth2"                      // Enables OAuth2 provider functionality.
 	ExperimentMCPServerHTTP             Experiment = "mcp-server-http"             // Enables the MCP HTTP server functionality.
+	ExperimentMCPGateway                Experiment = "mcp-gateway"                 // Enables the MCP Gateway prototype and routes chatd MCP traffic through it.
 	ExperimentMCPToolSearch             Experiment = "mcp-tool-search"             // Defers MCP tool schemas behind a searchable catalog in agent chats.
 	ExperimentWorkspaceBuildUpdates     Experiment = "workspace-build-updates"     // Enables publishing workspace build updates to the all builds pubsub channel.
 	ExperimentNATSPubsub                Experiment = "nats_pubsub"                 // Enables embedded NATS pubsub.
@@ -5501,6 +5502,8 @@ func (e Experiment) DisplayName() string {
 		return "OAuth2 Provider Functionality"
 	case ExperimentMCPServerHTTP:
 		return "MCP HTTP Server Functionality"
+	case ExperimentMCPGateway:
+		return "MCP Gateway Prototype"
 	case ExperimentWorkspaceBuildUpdates:
 		return "Workspace Build Updates Channel"
 	case ExperimentNATSPubsub:
@@ -5531,6 +5534,7 @@ var ExperimentsKnown = Experiments{
 	ExperimentWorkspaceUsage,
 	ExperimentOAuth2,
 	ExperimentMCPServerHTTP,
+	ExperimentMCPGateway,
 	ExperimentMCPToolSearch,
 	ExperimentNATSPubsub,
 	ExperimentWorkspaceBuildUpdates,

--- a/site/src/api/typesGenerated.ts
+++ b/site/src/api/typesGenerated.ts
@@ -5094,6 +5094,7 @@ export type Experiment =
 	| "chat-advisor"
 	| "chat-virtual-desktop"
 	| "example"
+	| "mcp-gateway"
 	| "mcp-server-http"
 	| "mcp-tool-search"
 	| "nats_pubsub"
@@ -5110,6 +5111,7 @@ export const Experiments: Experiment[] = [
 	"chat-advisor",
 	"chat-virtual-desktop",
 	"example",
+	"mcp-gateway",
 	"mcp-server-http",
 	"mcp-tool-search",
 	"nats_pubsub",


### PR DESCRIPTION
DNM: this is a throwaway proof of feasibility for the MCP Gateway. It exists to de-risk the direction in the [technical feasibility read](https://app.notion.com/p/3b9d579be59281618487cd9286cf77b6) before the Q4 kickoff. The architecture may change. Do not merge.

Adds `coderd/x/mcpgateway`: one stateless streamable-HTTP MCP endpoint per organization at `/api/experimental/organizations/{organization}/mcp-gateway`, behind the `mcp-gateway` experiment. Per request it loads the enabled `mcp_server_configs` the caller may read (dbauthz `group_acl`/`user_acl` post-filter, so the gateway holds zero authorization code), connects to each upstream with the user's stored credentials via chatd's `mcpclient` helpers, filters tools by `tool_allow_list`/`tool_deny_list`, and re-exposes them as `<slug>__<tool>`. Tool calls are forwarded to the owning upstream.

With the experiment on, chatd replaces its per-server connections with one synthetic config pointing at the gateway and an in-process `RoundTripper` that serves the gateway handler under the chat owner's dbauthz actor. `mcpclient.ConnectAll` is unchanged, which is the point: chatd becomes a plain MCP client.

Out of scope, deliberately: `force_on`, Explore/plan mode, audit, SSE client-facing, session pooling, token refresh, the OAuth2 client leg, DRPC/separate deployable.

<details>
<summary>Findings</summary>

- Connect-per-request against a loopback upstream: `tools/list` 5.7 ms avg, `tools/call` 7.3 ms avg. A remote upstream adds one TCP+TLS handshake plus `initialize`+`tools/list` per gateway request, per upstream. Pooling or reading the JSON-RPC body before connecting is the obvious next step.
- Stateless responses are one short SSE event, so `httptest.NewRecorder` was enough for the in-process transport.
- The synthetic chatd config has `ID == uuid.Nil`, so plan-mode per-server approval and mcp-tool-search deferral collapse to one pseudo-server. Untested, not broken.
- chatd to gateway authentication is short-circuited (in-process actor injection). chatd holds no user secret; a real loopback path needs key minting or the SEC-272 delegated-identity fix.
- Zero-tool or failed upstreams: the gateway serves whatever connected and logs a warning; a successful request logs nothing.
- `mcp-servers` CRUD is already mounted under `/api/v2` as well as `/api/experimental`.
- Tool names in chatd become `gw__<slug>__<tool>`, truncated at `MaxToolNameLen`.

</details>

<details>
<summary>Plan</summary>

# MCP Gateway prototype: thin vertical slice

Status: proof of feasibility. Not mergeable. Architecture may change.

Repo: `/home/coder/coder`, branch off `main` (`ab5c0595c8`).

## Goal

One test proves Tetrate 4.1, 4.2, 4.4 in one place:

> chatd, with the experiment on, lists and calls a tool from two fake upstream
> MCP servers through the gateway. One tool is denied. One server is hidden by
> ACL. The same chat test passes with the experiment off.

Plus: a raw JSON-RPC client (the "cURL") talks to the gateway over HTTP with a
Coder API key.

## What the gateway is in this slice

`coderd/x/mcpgateway`. One `http.Handler` at
`/api/experimental/organizations/{organization}/mcp-gateway`.

Per request (stateless, slow, simple):

1. Actor comes from `apiKeyMiddleware` (`dbauthz` actor already in ctx).
2. Load configs: `db.GetEnabledMCPServerConfigsByOrganization(ctx, orgID)`.
   dbauthz post-filters by `group_acl`/`user_acl`. This is server-level
   enforcement for free.
3. Load tokens: `db.GetMCPServerUserTokensByUserID(ctx, userID)`.
4. For each config: build transport and auth headers (chatd's
   `createTransport` + `buildAuthHeaders`, exported), `Connect`, `ListTools`.
5. Filter tools with chatd's `isToolAllowed` (exported). Register each as
   `slug__tool` on a fresh `*mcp.Server`. Handler forwards `CallTool` to the
   owning upstream session with the original name.
6. Serve with `mcp.NewStreamableHTTPHandler(getServer, {Stateless: true})`.
7. Close upstream sessions after `ServeHTTP` returns.

Out of scope: `force_on`, Explore/plan mode, audit, SSE client-facing,
session pooling, OAuth2 client leg, DRPC. Token refresh is a stretch step.

## chatd as consumer

When `ExperimentMCPGateway` is on, `generation_preparer.go` replaces
`mcpConnectConfigs` with one synthetic config:

```go
database.MCPServerConfig{
    Slug: "gw", Url: "http://mcp-gateway.internal/organizations/<org>",
    Transport: "streamable_http", Enabled: true, AuthType: "none",
}
```

and passes an `*http.Client` whose `RoundTripper` calls the gateway handler
in-process with `dbauthz.As(ctx, ownerSubject)`. `ConnectAll` is unchanged.

Why in-process and not loopback HTTP: chatd holds no user secret (its
synthetic key discards the token). Loopback HTTP needs key minting or a
delegated-identity header, which is the SEC-272 gap. Not this slice's risk.
Record it as the first deferred item.

Side effect: chatd names tools `gw__slug__tool`, truncated at
`MaxToolNameLen`. Acceptable for a prototype. Note it.

## Files

| Action | Path |
|---|---|
| add | `codersdk/deployment.go`: `ExperimentMCPGateway = "mcp-gateway"` |
| add | `coderd/x/mcpgateway/gateway.go`: `Gateway`, `Handler()`, per-request server build |
| add | `coderd/x/mcpgateway/gateway_test.go` |
| edit | `coderd/x/chatd/mcpclient/mcpclient.go`: export `CreateTransport`, `BuildAuthHeaders`, `IsToolAllowed` |
| edit | `coderd/coderd.go`: construct gateway; mount route in org block, gated by `httpmw.RequireExperiment` |
| edit | `coderd/x/chatd/chatd.go`: `Config.MCPGateway http.Handler` |
| edit | `coderd/x/chatd/generation_preparer.go`: synthetic config swap |
| add | `coderd/x/chatd/mcpgateway_test.go` (or extend an existing MCP e2e test) |

Target: under 400 lines including tests.

## Steps (red, green, no refactor)

### 1. Gateway aggregates and filters

Red: `gateway_test.go`. Two fake upstreams via `httptest` +
`NewStreamableHTTPHandler` (copy `newTestMCPServer` from
`mcpclient_test.go`). Insert with `dbgen`: config A (tools `echo`, `secret`;
`tool_deny_list: [secret]`), config B (`user_acl` for another user only,
`group_acl` empty). Client: go-sdk `mcp.Client` over `httptest.NewServer` of
`Gateway.Handler()` with the request context carrying user actor.
Assert `tools/list == [a__echo]`; `tools/call a__echo` returns upstream
result; `tools/call a__secret` and `tools/call b__x` return JSON-RPC errors.

Green: `gateway.go`.

### 2. Raw JSON-RPC client over the real route

Red: `coderdtest` server with experiment on, `dbgen` config, plain
`http.Post` with `Coder-Session-Token` and body
`{"jsonrpc":"2.0","id":1,"method":"tools/list"}` (after `initialize`).
Assert 200 and tool names. Also: a user outside the org gets 403/404.

Green: experiment constant, `coderd.go` wiring and route.

Manual: same calls with `curl` against `./scripts/develop.sh`. Paste the
transcript into the findings.

### 3. chatd through the gateway

Red: chatd test with experiment on and one fake upstream. Drive a
generation that calls the tool. Assert the upstream received the call and
the tool name seen by the model is `gw__<slug>__<tool>`. Run the existing
chatd MCP tests with experiment off; they must still pass.

Green: `Config.MCPGateway`, in-process `RoundTripper`, config swap.

### 4. Stretch: token refresh

Call `mcpclient.RefreshOAuth2Token` and persist with
`UpdateMCPServerUserTokenFromRefresh` under `dbauthz.AsChatdTokenOwner`.
Test: fake OAuth2 token endpoint, expired token, call succeeds.
Skip if step 3 exposes something more important.

## Findings to capture at the end

- Latency of connect-per-request with N upstreams.
- Whether `getServer` returning a server with zero tools on upstream failure
  is acceptable, or an error surface is needed.
- Tool-count and name-length blowup (`gw__slug__tool`).
- Where the JSON-RPC body must be read to avoid `ListTools` on every
  `tools/call` (this is the pooling/stateful question).
- chatd to gateway authentication (SEC-272 shape).

## Open decisions

1. chatd to gateway transport: in-process `RoundTripper` (proposed) or
   loopback HTTP with a minted key.
2. Double prefix `gw__slug__tool` is acceptable for the prototype.
3. Draft PR for visibility (marked "do not merge"), or branch only.


</details>

Generated by Coder Agents on behalf of @johnstcn.
