### PR TITLE
fix: error on CLI HTTP redirects instead of following them

### DIFF
--- a/cli/root.go
+++ b/cli/root.go
@@ -904,12 +904,9 @@ func (r *RootCmd) createHTTPClient(ctx context.Context, serverURL *url.URL, inv 
 	return httpClient, nil
 }
 
-// rejectRedirect is an http.Client CheckRedirect hook that refuses to
-// follow any redirect. Go's default behavior would follow a 301, 302, or
-// 303 by downgrading the request to a GET with no body, silently turning
-// a POST into a read of the same path. A redirect from the API almost
-// always means the configured deployment URL is stale, so surface that
-// instead. The --allow-redirects flag restores the old behavior.
+// rejectRedirect is an http.Client CheckRedirect hook. Go's default would
+// follow a 3xx by downgrading POST to GET, which silently changes the API
+// call being made.
 func rejectRedirect(req *http.Request, via []*http.Request) error {
 	err := &redirectError{to: req.URL}
 	if len(via) > 0 {
@@ -931,9 +928,7 @@ func (e *redirectError) Error() string {
 	return fmt.Sprintf("server redirected request from %s to %s", e.from, e.to)
 }
 
-// Helper returns a suggestion for resolving the redirect. When the
-// redirect points at a different deployment URL, the user should log in
-// against it so the stored URL and token are refreshed.
+// Helper returns a suggestion for resolving the redirect.
 func (e *redirectError) Helper() string {
 	if e.to == nil {
 		return ""
@@ -1610,8 +1605,7 @@ func formatCoderSDKError(from string, err *codersdk.Error, opts *formatOpts) str
 	return str.String()
 }
 
-// formatRedirectError formats a redirectError with the redirect target
-// and a suggestion for fixing the configured deployment URL.
+// formatRedirectError formats a redirectError for CLI output.
 func formatRedirectError(from string, err *redirectError) string {
 	var str strings.Builder
 	if from != "" {

--- a/cli/root.go
+++ b/cli/root.go
@@ -459,7 +459,7 @@ func (r *RootCmd) Command(subcommands []*serpent.Command) (*serpent.Command, err
 		{
 			Flag:        varAllowRedirects,
 			Env:         envAllowRedirects,
-			Description: "Follow HTTP redirects from the server instead of returning an error. Following a redirect downgrades POST requests to GET and may cause unexpected behavior.",
+			Description: "Follow HTTP redirects from the server instead of returning an error. Following redirects may alter the request method and/or drop its body.",
 			Value:       serpent.BoolOf(&r.allowRedirects),
 			Group:       globalGroup,
 		},
@@ -904,9 +904,9 @@ func (r *RootCmd) createHTTPClient(ctx context.Context, serverURL *url.URL, inv 
 	return httpClient, nil
 }
 
-// rejectRedirect is an http.Client CheckRedirect hook. Go's default would
-// follow a 3xx by downgrading POST to GET, which silently changes the API
-// call being made.
+// rejectRedirect is an http.Client CheckRedirect hook. Following a redirect
+// may alter the request method or drop its body, which silently changes the
+// API call being made.
 func rejectRedirect(req *http.Request, via []*http.Request) error {
 	err := &redirectError{to: req.URL}
 	if len(via) > 0 {

--- a/cli/root.go
+++ b/cli/root.go
@@ -886,8 +886,50 @@ func (r *RootCmd) createHTTPClient(ctx context.Context, serverURL *url.URL, inv 
 	// to clone on the DERP client.
 	headerTransport.Transport = transport
 	return &http.Client{
-		Transport: headerTransport,
+		Transport:     headerTransport,
+		CheckRedirect: rejectRedirect,
 	}, nil
+}
+
+// rejectRedirect is an http.Client CheckRedirect hook that refuses to
+// follow any redirect. Go's default behavior would follow a 301, 302, or
+// 303 by downgrading the request to a GET with no body, silently turning
+// a POST into a read of the same path. A redirect from the API almost
+// always means the configured deployment URL is stale, so surface that
+// instead.
+func rejectRedirect(req *http.Request, via []*http.Request) error {
+	err := &redirectError{to: req.URL}
+	if len(via) > 0 {
+		err.from = via[0].URL
+	}
+	return err
+}
+
+// redirectError is returned when the server redirects an API request.
+type redirectError struct {
+	from *url.URL
+	to   *url.URL
+}
+
+func (e *redirectError) Error() string {
+	if e.from == nil {
+		return fmt.Sprintf("server redirected request to %s", e.to)
+	}
+	return fmt.Sprintf("server redirected request from %s to %s", e.from, e.to)
+}
+
+// Helper returns a suggestion for resolving the redirect. When the
+// redirect points at a different deployment URL, the user should log in
+// against it so the stored URL and token are refreshed.
+func (e *redirectError) Helper() string {
+	if e.to == nil {
+		return ""
+	}
+	newBase := &url.URL{Scheme: e.to.Scheme, Host: e.to.Host}
+	if e.from != nil && e.from.Scheme == newBase.Scheme && e.from.Host == newBase.Host {
+		return "The request was redirected within the same deployment. Check for a proxy or path rewrite in front of Coder."
+	}
+	return fmt.Sprintf("The deployment URL may have changed. Run %q to log in against the new URL.", "coder login "+newBase.String())
 }
 
 func newHTTPTransport(tlsConfig *tls.Config) (http.RoundTripper, error) {
@@ -1416,6 +1458,10 @@ func cliHumanFormatError(from string, err error, opts *formatOpts) (string, bool
 		return formatCoderSDKError(from, sdkError, opts), true
 	}
 
+	if redirectErr, ok := err.(*redirectError); ok {
+		return formatRedirectError(from, redirectErr), true
+	}
+
 	if cmdErr, ok := err.(*serpent.RunCommandError); ok {
 		// no need to pass the "from" context to this since it is always
 		// top level. We care about what is below this.
@@ -1547,6 +1593,22 @@ func formatCoderSDKError(from string, err *codersdk.Error, opts *formatOpts) str
 	if opts.Verbose || (err.Helper == "" && err.Detail != "") {
 		_, _ = str.WriteString("\n")
 		_, _ = str.WriteString(pretty.Sprint(tailLineStyle(), err.Detail))
+	}
+	return str.String()
+}
+
+// formatRedirectError formats a redirectError with the redirect target
+// and a suggestion for fixing the configured deployment URL.
+func formatRedirectError(from string, err *redirectError) string {
+	var str strings.Builder
+	if from != "" {
+		_, _ = str.WriteString(pretty.Sprint(headLineStyle(), fmt.Sprintf("Trace=[%s]", from)))
+		_, _ = str.WriteString("\n")
+	}
+	_, _ = str.WriteString(pretty.Sprint(headLineStyle(), err.Error()))
+	if helper := err.Helper(); helper != "" {
+		_, _ = str.WriteString("\n")
+		_, _ = str.WriteString(pretty.Sprintf(tailLineStyle(), "Suggestion: %s", helper))
 	}
 	return str.String()
 }

--- a/cli/root.go
+++ b/cli/root.go
@@ -75,6 +75,7 @@ const (
 	varNoOpen                  = "no-open"
 	varNoVersionCheck          = "no-version-warning"
 	varNoFeatureWarning        = "no-feature-warning"
+	varAllowRedirects          = "allow-redirects"
 	varForceTty                = "force-tty"
 	varVerbose                 = "verbose"
 	varDisableDirect           = "disable-direct-connections"
@@ -88,6 +89,7 @@ const (
 
 	envNoVersionCheck    = "CODER_NO_VERSION_WARNING"
 	envNoFeatureWarning  = "CODER_NO_FEATURE_WARNING"
+	envAllowRedirects    = "CODER_ALLOW_REDIRECTS"
 	envSessionToken      = "CODER_SESSION_TOKEN"
 	envUseKeyring        = "CODER_USE_KEYRING"
 	envClientTLSCAFile   = "CODER_CLIENT_TLS_CA_FILE"
@@ -455,6 +457,13 @@ func (r *RootCmd) Command(subcommands []*serpent.Command) (*serpent.Command, err
 			Group:       globalGroup,
 		},
 		{
+			Flag:        varAllowRedirects,
+			Env:         envAllowRedirects,
+			Description: "Follow HTTP redirects from the server instead of returning an error. Following a redirect downgrades POST requests to GET and may cause unexpected behavior.",
+			Value:       serpent.BoolOf(&r.allowRedirects),
+			Group:       globalGroup,
+		},
+		{
 			Flag:        varHeader,
 			Env:         "CODER_HEADER",
 			Description: "Additional HTTP headers added to all requests. Provide as " + `key=value` + ". Can be specified multiple times.",
@@ -587,6 +596,7 @@ type RootCmd struct {
 	disableNetworkTelemetry    bool
 	noVersionCheck             bool
 	noFeatureWarning           bool
+	allowRedirects             bool
 	useKeyring                 bool
 	keyringServiceName         string
 	useKeyringWithGlobalConfig bool
@@ -885,10 +895,13 @@ func (r *RootCmd) createHTTPClient(ctx context.Context, serverURL *url.URL, inv 
 	// codersdk checks for the header transport to get headers
 	// to clone on the DERP client.
 	headerTransport.Transport = transport
-	return &http.Client{
-		Transport:     headerTransport,
-		CheckRedirect: rejectRedirect,
-	}, nil
+	httpClient := &http.Client{
+		Transport: headerTransport,
+	}
+	if !r.allowRedirects {
+		httpClient.CheckRedirect = rejectRedirect
+	}
+	return httpClient, nil
 }
 
 // rejectRedirect is an http.Client CheckRedirect hook that refuses to
@@ -896,7 +909,7 @@ func (r *RootCmd) createHTTPClient(ctx context.Context, serverURL *url.URL, inv 
 // 303 by downgrading the request to a GET with no body, silently turning
 // a POST into a read of the same path. A redirect from the API almost
 // always means the configured deployment URL is stale, so surface that
-// instead.
+// instead. The --allow-redirects flag restores the old behavior.
 func rejectRedirect(req *http.Request, via []*http.Request) error {
 	err := &redirectError{to: req.URL}
 	if len(via) > 0 {
@@ -927,9 +940,9 @@ func (e *redirectError) Helper() string {
 	}
 	newBase := &url.URL{Scheme: e.to.Scheme, Host: e.to.Host}
 	if e.from != nil && e.from.Scheme == newBase.Scheme && e.from.Host == newBase.Host {
-		return "The request was redirected within the same deployment. Check for a proxy or path rewrite in front of Coder."
+		return fmt.Sprintf("The request was redirected within the same deployment. Check for a proxy or path rewrite in front of Coder, or pass --%s to follow redirects.", varAllowRedirects)
 	}
-	return fmt.Sprintf("The deployment URL may have changed. Run %q to log in against the new URL.", "coder login "+newBase.String())
+	return fmt.Sprintf("The deployment URL may have changed. Run %q to log in against the new URL, or pass --%s to follow redirects.", "coder login "+newBase.String(), varAllowRedirects)
 }
 
 func newHTTPTransport(tlsConfig *tls.Config) (http.RoundTripper, error) {

--- a/cli/root_internal_test.go
+++ b/cli/root_internal_test.go
@@ -712,14 +712,12 @@ func Test_createHTTPClientRedirects(t *testing.T) {
 
 		r := &RootCmd{noVersionCheck: true, noFeatureWarning: true, allowRedirects: true}
 		client := newClient(t, r, stale.URL)
-		// The redirect is followed as a GET, so the list endpoint responds.
 		tokens, err := client.Tokens(context.Background(), codersdk.Me, codersdk.TokensFilter{})
 		require.NoError(t, err)
 		require.Empty(t, tokens)
 
-		// The legacy downgrade behavior is preserved: the POST is followed as
-		// a GET and the mismatched body surfaces as a decode error rather
-		// than a redirectError.
+		// Legacy behavior: the POST is followed as a GET and fails on the
+		// mismatched body rather than on the redirect itself.
 		_, err = client.CreateToken(context.Background(), codersdk.Me, codersdk.CreateTokenRequest{})
 		require.Error(t, err)
 		var redirectErr *redirectError

--- a/cli/root_internal_test.go
+++ b/cli/root_internal_test.go
@@ -10,6 +10,7 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"net/url"
 	"os"
 	"runtime"
 	"testing"
@@ -651,4 +652,82 @@ func TestWrapTransportWithSessionIDHeader(t *testing.T) {
 	// The baggage header the server receives must carry the session ID under
 	// the client_session_id key so the tracing middleware can extract it.
 	require.Equal(t, tracing.SessionIDBaggageKey+"="+sessionID, gotHeader.Get("baggage"))
+}
+
+func Test_createHTTPClientRejectsRedirect(t *testing.T) {
+	t.Parallel()
+
+	// The redirect target serves the "list" shape on GET so that following
+	// the redirect would silently turn a create into a list.
+	target := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte("[]"))
+	}))
+	t.Cleanup(target.Close)
+
+	stale := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Redirect(w, r, target.URL+r.URL.Path, http.StatusMovedPermanently)
+	}))
+	t.Cleanup(stale.Close)
+
+	staleURL, err := url.Parse(stale.URL)
+	require.NoError(t, err)
+
+	r := &RootCmd{noVersionCheck: true, noFeatureWarning: true}
+	inv := &serpent.Invocation{Command: &serpent.Command{Use: "test"}}
+	httpClient, err := r.createHTTPClient(context.Background(), staleURL, inv)
+	require.NoError(t, err)
+	t.Cleanup(httpClient.CloseIdleConnections)
+
+	client := codersdk.New(staleURL, codersdk.WithHTTPClient(httpClient))
+	_, err = client.CreateToken(context.Background(), codersdk.Me, codersdk.CreateTokenRequest{})
+	require.Error(t, err)
+
+	var redirectErr *redirectError
+	require.ErrorAs(t, err, &redirectErr)
+	require.Equal(t, stale.URL+"/api/v2/users/me/keys/tokens", redirectErr.from.String())
+	require.Equal(t, target.URL+"/api/v2/users/me/keys/tokens", redirectErr.to.String())
+
+	msg, special := cliHumanFormatError("", err, nil)
+	require.True(t, special)
+	require.Contains(t, msg, "server redirected request from "+stale.URL)
+	require.Contains(t, msg, fmt.Sprintf("Run %q to log in against the new URL.", "coder login "+target.URL))
+}
+
+func Test_redirectErrorHelper(t *testing.T) {
+	t.Parallel()
+
+	mustParse := func(s string) *url.URL {
+		u, err := url.Parse(s)
+		require.NoError(t, err)
+		return u
+	}
+
+	t.Run("DifferentHost", func(t *testing.T) {
+		t.Parallel()
+		err := &redirectError{
+			from: mustParse("https://old.example.com/api/v2/users/me"),
+			to:   mustParse("https://new.example.com/api/v2/users/me"),
+		}
+		require.Contains(t, err.Helper(), `"coder login https://new.example.com"`)
+	})
+
+	t.Run("SchemeUpgrade", func(t *testing.T) {
+		t.Parallel()
+		err := &redirectError{
+			from: mustParse("http://coder.example.com/api/v2/users/me"),
+			to:   mustParse("https://coder.example.com/api/v2/users/me"),
+		}
+		require.Contains(t, err.Helper(), `"coder login https://coder.example.com"`)
+	})
+
+	t.Run("SameDeployment", func(t *testing.T) {
+		t.Parallel()
+		err := &redirectError{
+			from: mustParse("https://coder.example.com/api/v2/users/me"),
+			to:   mustParse("https://coder.example.com/api/v2/users/me/"),
+		}
+		require.Contains(t, err.Helper(), "redirected within the same deployment")
+		require.NotContains(t, err.Helper(), "coder login")
+	})
 }

--- a/cli/root_internal_test.go
+++ b/cli/root_internal_test.go
@@ -6,6 +6,7 @@ import (
 	"crypto/tls"
 	"encoding/base64"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -654,44 +655,76 @@ func TestWrapTransportWithSessionIDHeader(t *testing.T) {
 	require.Equal(t, tracing.SessionIDBaggageKey+"="+sessionID, gotHeader.Get("baggage"))
 }
 
-func Test_createHTTPClientRejectsRedirect(t *testing.T) {
+func Test_createHTTPClientRedirects(t *testing.T) {
 	t.Parallel()
 
-	// The redirect target serves the "list" shape on GET so that following
-	// the redirect would silently turn a create into a list.
-	target := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.Header().Set("Content-Type", "application/json")
-		_, _ = w.Write([]byte("[]"))
-	}))
-	t.Cleanup(target.Close)
+	// newRedirectingServers returns a stale server that 301s every request
+	// to a target serving the "list" shape on GET, so that following the
+	// redirect would silently turn a create into a list.
+	newRedirectingServers := func(t *testing.T) (stale, target *httptest.Server) {
+		target = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte("[]"))
+		}))
+		t.Cleanup(target.Close)
 
-	stale := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		http.Redirect(w, r, target.URL+r.URL.Path, http.StatusMovedPermanently)
-	}))
-	t.Cleanup(stale.Close)
+		stale = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			http.Redirect(w, r, target.URL+r.URL.Path, http.StatusMovedPermanently)
+		}))
+		t.Cleanup(stale.Close)
+		return stale, target
+	}
 
