### PR TITLE
fix: persist models filters in URL

### DIFF
--- a/site/src/pages/AISettingsPage/ModelsPage/ModelsPageView.stories.tsx
+++ b/site/src/pages/AISettingsPage/ModelsPage/ModelsPageView.stories.tsx
@@ -1,6 +1,5 @@
 import type { Meta, StoryObj } from "@storybook/react-vite";
-import { useLocation } from "react-router";
-import { expect, screen, userEvent, waitFor, within } from "storybook/test";
+import { expect, userEvent, within } from "storybook/test";
 import { reactRouterParameters } from "storybook-addon-remix-react-router";
 import type { ChatModel } from "#/api/typesGenerated";
 import {
@@ -21,16 +20,6 @@ import {
 	mockOrphanedModel,
 	mockProviderDisabledModel,
 } from "./testFixtures";
-
-const LocationProbe = () => {
-	const location = useLocation();
-	return (
-		<div data-testid="location-probe">
-			{location.pathname}
-			{location.search}
-		</div>
-	);
-};
 
 const meta: Meta<typeof ModelsPageView> = {
 	title: "pages/AISettingsPage/ModelsPage/ModelsPageView",
@@ -167,41 +156,6 @@ export const FilterByProvider: Story = {
 		await expect(canvas.getByText("Claude Sonnet 4.5")).toBeInTheDocument();
 		await expect(canvas.queryByText("GPT-5")).not.toBeInTheDocument();
 		await expect(canvas.queryByText("GPT-4o mini")).not.toBeInTheDocument();
-	},
-};
-
-export const PersistsProviderFilterAcrossNavigation: Story = {
-	render: (args) => (
-		<>
-			<ModelsPageView {...args} />
-			<LocationProbe />
-		</>
-	),
-	play: async ({ canvasElement }) => {
-		const canvas = within(canvasElement);
-
-		// Selecting a provider writes the filter to the URL.
-		await userEvent.click(
-			canvas.getByRole("combobox", { name: /filter by provider/i }),
-		);
-		await userEvent.click(
-			await within(document.body).findByRole("option", { name: "Anthropic" }),
-		);
-		await waitFor(() =>
-			expect(screen.getByTestId("location-probe")).toHaveTextContent(
-				"provider=prov-anthropic",
-			),
-		);
-
-		// Opening a model carries the filter along, so returning keeps it.
-		await userEvent.click(
-			await canvas.findByRole("button", { name: /Claude Sonnet 4.5/i }),
-		);
-		await waitFor(() => {
-			const probe = screen.getByTestId("location-probe");
-			expect(probe).toHaveTextContent("/ai/settings/models/model-claude");
-			expect(probe).toHaveTextContent("provider=prov-anthropic");
-		});
 	},
 };
 

--- a/site/src/pages/AISettingsPage/ModelsPage/ModelsPageView.stories.tsx
+++ b/site/src/pages/AISettingsPage/ModelsPage/ModelsPageView.stories.tsx
@@ -1,5 +1,6 @@
 import type { Meta, StoryObj } from "@storybook/react-vite";
-import { expect, userEvent, within } from "storybook/test";
+import { useLocation } from "react-router";
+import { expect, screen, userEvent, waitFor, within } from "storybook/test";
 import { reactRouterParameters } from "storybook-addon-remix-react-router";
 import type { ChatModel } from "#/api/typesGenerated";
 import {
@@ -20,6 +21,16 @@ import {
 	mockOrphanedModel,
 	mockProviderDisabledModel,
 } from "./testFixtures";
+
+const LocationProbe = () => {
+	const location = useLocation();
+	return (
+		<div data-testid="location-probe">
+			{location.pathname}
+			{location.search}
+		</div>
+	);
+};
 
 const meta: Meta<typeof ModelsPageView> = {
 	title: "pages/AISettingsPage/ModelsPage/ModelsPageView",
@@ -156,6 +167,41 @@ export const FilterByProvider: Story = {
 		await expect(canvas.getByText("Claude Sonnet 4.5")).toBeInTheDocument();
 		await expect(canvas.queryByText("GPT-5")).not.toBeInTheDocument();
 		await expect(canvas.queryByText("GPT-4o mini")).not.toBeInTheDocument();
+	},
+};
+
+export const PersistsProviderFilterAcrossNavigation: Story = {
+	render: (args) => (
+		<>
+			<ModelsPageView {...args} />
+			<LocationProbe />
+		</>
+	),
+	play: async ({ canvasElement }) => {
+		const canvas = within(canvasElement);
+
+		// Selecting a provider writes the filter to the URL.
+		await userEvent.click(
+			canvas.getByRole("combobox", { name: /filter by provider/i }),
+		);
+		await userEvent.click(
+			await within(document.body).findByRole("option", { name: "Anthropic" }),
+		);
+		await waitFor(() =>
+			expect(screen.getByTestId("location-probe")).toHaveTextContent(
+				"provider=prov-anthropic",
+			),
+		);
+
+		// Opening a model carries the filter along, so returning keeps it.
+		await userEvent.click(
+			await canvas.findByRole("button", { name: /Claude Sonnet 4.5/i }),
+		);
+		await waitFor(() => {
+			const probe = screen.getByTestId("location-probe");
+			expect(probe).toHaveTextContent("/ai/settings/models/model-claude");
+			expect(probe).toHaveTextContent("provider=prov-anthropic");
+		});
 	},
 };
 

--- a/site/src/pages/AISettingsPage/ModelsPage/ModelsPageView.test.tsx
+++ b/site/src/pages/AISettingsPage/ModelsPage/ModelsPageView.test.tsx
@@ -1,0 +1,90 @@
+import { screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { createMemoryRouter } from "react-router";
+import { describe, expect, it } from "vitest";
+import {
+	MockDefaultOrganization,
+	MockOrganizationPermissions,
+} from "#/testHelpers/entities";
+import { renderWithRouter } from "#/testHelpers/renderHelpers";
+import ModelsPageView from "./ModelsPageView";
+import { OrganizationModelsContext } from "./organizationModels";
+import {
+	MockAnthropicProviderState,
+	MockBedrockProviderState,
+	MockOpenAIProviderState,
+	mockBedrockClaude,
+	mockClaude,
+	mockDisabledModel,
+	mockGPT5,
+} from "./testFixtures";
+
+const renderModelsPageView = () => {
+	const element = (
+		<OrganizationModelsContext.Provider
+			value={{
+				organization: MockDefaultOrganization,
+				accessibleOrganizations: [MockDefaultOrganization],
+				permissions: MockOrganizationPermissions,
+				requestedOrganizationDenied: false,
+			}}
+		>
+			<ModelsPageView
+				isLoading={false}
+				loadError={null}
+				refetchError={null}
+				models={[mockGPT5, mockClaude, mockDisabledModel, mockBedrockClaude]}
+				providerStates={[
+					MockOpenAIProviderState,
+					MockAnthropicProviderState,
+					MockBedrockProviderState,
+				]}
+				providerTypeByID={
+					new Map([
+						["prov-openai", "openai"],
+						["prov-anthropic", "anthropic"],
+						["prov-bedrock", "bedrock"],
+					])
+				}
+				canCreateModel
+			/>
+		</OrganizationModelsContext.Provider>
+	);
+
+	return renderWithRouter(
+		createMemoryRouter(
+			[
+				{ path: "/ai/settings/models", element },
+				{ path: "/ai/settings/models/:modelId", element },
+			],
+			{ initialEntries: ["/ai/settings/models"] },
+		),
+	);
+};
+
+describe("ModelsPageView", () => {
+	it("keeps the provider filter in the URL when opening a model", async () => {
+		const user = userEvent.setup();
+		const { router } = renderModelsPageView();
+
+		await user.click(
+			screen.getByRole("combobox", { name: /filter by provider/i }),
+		);
+		await user.click(await screen.findByRole("option", { name: "Anthropic" }));
+
+		await waitFor(() =>
+			expect(router.state.location.search).toContain("provider=prov-anthropic"),
+		);
+
+		await user.click(
+			await screen.findByRole("button", { name: /Claude Sonnet 4.5/i }),
+		);
+
+		await waitFor(() =>
+			expect(router.state.location.pathname).toBe(
+				"/ai/settings/models/model-claude",
+			),
+		);
+		expect(router.state.location.search).toContain("provider=prov-anthropic");
+	});
+});

--- a/site/src/pages/AISettingsPage/ModelsPage/ModelsPageView.tsx
+++ b/site/src/pages/AISettingsPage/ModelsPage/ModelsPageView.tsx
@@ -1,5 +1,5 @@
 import { ChevronDownIcon, PlusIcon, SearchIcon } from "lucide-react";
-import { type FC, useMemo, useState } from "react";
+import { type FC, useMemo } from "react";
 import { useNavigate, useSearchParams } from "react-router";
 import type { ChatModel } from "#/api/typesGenerated";
 import { ErrorAlert } from "#/components/Alert/ErrorAlert";
@@ -54,6 +54,9 @@ import {
 
 const MODELS_PAGE_SIZE = 10;
 const ALL_PROVIDERS_VALUE = "all";
+const PROVIDER_PARAM = "provider";
+const SEARCH_PARAM = "search";
+const PAGE_PARAM = "page";
 
 const AddModelDropdown: FC<{
 	providerStates: readonly ProviderState[];
@@ -121,12 +124,26 @@ const ModelsPageView: FC<ModelsPageViewProps> = ({
 	canCreateModel,
 }) => {
 	const navigate = useNavigate();
-	const [searchParams] = useSearchParams();
+	const [searchParams, setSearchParams] = useSearchParams();
 	const { organization, accessibleOrganizations } = useOrganizationModels();
-	const [page, setPage] = useState(1);
-	const [searchQuery, setSearchQuery] = useState("");
-	const [providerFilter, setProviderFilter] =
-		useState<string>(ALL_PROVIDERS_VALUE);
+
+	// Keep filter state in the URL so it persists across navigation.
+	const providerFilter =
+		searchParams.get(PROVIDER_PARAM) ?? ALL_PROVIDERS_VALUE;
+	const searchQuery = searchParams.get(SEARCH_PARAM) ?? "";
+	const rawPage = Number.parseInt(searchParams.get(PAGE_PARAM) ?? "1", 10);
+	const page = Number.isNaN(rawPage) || rawPage <= 0 ? 1 : rawPage;
+
+	const updateSearchParams = (mutate: (params: URLSearchParams) => void) => {
+		setSearchParams(
+			(prev) => {
+				const next = new URLSearchParams(prev);
+				mutate(next);
+				return next;
+			},
+			{ replace: true },
+		);
+	};
 
 	const providerKeyByModelId = useMemo(() => {
 		const map = new Map<string, string>();
@@ -205,13 +222,35 @@ const ModelsPageView: FC<ModelsPageViewProps> = ({
 		searchQuery.trim().length > 0 || providerFilter !== ALL_PROVIDERS_VALUE;
 
 	const handleSearchChange = (value: string) => {
-		setSearchQuery(value);
-		setPage(1);
+		updateSearchParams((params) => {
+			if (value) {
+				params.set(SEARCH_PARAM, value);
+			} else {
+				params.delete(SEARCH_PARAM);
+			}
+			params.delete(PAGE_PARAM);
+		});
 	};
 
 	const handleProviderChange = (value: string) => {
-		setProviderFilter(value);
-		setPage(1);
+		updateSearchParams((params) => {
+			if (value && value !== ALL_PROVIDERS_VALUE) {
+				params.set(PROVIDER_PARAM, value);
+			} else {
+				params.delete(PROVIDER_PARAM);
+			}
+			params.delete(PAGE_PARAM);
+		});
+	};
+
+	const handlePageChange = (newPage: number) => {
+		updateSearchParams((params) => {
+			if (newPage <= 1) {
+				params.delete(PAGE_PARAM);
+			} else {
+				params.set(PAGE_PARAM, String(newPage));
+			}
+		});
 	};
 
 	return (
@@ -349,7 +388,7 @@ const ModelsPageView: FC<ModelsPageViewProps> = ({
 							currentPage={clampedPage}
 							pageSize={MODELS_PAGE_SIZE}
 							totalRecords={filteredModels.length}
-							onPageChange={setPage}
+							onPageChange={handlePageChange}
 							hasPreviousPage={hasPreviousPage}
 							hasNextPage={hasNextPage}
 						/>


### PR DESCRIPTION
## Description

The provider filter, search query, and page on the Models page were held in local component state, so navigating to a model and back reset them.

The filter state now lives in URL search params, so it survives back navigation and is shareable and refresh-safe.

## Changes

- Persist the provider filter, search query, and page in URL search params.
- Add a Storybook story verifying the provider filter persists across navigation.

Closes https://linear.app/codercom/issue/AIGOV-641

> [!NOTE]
> Generated by Coder Agents on behalf of @ssncferreira.
