### PR TITLE
fix(coderd): keep parameter values when the render is incomplete

### DIFF
--- a/coderd/dynamicparameters/resolver.go
+++ b/coderd/dynamicparameters/resolver.go
@@ -10,6 +10,7 @@ import (
 	"github.com/coder/coder/v2/coderd/database"
 	"github.com/coder/coder/v2/coderd/util/slice"
 	"github.com/coder/coder/v2/codersdk"
+	previewtypes "github.com/coder/preview/types"
 	"github.com/coder/terraform-provider-coder/v2/provider"
 )
 
@@ -216,10 +217,20 @@ func ResolveParameters(
 	// the reduced set and the following start build reads it as the previous state,
 	// which loses the value even when that build renders the parameter correctly.
 	if transition == database.WorkspaceTransitionStart {
+		// An incomplete render does not report every parameter the template
+		// declares, so absence from the output says nothing about whether the
+		// parameter still exists. Keeping the values is safe: provisionerd
+		// resolves modules itself, so the build still applies them correctly.
+		// Dropping them destroys user data, which is not recoverable.
+		incomplete := incompleteRender(diags)
 		for k := range values {
-			if _, ok := parameterNames[k]; !ok {
-				delete(values, k)
+			if _, ok := parameterNames[k]; ok {
+				continue
 			}
+			if incomplete {
+				continue
+			}
+			delete(values, k)
 		}
 	}
 
@@ -240,4 +251,19 @@ func (p parameterValueMap) ValuesMap() map[string]string {
 		values[name] = paramValue.Value
 	}
 	return values
+}
+
+// incompleteRender reports whether the render could not see the whole template.
+// Parameters missing from such a render are missing because the renderer could
+// not reach their source, not because the template stopped declaring them.
+func incompleteRender(diags hcl.Diagnostics) bool {
+	for _, diag := range diags {
+		// A module that fails to load takes every parameter it declares with it.
+		// This happens when the template version has no cached module files.
+		if previewtypes.ExtractDiagnosticExtra(diag).Code == previewtypes.DiagnosticModuleNotLoaded {
+			return true
+		}
+	}
+
+	return false
 }

--- a/coderd/dynamicparameters/resolver.go
+++ b/coderd/dynamicparameters/resolver.go
@@ -211,26 +211,23 @@ func ResolveParameters(
 	// problems in the future, as it makes it challenging to remove values from the
 	// database
 	//
+	// Two conditions must hold before a value can be discarded.
+	//
 	// Only a start build may narrow the stored set. A stop or delete build does not
 	// change which parameters a workspace has, so a parameter missing from this
 	// render is not evidence the user removed it. Dropping the value there persists
 	// the reduced set and the following start build reads it as the previous state,
 	// which loses the value even when that build renders the parameter correctly.
-	if transition == database.WorkspaceTransitionStart {
-		// An incomplete render does not report every parameter the template
-		// declares, so absence from the output says nothing about whether the
-		// parameter still exists. Keeping the values is safe: provisionerd
-		// resolves modules itself, so the build still applies them correctly.
-		// Dropping them destroys user data, which is not recoverable.
-		incomplete := incompleteRender(diags)
+	//
+	// The render must also be complete. An incomplete one does not report every
+	// parameter the template declares, so absence from the output means nothing.
+	// Keeping those values is safe, because provisionerd resolves modules itself
+	// and the build still applies them correctly. Dropping them destroys user data.
+	if transition == database.WorkspaceTransitionStart && !incompleteRender(diags) {
 		for k := range values {
-			if _, ok := parameterNames[k]; ok {
-				continue
+			if _, ok := parameterNames[k]; !ok {
+				delete(values, k)
 			}
-			if incomplete {
-				continue
-			}
-			delete(values, k)
 		}
 	}
 

--- a/coderd/dynamicparameters/resolver_test.go
+++ b/coderd/dynamicparameters/resolver_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/google/uuid"
+	"github.com/hashicorp/hcl/v2"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/mock/gomock"
 
@@ -274,4 +275,109 @@ func TestResolveParameters(t *testing.T) {
 			})
 		}
 	})
