### PR TITLE
docs: drop duplicated 'the the' in scaletest flag help and OIDC docs

### DIFF
--- a/cli/exp_scaletest.go
+++ b/cli/exp_scaletest.go
@@ -1095,7 +1095,7 @@ func (r *RootCmd) scaletestCreateWorkspaces() *serpent.Command {
 		{
 			Flag:        "connect-url",
 			Env:         "CODER_SCALETEST_CONNECT_URL",
-			Description: "URL to connect to inside the the workspace over WireGuard. " + "If not specified, no connections will be made over WireGuard.",
+			Description: "URL to connect to inside the workspace over WireGuard. " + "If not specified, no connections will be made over WireGuard.",
 			Value:       serpent.StringOf(&connectURL),
 		},
 		{

--- a/docs/admin/users/oidc-auth/index.md
+++ b/docs/admin/users/oidc-auth/index.md
@@ -68,7 +68,7 @@ CODER_OIDC_IGNORE_EMAIL_VERIFIED=true
 ### Usernames
 
 When a new user logs in via OIDC, Coder will by default use the value of the
-claim field named `preferred_username` as the the username.
+claim field named `preferred_username` as the username.
 
 If your upstream identity provider uses a different claim, you can set
 `CODER_OIDC_USERNAME_FIELD` to the desired claim.


### PR DESCRIPTION
Two doubled-word typos:

- `cli/exp_scaletest.go`: the `--connect-url` flag description shown by `coder exp scaletest --help` read "inside **the the** workspace over WireGuard"
- `docs/admin/users/oidc-auth/index.md`: "as **the the** username"

Docs/help text only.