### PR TITLE
fix(coderd): do not narrow the parameter set on non-start builds

### DIFF
--- a/coderd/dynamicparameters/resolver.go
+++ b/coderd/dynamicparameters/resolver.go
@@ -27,12 +27,17 @@ type parameterValue struct {
 	Source parameterValueSource
 }
 
+// ResolveParameters determines the parameter values to store for a build. The
+// transition is required because only a start build may narrow the set of
+// stored values.
+//
 //nolint:revive // firstbuild is a control flag to turn on immutable validation
 func ResolveParameters(
 	ctx context.Context,
 	ownerID uuid.UUID,
 	renderer Renderer,
 	firstBuild bool,
+	transition database.WorkspaceTransition,
 	previousValues []database.WorkspaceBuildParameter,
 	buildValues []codersdk.WorkspaceBuildParameter,
 	presetValues []database.TemplateVersionPresetParameter,
@@ -204,9 +209,17 @@ func ResolveParameters(
 	// parameter values that have no effect. These leaky parameter values can cause
 	// problems in the future, as it makes it challenging to remove values from the
 	// database
-	for k := range values {
-		if _, ok := parameterNames[k]; !ok {
-			delete(values, k)
+	//
+	// Only a start build may narrow the stored set. A stop or delete build does not
+	// change which parameters a workspace has, so a parameter missing from this
+	// render is not evidence the user removed it. Dropping the value there persists
+	// the reduced set and the following start build reads it as the previous state,
+	// which loses the value even when that build renders the parameter correctly.
+	if transition == database.WorkspaceTransitionStart {
+		for k := range values {
+			if _, ok := parameterNames[k]; !ok {
+				delete(values, k)
+			}
 		}
 	}
 

--- a/coderd/dynamicparameters/resolver_test.go
+++ b/coderd/dynamicparameters/resolver_test.go
@@ -50,6 +50,7 @@ func TestResolveParameters(t *testing.T) {
 
 		ctx := testutil.Context(t, testutil.WaitShort)
 		values, err := dynamicparameters.ResolveParameters(ctx, uuid.New(), render, false,
+			database.WorkspaceTransitionStart,
 			[]database.WorkspaceBuildParameter{},        // No previous values
 			[]codersdk.WorkspaceBuildParameter{},        // No new build values
 			[]database.TemplateVersionPresetParameter{}, // No preset values
@@ -106,6 +107,7 @@ func TestResolveParameters(t *testing.T) {
 
 		ctx := testutil.Context(t, testutil.WaitShort)
 		_, err := dynamicparameters.ResolveParameters(ctx, uuid.New(), render, false,
+			database.WorkspaceTransitionStart,
 			[]database.WorkspaceBuildParameter{
 				{Name: "immutable", Value: "foo"}, // Previous value foo
 			},
@@ -185,6 +187,7 @@ func TestResolveParameters(t *testing.T) {
 
 				ctx := testutil.Context(t, testutil.WaitShort)
 				_, err := dynamicparameters.ResolveParameters(ctx, uuid.New(), render, tc.firstBuild,
+					database.WorkspaceTransitionStart,
 					previousValues,
 					[]codersdk.WorkspaceBuildParameter{
 						{Name: "param", Value: tc.cur},
@@ -201,6 +204,73 @@ func TestResolveParameters(t *testing.T) {
 				} else {
 					require.NoError(t, err)
 				}
+			})
+		}
+	})
+
+	// A render that omits a parameter the workspace already has a value for must
+	// not discard that value on a stop or delete build. Only a start build may
+	// narrow the stored set. See https://github.com/coder/coder/issues/29099.
+	t.Run("UnmatchedValues", func(t *testing.T) {
+		t.Parallel()
+
+		tests := []struct {
+			transition database.WorkspaceTransition
+			expect     map[string]string
+		}{
+			{
+				transition: database.WorkspaceTransitionStart,
+				expect:     map[string]string{"rendered": "foo"},
+			},
+			{
+				transition: database.WorkspaceTransitionStop,
+				expect:     map[string]string{"rendered": "foo", "unrendered": "1000Gi"},
+			},
+			{
+				transition: database.WorkspaceTransitionDelete,
+				expect:     map[string]string{"rendered": "foo", "unrendered": "1000Gi"},
+			},
+		}
+
+		for _, tc := range tests {
+			t.Run(string(tc.transition), func(t *testing.T) {
+				t.Parallel()
+
+				ctrl := gomock.NewController(t)
+				render := rendermock.NewMockRenderer(ctrl)
+
+				// The render only knows about "rendered". "unrendered" is absent,
+				// as it would be if it came from a module that failed to load.
+				render.EXPECT().
+					Render(gomock.Any(), gomock.Any(), gomock.Any()).
+					AnyTimes().
+					Return(&preview.Output{
+						Parameters: []previewtypes.Parameter{
+							{
+								ParameterData: previewtypes.ParameterData{
+									Name:     "rendered",
+									Type:     previewtypes.ParameterTypeString,
+									FormType: provider.ParameterFormTypeInput,
+									Mutable:  true,
+								},
+								Value:       previewtypes.StringLiteral("foo"),
+								Diagnostics: nil,
+							},
+						},
+					}, nil)
+
+				ctx := testutil.Context(t, testutil.WaitShort)
+				values, err := dynamicparameters.ResolveParameters(ctx, uuid.New(), render, false,
+					tc.transition,
+					[]database.WorkspaceBuildParameter{
+						{Name: "rendered", Value: "foo"},
+						{Name: "unrendered", Value: "1000Gi"},
+					},
+					[]codersdk.WorkspaceBuildParameter{},
+					[]database.TemplateVersionPresetParameter{},
+				)
+				require.NoError(t, err)
+				require.Equal(t, tc.expect, values)
 			})
 		}
 	})

--- a/coderd/parameters_test.go
+++ b/coderd/parameters_test.go
@@ -388,6 +388,72 @@ func TestDynamicParametersWithTerraformValues(t *testing.T) {
 	})
 }
 
+// TestDynamicParametersModuleCachePurged asserts that a stop build does not
+// discard stored parameter values when the template version's module cache is
+// gone. Without the cache the render omits every module declared parameter, and
+// narrowing the stored set there would carry the loss into the next start
+// build. See https://github.com/coder/coder/issues/29099.
+func TestDynamicParametersModuleCachePurged(t *testing.T) {
+	t.Parallel()
+
+	mainTF, err := os.ReadFile("testdata/parameters/modules/main.tf")
+	require.NoError(t, err)
+
+	modulesArchive, skipped, err := terraform.GetModulesArchive(os.DirFS("testdata/parameters/modules"))
+	require.NoError(t, err)
+	require.Len(t, skipped, 0)
+
+	store, ps := dbtestutil.NewDB(t)
+	db := newPurgeModuleFilesDB(store)
+
+	ownerClient := coderdtest.New(t, &coderdtest.Options{
+		Database:                 db,
+		Pubsub:                   ps,
+		IncludeProvisionerDaemon: true,
+		ProvisionerDaemonVersion: provProto.CurrentVersion.String(),
+	})
+	owner := coderdtest.CreateFirstUser(t, ownerClient)
+	templateAdmin, templateAdminUser := coderdtest.CreateAnotherUser(t, ownerClient, owner.OrganizationID, rbac.RoleTemplateAdmin())
+
+	_, version := coderdtest.DynamicParameterTemplate(t, templateAdmin, owner.OrganizationID, coderdtest.DynamicParameterTemplateParams{
+		MainTF:         string(mainTF),
+		ModulesArchive: modulesArchive,
+	})
+
+	ctx := testutil.Context(t, testutil.WaitLong)
+
+	// "jetbrains_ide" is declared by the module, "region" by main.tf.
+	expected := []codersdk.WorkspaceBuildParameter{
+		{Name: "jetbrains_ide", Value: "GO"},
+		{Name: "region", Value: "eu"},
+	}
+	workspace, err := templateAdmin.CreateUserWorkspace(ctx, templateAdminUser.ID.String(), codersdk.CreateWorkspaceRequest{
+		TemplateVersionID:   version.ID,
+		Name:                "module-cache",
+		RichParameterValues: expected,
+	})
+	require.NoError(t, err)
+	coderdtest.AwaitWorkspaceBuildJobCompleted(t, templateAdmin, workspace.LatestBuild.ID)
+
+	startParams, err := templateAdmin.WorkspaceBuildParameters(ctx, workspace.LatestBuild.ID)
+	require.NoError(t, err)
+	require.ElementsMatch(t, expected, startParams)
+
+	// The module cache is now gone, so the module and its parameter cannot be
+	// resolved by the renderer.
+	db.SetPurged(true)
+
+	stop, err := templateAdmin.CreateWorkspaceBuild(ctx, workspace.ID, codersdk.CreateWorkspaceBuildRequest{
+		Transition: codersdk.WorkspaceTransitionStop,
+	})
+	require.NoError(t, err)
+	coderdtest.AwaitWorkspaceBuildJobCompleted(t, templateAdmin, stop.ID)
+
+	stopParams, err := templateAdmin.WorkspaceBuildParameters(ctx, stop.ID)
+	require.NoError(t, err)
+	require.ElementsMatch(t, expected, stopParams, "stop build must not drop the module parameter")
+}
+
 type setupDynamicParamsTestParams struct {
 	db                       database.Store
 	ps                       pubsub.Pubsub
@@ -451,6 +517,52 @@ func setupDynamicParamsTest(t *testing.T, args setupDynamicParamsTestParams) dyn
 		stream:   stream,
 		template: tpl,
 	}
+}
+
+// dbPurgeModuleFiles simulates a template version whose cached module files
+// have been removed, as the GHSA-vx42-ghc9-gw65 remediation does.
+type dbPurgeModuleFiles struct {
+	database.Store
+	state *purgeState
+}
+
+type purgeState struct {
+	mu     sync.RWMutex
+	purged bool
+}
+
+func newPurgeModuleFilesDB(store database.Store) *dbPurgeModuleFiles {
+	return &dbPurgeModuleFiles{Store: store, state: &purgeState{}}
+}
+
+// SetPurged toggles whether the cached module files are reported as absent.
+func (d *dbPurgeModuleFiles) SetPurged(purged bool) {
+	d.state.mu.Lock()
+	defer d.state.mu.Unlock()
+	d.state.purged = purged
+}
+
+// InTx keeps the override in place inside transactions, which is where
+// workspace builds resolve their parameters.
+func (d *dbPurgeModuleFiles) InTx(fn func(database.Store) error, opts *database.TxOptions) error {
+	return d.Store.InTx(func(tx database.Store) error {
+		return fn(&dbPurgeModuleFiles{Store: tx, state: d.state})
+	}, opts)
+}
+
+func (d *dbPurgeModuleFiles) GetTemplateVersionTerraformValues(ctx context.Context, templateVersionID uuid.UUID) (database.TemplateVersionTerraformValue, error) {
+	values, err := d.Store.GetTemplateVersionTerraformValues(ctx, templateVersionID)
+	if err != nil {
+		return values, err
+	}
+
+	d.state.mu.RLock()
+	defer d.state.mu.RUnlock()
+	if d.state.purged {
+		values.CachedModuleFiles = uuid.NullUUID{}
+	}
+
+	return values, nil
 }
 
 // dbRejectGitSSHKey is a cheeky way to force an error to occur in a place

--- a/coderd/wsbuilder/wsbuilder.go
+++ b/coderd/wsbuilder/wsbuilder.go
@@ -894,6 +894,7 @@ func (b *Builder) getDynamicParameters() (names, values []string, err error) {
 	}
 
 	buildValues, err := dynamicparameters.ResolveParameters(b.ctx, b.workspace.OwnerID, render, firstBuild,
+		b.trans,
 		lastBuildParameters,
 		b.richParameterValues,
 		presetParameterValues)


### PR DESCRIPTION
Fixes part of #29099 ([ENG-3324](https://linear.app/codercom/issue/ENG-3324)).

## What this does

Only a start build may narrow the stored set. A stop or delete build does not change which parameters a workspace has.

## Why

A stop or delete build re-resolves the workspace parameters and deletes every stored value the render did not return.

- When a template version's `cached_module_files` is NULL the renderer cannot load modules, and the parameters are dropped. Any `restart` or `coder update`, uses the broken version for `stop` and all parameters are removed before the fixed `start`.
  - This can happen on any broken template version

## Scope

This does not fix a start build that resolves against a version with a NULL module cache, which still truncates. That is the completeness-aware discard loop described in the issue, and it lands separately.

## Tests

- `TestResolveParameters/UnmatchedValues` covers all three transitions at the resolver level.
- `TestDynamicParametersModuleCachePurged` is an end-to-end regression test: create a workspace with a module declared parameter, remove the module cache, stop, and assert the value survives. It fails on `main`.

<details>
<summary>Implementation plan</summary>

### Problem

`dynamicparameters.ResolveParameters` ends with an unconditional discard loop (`coderd/dynamicparameters/resolver.go`) that deletes every stored value whose parameter is absent from the render output. With a NULL module cache the render is incomplete, `preview` reports `module_not_loaded` at warning severity, and the reduced parameter set is treated as authoritative.

`wsbuilder.getParameters()` is transition-agnostic, so a stop build persists that truncated set. `cli/update.go` stops first against the workspace's current version, then starts against the active version, and the start build reads the truncated set via `getLastBuildParameters()`.

### Coverage

| Case | Fixed here |
|---|---|
| `coder update`, old version purged, active version healthy | yes |
| Workspace sits on a purged version, autostop then autostart | no, needs the discard loop fix |
| `require_active_version` where the active version is purged | no, needs the discard loop fix |

### Changes

1. `resolver.go`: gate the discard loop on the build transition. Ephemeral trimming, immutability, monotonicity, and default backfill are unchanged.
2. `wsbuilder.go`: pass `b.trans`. Single non-test caller.

### Deliberate calls

- `delete` is treated like `stop`. Neither transition changes which parameters a workspace has, and it keeps the condition to one comparison.
- The transition is passed rather than a second boolean flag, so the call site stays unambiguous next to `firstBuild`.

</details>

---

🤖 Authored by Coder Agents on behalf of @Emyrk.