+
+	// An incomplete render omits parameters the template still declares, so the
+	// values behind them must survive a start build.
+	// See https://github.com/coder/coder/issues/29099.
+	t.Run("IncompleteRender", func(t *testing.T) {
+		t.Parallel()
+
+		tests := []struct {
+			name     string
+			diags    hcl.Diagnostics
+			previous []database.WorkspaceBuildParameter
+			build    []codersdk.WorkspaceBuildParameter
+			expect   map[string]string
+		}{
+			{
+				// A complete render is authoritative, so the value is still dropped.
+				name: "complete render drops",
+				previous: []database.WorkspaceBuildParameter{
+					{Name: "rendered", Value: "foo"},
+					{Name: "unrendered", Value: "1000Gi"},
+				},
+				expect: map[string]string{"rendered": "foo"},
+			},
+			{
+				name:  "module not loaded preserves previous",
+				diags: hcl.Diagnostics{moduleNotLoadedDiagnostic()},
+				previous: []database.WorkspaceBuildParameter{
+					{Name: "rendered", Value: "foo"},
+					{Name: "unrendered", Value: "1000Gi"},
+				},
+				expect: map[string]string{"rendered": "foo", "unrendered": "1000Gi"},
+			},
+			{
+				// A value supplied with this build is user input too.
+				name:  "module not loaded preserves build value",
+				diags: hcl.Diagnostics{moduleNotLoadedDiagnostic()},
+				build: []codersdk.WorkspaceBuildParameter{
+					{Name: "unrendered", Value: "1000Gi"},
+				},
+				expect: map[string]string{"rendered": "foo", "unrendered": "1000Gi"},
+			},
+			{
+				// Warnings that say nothing about completeness do not preserve.
+				name: "unrelated warning drops",
+				diags: hcl.Diagnostics{{
+					Severity: hcl.DiagWarning,
+					Summary:  "Some other warning",
+				}},
+				previous: []database.WorkspaceBuildParameter{
+					{Name: "rendered", Value: "foo"},
+					{Name: "unrendered", Value: "1000Gi"},
+				},
+				expect: map[string]string{"rendered": "foo"},
+			},
+		}
+
+		for _, tc := range tests {
+			t.Run(tc.name, func(t *testing.T) {
+				t.Parallel()
+
+				ctrl := gomock.NewController(t)
+				render := rendermock.NewMockRenderer(ctrl)
+
+				// "unrendered" is never reported by the render.
+				render.EXPECT().
+					Render(gomock.Any(), gomock.Any(), gomock.Any()).
+					AnyTimes().
+					Return(&preview.Output{
+						Parameters: []previewtypes.Parameter{
+							{
+								ParameterData: previewtypes.ParameterData{
+									Name:         "rendered",
+									Type:         previewtypes.ParameterTypeString,
+									FormType:     provider.ParameterFormTypeInput,
+									Mutable:      true,
+									DefaultValue: previewtypes.StringLiteral("foo"),
+								},
+								Value:       previewtypes.StringLiteral("foo"),
+								Diagnostics: nil,
+							},
+						},
+					}, tc.diags)
+
+				ctx := testutil.Context(t, testutil.WaitShort)
+				values, err := dynamicparameters.ResolveParameters(ctx, uuid.New(), render, false,
+					database.WorkspaceTransitionStart,
+					tc.previous,
+					tc.build,
+					[]database.TemplateVersionPresetParameter{},
+				)
+				require.NoError(t, err)
+				require.Equal(t, tc.expect, values)
+			})
+		}
+	})
+}
+
+// moduleNotLoadedDiagnostic is the warning preview emits when a module block
+// cannot be resolved, which is what a missing module cache looks like.
+func moduleNotLoadedDiagnostic() *hcl.Diagnostic {
+	return previewtypes.DiagnosticCode(&hcl.Diagnostic{
+		Severity: hcl.DiagWarning,
+		Summary:  "Module not loaded. Did you run `terraform init`?",
+		Detail:   "Module 'module \"jetbrains_gateway\"' cannot be resolved. This module will be ignored.",
+	}, previewtypes.DiagnosticModuleNotLoaded)
 }