-	staleURL, err := url.Parse(stale.URL)
-	require.NoError(t, err)
+	newClient := func(t *testing.T, r *RootCmd, rawURL string) *codersdk.Client {
+		serverURL, err := url.Parse(rawURL)
+		require.NoError(t, err)
+		inv := &serpent.Invocation{Command: &serpent.Command{Use: "test"}}
+		httpClient, err := r.createHTTPClient(context.Background(), serverURL, inv)
+		require.NoError(t, err)
+		t.Cleanup(httpClient.CloseIdleConnections)
+		return codersdk.New(serverURL, codersdk.WithHTTPClient(httpClient))
+	}
 
-	r := &RootCmd{noVersionCheck: true, noFeatureWarning: true}
-	inv := &serpent.Invocation{Command: &serpent.Command{Use: "test"}}
-	httpClient, err := r.createHTTPClient(context.Background(), staleURL, inv)
-	require.NoError(t, err)
-	t.Cleanup(httpClient.CloseIdleConnections)
+	t.Run("RejectedByDefault", func(t *testing.T) {
+		t.Parallel()
+		stale, target := newRedirectingServers(t)
 
-	client := codersdk.New(staleURL, codersdk.WithHTTPClient(httpClient))
-	_, err = client.CreateToken(context.Background(), codersdk.Me, codersdk.CreateTokenRequest{})
-	require.Error(t, err)
+		r := &RootCmd{noVersionCheck: true, noFeatureWarning: true}
+		client := newClient(t, r, stale.URL)
+		_, err := client.CreateToken(context.Background(), codersdk.Me, codersdk.CreateTokenRequest{})
+		require.Error(t, err)
 
-	var redirectErr *redirectError
-	require.ErrorAs(t, err, &redirectErr)
-	require.Equal(t, stale.URL+"/api/v2/users/me/keys/tokens", redirectErr.from.String())
-	require.Equal(t, target.URL+"/api/v2/users/me/keys/tokens", redirectErr.to.String())
+		var redirectErr *redirectError
+		require.ErrorAs(t, err, &redirectErr)
+		require.Equal(t, stale.URL+"/api/v2/users/me/keys/tokens", redirectErr.from.String())
+		require.Equal(t, target.URL+"/api/v2/users/me/keys/tokens", redirectErr.to.String())
 
-	msg, special := cliHumanFormatError("", err, nil)
-	require.True(t, special)
-	require.Contains(t, msg, "server redirected request from "+stale.URL)
-	require.Contains(t, msg, fmt.Sprintf("Run %q to log in against the new URL.", "coder login "+target.URL))
+		msg, special := cliHumanFormatError("", err, nil)
+		require.True(t, special)
+		require.Contains(t, msg, "server redirected request from "+stale.URL)
+		require.Contains(t, msg, fmt.Sprintf("Run %q to log in against the new URL", "coder login "+target.URL))
+		require.Contains(t, msg, "--allow-redirects")
+	})
+
+	t.Run("AllowRedirects", func(t *testing.T) {
+		t.Parallel()
+		stale, _ := newRedirectingServers(t)
+
+		r := &RootCmd{noVersionCheck: true, noFeatureWarning: true, allowRedirects: true}
+		client := newClient(t, r, stale.URL)
+		// The redirect is followed as a GET, so the list endpoint responds.
+		tokens, err := client.Tokens(context.Background(), codersdk.Me, codersdk.TokensFilter{})
+		require.NoError(t, err)
+		require.Empty(t, tokens)
+
+		// The legacy downgrade behavior is preserved: the POST is followed as
+		// a GET and the mismatched body surfaces as a decode error rather
+		// than a redirectError.
+		_, err = client.CreateToken(context.Background(), codersdk.Me, codersdk.CreateTokenRequest{})
+		require.Error(t, err)
+		var redirectErr *redirectError
+		require.False(t, errors.As(err, &redirectErr))
+	})
 }
 
 func Test_redirectErrorHelper(t *testing.T) {

--- a/cli/testdata/coder_--help.golden
+++ b/cli/testdata/coder_--help.golden
@@ -70,6 +70,11 @@ GLOBAL OPTIONS:
 Global options are applied to all commands. They can be set using environment
 variables or flags.
 
+      --allow-redirects bool, $CODER_ALLOW_REDIRECTS
+          Follow HTTP redirects from the server instead of returning an error.
+          Following a redirect downgrades POST requests to GET and may cause
+          unexpected behavior.
+
       --client-tls-ca-file string, $CODER_CLIENT_TLS_CA_FILE
           Path to a CA certificate file to trust for API and DERP connections.
 

--- a/cli/testdata/coder_--help.golden
+++ b/cli/testdata/coder_--help.golden
@@ -72,8 +72,7 @@ variables or flags.
 
       --allow-redirects bool, $CODER_ALLOW_REDIRECTS
           Follow HTTP redirects from the server instead of returning an error.
-          Following a redirect downgrades POST requests to GET and may cause
-          unexpected behavior.
+          Following redirects may alter the request method and/or drop its body.
 
       --client-tls-ca-file string, $CODER_CLIENT_TLS_CA_FILE
           Path to a CA certificate file to trust for API and DERP connections.

--- a/docs/reference/cli/index.md
+++ b/docs/reference/cli/index.md
@@ -133,7 +133,7 @@ Suppress warnings about unlicensed features.
 | Type        | <code>bool</code>                   |
 | Environment | <code>$CODER_ALLOW_REDIRECTS</code> |
 
-Follow HTTP redirects from the server instead of returning an error. Following a redirect downgrades POST requests to GET and may cause unexpected behavior.
+Follow HTTP redirects from the server instead of returning an error. Following redirects may alter the request method and/or drop its body.
 
 ### --header
 

--- a/docs/reference/cli/index.md
+++ b/docs/reference/cli/index.md
@@ -126,6 +126,15 @@ Suppress warning when client and server versions do not match.
 
 Suppress warnings about unlicensed features.
 
+### --allow-redirects
+
+|             |                                     |
+|-------------|-------------------------------------|
+| Type        | <code>bool</code>                   |
+| Environment | <code>$CODER_ALLOW_REDIRECTS</code> |
+
+Follow HTTP redirects from the server instead of returning an error. Following a redirect downgrades POST requests to GET and may cause unexpected behavior.
+
 ### --header
 
 |             |                            |

--- a/enterprise/cli/testdata/coder_--help.golden
+++ b/enterprise/cli/testdata/coder_--help.golden
@@ -31,8 +31,7 @@ variables or flags.
 
       --allow-redirects bool, $CODER_ALLOW_REDIRECTS
           Follow HTTP redirects from the server instead of returning an error.
-          Following a redirect downgrades POST requests to GET and may cause
-          unexpected behavior.
+          Following redirects may alter the request method and/or drop its body.
 
       --client-tls-ca-file string, $CODER_CLIENT_TLS_CA_FILE
           Path to a CA certificate file to trust for API and DERP connections.

--- a/enterprise/cli/testdata/coder_--help.golden
+++ b/enterprise/cli/testdata/coder_--help.golden
@@ -29,6 +29,11 @@ GLOBAL OPTIONS:
 Global options are applied to all commands. They can be set using environment
 variables or flags.
 
+      --allow-redirects bool, $CODER_ALLOW_REDIRECTS
+          Follow HTTP redirects from the server instead of returning an error.
+          Following a redirect downgrades POST requests to GET and may cause
+          unexpected behavior.
+
       --client-tls-ca-file string, $CODER_CLIENT_TLS_CA_FILE
           Path to a CA certificate file to trust for API and DERP connections.
 


### PR DESCRIPTION
## Problem

`codersdk.Client` uses an `http.Client` with no `CheckRedirect`, so Go's default applies: a 301/302/303 is followed by downgrading the request to a GET with no body. When `~/.config/coderv2/url` points at a stale host that redirects to the new deployment, `coder tokens create` silently becomes a `GET /api/v2/users/{user}/keys/tokens` (the list endpoint, same path) and fails with:

```
error: create tokens: json: cannot unmarshal array into Go value of type codersdk.GenerateAPIKeyResponse
```

## Fix

Set `CheckRedirect` on the HTTP client built in `cli/root.go` (`createHTTPClient`, used by every CLI command including `coder login`) to refuse redirects and return a typed `redirectError`. The CLI error formatter prints the original and target URLs plus a suggestion to run `coder login <new URL>` when the redirect changes host or scheme, or a proxy/path-rewrite hint when it stays within the same deployment.

```
Encountered an error running "coder tokens create", see "coder tokens create --help" for more information
error: Trace=[get token config: Get "https://dogfood.cdr.dev/api/v2/users/me/keys/tokens/tokenconfig": ]
server redirected request from https://dev.coder.com/api/v2/users/me/keys/tokens/tokenconfig to https://dogfood.cdr.dev/api/v2/users/me/keys/tokens/tokenconfig
Suggestion: The deployment URL may have changed. Run "coder login https://dogfood.cdr.dev" to log in against the new URL, or pass --allow-redirects to follow redirects.
```

The `codersdk.New` default `http.Client` is intentionally left unchanged to avoid altering behavior for agents, provisioner daemons, and external SDK consumers.

## Breaking change

The CLI previously followed redirects silently. Any workflow that depended on that, for example a stale URL config that "worked" through a host redirect, or an http-to-https redirect in front of a deployment, will now fail with the error above until the stored URL is updated with `coder login`.

To keep the old behavior, opt in with the new global flag `--allow-redirects` or `CODER_ALLOW_REDIRECTS=true`. The flag help text notes that following redirects may alter the request method or drop its body, so this is a compatibility escape hatch rather than a recommended setting.

## Tests

- `Test_createHTTPClientRedirects/RejectedByDefault`: a stale server redirects to a target serving `[]` on GET; asserts `CreateToken` fails with `*redirectError` carrying the correct URLs and that the formatted output includes the login suggestion and the flag name.
- `Test_createHTTPClientRedirects/AllowRedirects`: with `allowRedirects` set, GET requests follow the redirect successfully and the POST reproduces the legacy downgrade behavior without a `redirectError`.
- `Test_redirectErrorHelper`: host change, http-to-https upgrade, and same-deployment cases.

Golden help files and `docs/reference/cli/index.md` regenerated with `make gen`.

---
Generated by Coder Agents on behalf of @f0ssel.