--- a/coderd/parameters_test.go
+++ b/coderd/parameters_test.go
@@ -452,6 +452,19 @@ func TestDynamicParametersModuleCachePurged(t *testing.T) {
 	stopParams, err := templateAdmin.WorkspaceBuildParameters(ctx, stop.ID)
 	require.NoError(t, err)
 	require.ElementsMatch(t, expected, stopParams, "stop build must not drop the module parameter")
+
+	// Starting again on the same purged version renders an incomplete parameter
+	// set. The stored value is what the provisioner needs to keep the resource
+	// it sizes, so the build must not fall back to the module default.
+	start, err := templateAdmin.CreateWorkspaceBuild(ctx, workspace.ID, codersdk.CreateWorkspaceBuildRequest{
+		Transition: codersdk.WorkspaceTransitionStart,
+	})
+	require.NoError(t, err)
+	coderdtest.AwaitWorkspaceBuildJobCompleted(t, templateAdmin, start.ID)
+
+	restartParams, err := templateAdmin.WorkspaceBuildParameters(ctx, start.ID)
+	require.NoError(t, err)
+	require.ElementsMatch(t, expected, restartParams, "start build must not drop the module parameter")
 }
 
 type setupDynamicParamsTestParams struct {


### PR DESCRIPTION
Closes #29099 ([ENG-3324](https://linear.app/codercom/issue/ENG-3324)). Follow-up to #29102, which stopped the loss propagating through stop builds but left start builds truncating.

## What this does

A render carrying a `module_not_loaded` diagnostic could not see the whole template, so a parameter's absence from it is not evidence the template stopped declaring that parameter. Keep the unmatched values instead of deleting them.

## Why preserve rather than fail

provisionerd resolves modules itself, so only coderd's render is degraded. Keeping the value produces a correct apply and the workspace keeps building. Failing the build would turn silent data loss into an inability to start every workspace on an affected template version.

A complete render is still authoritative and still narrows the set, so unrelated warnings and legitimate parameter removals behave exactly as before.

## Tests

- `TestResolveParameters/IncompleteRender`: complete render drops, `module_not_loaded` preserves previous and build values, unrelated warning drops.
- `TestDynamicParametersModuleCachePurged` now continues into the start build. On `main` it fails with `start build must not drop the module parameter`.

<details>
<summary>Notes for the reviewer</summary>

### Detection

`preview` tags the warning with `types.DiagnosticCode(diag, types.DiagnosticModuleNotLoaded)`, so the check is `previewtypes.ExtractDiagnosticExtra(diag).Code == previewtypes.DiagnosticModuleNotLoaded` over the second render's diagnostics. Adding future completeness codes is a one-line change in `incompleteRender`.

### Departure from the issue's sketch

The issue proposed also gating on `v.Source != sourceDefault`, to keep discarding values that only ever came from a default. That check cannot fire: `sourceDefault` is only assigned to parameters present in the render output, so an unmatched value is never default-sourced. A default stored by an earlier build arrives as `sourcePrevious` and is indistinguishable from user input at this layer. The condition is omitted rather than left in as dead code.

### Not covered

Nothing surfaces the degraded render to the operator. `wsbuilder` has no logger, and `render.go` still discards preview's diagnostics (`Logger: slog.New(slog.DiscardHandler)`). That is the follow-up work listed in the issue.

</details>

---

🤖 Authored by Coder Agents on behalf of @Emyrk.