### PR TITLE
refactor(site/src/pages/AgentsPage): fetch workspace options in `<ChatPageInput />`

### DIFF
--- a/site/src/pages/AgentsPage/AgentChatPage.stories.tsx
+++ b/site/src/pages/AgentsPage/AgentChatPage.stories.tsx
@@ -23,7 +23,7 @@ import {
 	userCompactionThresholdsKey,
 } from "#/api/queries/chats";
 import { preferenceSettingsKey } from "#/api/queries/users";
-import { workspaceByIdKey } from "#/api/queries/workspaces";
+import { workspaceByIdKey, workspacesKey } from "#/api/queries/workspaces";
 import type * as TypesGen from "#/api/typesGenerated";
 import {
 	MockChat,
@@ -354,6 +354,13 @@ const buildQueries = (
 		{
 			key: workspaceByIdKey(mockWorkspace.id),
 			data: mockWorkspace,
+		},
+		{
+			key: workspacesKey({ q: "owner:me", limit: 0 }),
+			data: {
+				workspaces: [mockWorkspace],
+				count: 1,
+			} satisfies TypesGen.WorkspacesResponse,
 		},
 		{
 			key: organizationChatModelsKey(chat.organization_id),

--- a/site/src/pages/AgentsPage/AgentChatPage.tsx
+++ b/site/src/pages/AgentsPage/AgentChatPage.tsx
@@ -44,11 +44,7 @@ import {
 } from "#/api/queries/chats";
 import { deploymentSSHConfig } from "#/api/queries/deployment";
 import { userSkills } from "#/api/queries/userSkills";
-import {
-	workspaceById,
-	workspaceByIdKey,
-	workspaces,
-} from "#/api/queries/workspaces";
+import { workspaceById, workspaceByIdKey } from "#/api/queries/workspaces";
 import type * as TypesGen from "#/api/typesGenerated";
 import { useProxy } from "#/contexts/ProxyContext";
 import { useAuthenticated } from "#/hooks/useAuthenticated";
@@ -103,7 +99,6 @@ import {
 } from "./components/MCPServerPicker";
 import { getModelSelectorHelp } from "./components/ModelSelectorHelp";
 import { useAgentChatPanelPreference } from "./components/RightPanel/useAgentChatPanelPreference";
-import { getWorkspaceOptionsWithLinkedWorkspace } from "./components/workspaceOptions";
 import {
 	BuiltInCommandPendingError,
 	useConversationEditingState,
@@ -227,12 +222,6 @@ const AgentChatPage: FC = () => {
 	const isDefaultChatOrganization = organizations.some(
 		(organization) =>
 			organization.id === chatOrganizationId && organization.is_default,
-	);
-	const workspacesQuery = useQuery(workspaces({ q: "owner:me", limit: 0 }));
-	const workspaceOptions = getWorkspaceOptionsWithLinkedWorkspace(
-		workspacesQuery.data?.workspaces ?? [],
-		workspace,
-		currentUser.id,
 	);
 	const desktopEnabled = experiments.includes("chat-virtual-desktop");
 	const debugLoggingEnabled = Boolean(
@@ -598,9 +587,6 @@ const AgentChatPage: FC = () => {
 		aiGatewayDisabled;
 	const canUpdateChatWorkspace = !isArchived && !isViewerNotOwner;
 	const selectedWorkspaceId = chatQuery.data?.workspace_id ?? null;
-
-	const isWorkspaceLoading =
-		workspacesQuery.isLoading || isUpdateChatWorkspacePending;
 	const handlePlanModeToggle = (enabled: boolean) => {
 		if (enabled === planModeEnabled) {
 			return;
@@ -1161,11 +1147,10 @@ const AgentChatPage: FC = () => {
 					isInputDisabled={isInputDisabled}
 					isSubmissionPending={isSubmissionPending}
 					isInterruptPending={isInterruptPending}
-					workspaceOptions={workspaceOptions}
 					onWorkspaceChange={
 						canUpdateChatWorkspace ? handleWorkspaceChange : undefined
 					}
-					isWorkspaceLoading={isWorkspaceLoading}
+					isWorkspaceLoading={isUpdateChatWorkspacePending}
 					showSidebarPanel={showSidebarPanel}
 					onSetShowSidebarPanel={handleSetShowSidebarPanel}
 					debugLoggingEnabled={debugLoggingEnabled}

--- a/site/src/pages/AgentsPage/AgentChatPageView.stories.tsx
+++ b/site/src/pages/AgentsPage/AgentChatPageView.stories.tsx
@@ -18,6 +18,7 @@ import {
 	userCompactionThresholdsKey,
 } from "#/api/queries/chats";
 import { preferenceSettingsKey } from "#/api/queries/users";
+import { workspacesKey } from "#/api/queries/workspaces";
 import type * as TypesGen from "#/api/typesGenerated";
 import type { ChatDiffStatus, ChatMessagePart } from "#/api/typesGenerated";
 import type { ModelSelectorOption } from "#/modules/aiModels/ModelSelector";
@@ -243,6 +244,13 @@ const meta: Meta<typeof AgentChatPageView> = {
 			{
 				key: userCompactionThresholdsKey,
 				data: MockUserChatCompactionThresholds,
+			},
+			{
+				key: workspacesKey({ q: "owner:me", limit: 0 }),
+				data: {
+					workspaces: [],
+					count: 0,
+				} satisfies TypesGen.WorkspacesResponse,
 			},
 		],
 		reactRouter: reactRouterParameters({
@@ -538,6 +546,13 @@ export const WithParentChat: Story = {
 			{
 				key: userCompactionThresholdsKey,
 				data: MockUserChatCompactionThresholds,
+			},
+			{
+				key: workspacesKey({ q: "owner:me", limit: 0 }),
+				data: {
+					workspaces: [],
+					count: 0,
+				} satisfies TypesGen.WorkspacesResponse,
 			},
 			{
 				key: chatEntityKey("parent-chat-1"),
@@ -952,7 +967,6 @@ export const WorkspaceNoAgent: Story = {
 	render: () => (
 		<StoryAgentChatPageView
 			workspace={MockWorkspace}
-			workspaceOptions={[MockWorkspace]}
 			chat={{ workspace_id: MockWorkspace.id }}
 			onWorkspaceChange={fn()}
 		/>

--- a/site/src/pages/AgentsPage/AgentChatPageView.tsx
+++ b/site/src/pages/AgentsPage/AgentChatPageView.tsx
@@ -145,7 +145,6 @@ interface AgentChatPageViewProps {
 	isInputDisabled: boolean;
 	isSubmissionPending: boolean;
 	isInterruptPending: boolean;
-	workspaceOptions?: readonly TypesGen.Workspace[];
 	onWorkspaceChange?: (workspaceId: string | null) => void;
 	isWorkspaceLoading?: boolean;
 
@@ -310,7 +309,6 @@ export const AgentChatPageView: FC<AgentChatPageViewProps> = ({
 	isInputDisabled,
 	isSubmissionPending,
 	isInterruptPending,
-	workspaceOptions = [],
 	onWorkspaceChange,
 	isWorkspaceLoading = false,
 	showSidebarPanel,
@@ -991,7 +989,6 @@ export const AgentChatPageView: FC<AgentChatPageViewProps> = ({
 									onReasoningEffortChange={onReasoningEffortChange}
 									onPlanModeToggle={onPlanModeToggle}
 									isModelCatalogLoading={isModelCatalogLoading}
-									workspaceOptions={workspaceOptions}
 									onWorkspaceChange={onWorkspaceChange}
 									isWorkspaceLoading={isWorkspaceLoading}
 									inputRef={editing.chatInputRef}

--- a/site/src/pages/AgentsPage/components/ChatPageContent.stories.tsx
+++ b/site/src/pages/AgentsPage/components/ChatPageContent.stories.tsx
@@ -7,13 +7,16 @@ import {
 	userCompactionThresholdsKey,
 } from "#/api/queries/chats";
 import { preferenceSettingsKey } from "#/api/queries/users";
+import { workspacesKey } from "#/api/queries/workspaces";
 import type * as TypesGen from "#/api/typesGenerated";
 import { MockChat, MockChatQueuedMessage } from "#/testHelpers/chatEntities";
 import { MockChatModel } from "#/testHelpers/chatModels";
 import {
 	MockUserChatCompactionThresholds,
+	MockUserOwner,
 	MockUserPreferenceSettings,
 } from "#/testHelpers/entities";
+import { withAuthProvider } from "#/testHelpers/storybook";
 import { ChatWorkspaceContext } from "../context/ChatWorkspaceContext";
 import { createChatStore } from "./ChatConversation/chatStore";
 import { FIXTURE_NOW } from "./ChatConversation/storyFixtures";
@@ -39,7 +42,9 @@ const StoryChatPageTimeline: FC<{
 
 const meta = {
 	title: "pages/AgentsPage/ChatPageContent",
+	decorators: [withAuthProvider],
 	parameters: {
+		user: MockUserOwner,
 		queries: [
 			{
 				key: preferenceSettingsKey,
@@ -48,6 +53,13 @@ const meta = {
 			{
 				key: userCompactionThresholdsKey,
 				data: MockUserChatCompactionThresholds,
+			},
+			{
+				key: workspacesKey({ q: "owner:me", limit: 0 }),
+				data: {
+					workspaces: [],
+					count: 0,
+				} satisfies TypesGen.WorkspacesResponse,
 			},
 		],
 	},
@@ -109,8 +121,6 @@ const StoryChatPageInput: FC<{
 			canConfigureAgentSetup={false}
 			isEditing={false}
 			onCancelHistoryEdit={fn()}
-			workspaceOptions={[]}
-			isWorkspaceLoading={false}
 		/>
 	</div>
 );
@@ -410,8 +420,6 @@ const CompactionChatPageInput: FC = () => {
 				canConfigureAgentSetup={false}
 				isEditing={false}
 				onCancelHistoryEdit={fn()}
-				workspaceOptions={[]}
-				isWorkspaceLoading={false}
 			/>
 		</div>
 	);
@@ -440,6 +448,13 @@ export const CompactsAtUserOverride: Story = {
 				key: chatPromptsKey(MockChat.id),
 				data: { prompts: [] } satisfies TypesGen.ChatPromptsResponse,
 			},
+			{
+				key: workspacesKey({ q: "owner:me", limit: 0 }),
+				data: {
+					workspaces: [],
+					count: 0,
+				} satisfies TypesGen.WorkspacesResponse,
+			},
 		],
 	},
 	render: () => <CompactionChatPageInput />,
@@ -467,6 +482,13 @@ export const CompactsAtHistoricalModelDefault: Story = {
 			{
 				key: chatPromptsKey(MockChat.id),
 				data: { prompts: [] } satisfies TypesGen.ChatPromptsResponse,
+			},
+			{
+				key: workspacesKey({ q: "owner:me", limit: 0 }),
+				data: {
+					workspaces: [],
+					count: 0,
+				} satisfies TypesGen.WorkspacesResponse,
 			},
 		],
 	},

--- a/site/src/pages/AgentsPage/components/ChatPageContent.tsx
+++ b/site/src/pages/AgentsPage/components/ChatPageContent.tsx
@@ -8,7 +8,9 @@ import {
 	refreshChatContext,
 	userCompactionThresholds,
 } from "#/api/queries/chats";
+import { workspaces } from "#/api/queries/workspaces";
 import type * as TypesGen from "#/api/typesGenerated";
+import { useAuthenticated } from "#/hooks/useAuthenticated";
 import type { ModelSelectorOption } from "#/modules/aiModels/ModelSelector";
 import { useChatDraftAttachments } from "../hooks/useChatDraftAttachments";
 import { chatWidthClass, useChatFullWidth } from "../hooks/useChatFullWidth";
@@ -58,6 +60,7 @@ import { buildStreamTools } from "./ChatConversation/streamState";
 import { useOnRenderProfiler } from "./ChatConversation/useOnRenderProfiler";
 import type { SkillMetadata } from "./ChatMessageInput/SkillsTriggerMenu";
 import { ChatMessageScroller } from "./ChatMessageScroller";
+import { getWorkspaceOptionsWithLinkedWorkspace } from "./workspaceOptions";
 
 type ChatStoreHandle = ReturnType<typeof useChatStore>["store"];
 
@@ -293,9 +296,8 @@ interface ChatPageInputProps {
 	selectedMCPServerIds?: readonly string[];
 	onMCPSelectionChange?: (ids: string[]) => void;
 	onMCPAuthComplete?: (serverId: string) => void;
-	workspaceOptions: readonly TypesGen.Workspace[];
 	onWorkspaceChange?: (workspaceId: string | null) => void;
-	isWorkspaceLoading: boolean;
+	isWorkspaceLoading?: boolean;
 	workspace?: TypesGen.Workspace;
 	workspaceAgent?: TypesGen.WorkspaceAgent;
 	sshCommand?: string;
@@ -341,21 +343,27 @@ export const ChatPageInput: FC<ChatPageInputProps> = ({
 	selectedMCPServerIds,
 	onMCPSelectionChange,
 	onMCPAuthComplete,
-	workspaceOptions,
 	onWorkspaceChange,
-	isWorkspaceLoading,
+	isWorkspaceLoading = false,
 	workspace,
 	workspaceAgent,
 	sshCommand,
 	attachedWorkspace,
 	folder,
 }) => {
+	const { user: currentUser } = useAuthenticated();
 	const organizationId = chat.organization_id;
 	const chatId = chat.id;
 	const chatContext = chat.context;
 	const planModeEnabled = chat.plan_mode === "plan";
 	const selectedWorkspaceId = chat.workspace_id ?? null;
 	const workspaceSkills = workspaceSkillsFromChat(chat);
+	const workspacesQuery = useQuery(workspaces({ q: "owner:me", limit: 0 }));
+	const workspaceOptions = getWorkspaceOptionsWithLinkedWorkspace(
+		workspacesQuery.data?.workspaces ?? [],
+		workspace,
+		currentUser.id,
+	);
 	const thresholdsQuery = useQuery(userCompactionThresholds());
 	const compressionThreshold = resolveCompactionThreshold(
 		chat.last_model_config_id,
@@ -590,7 +598,7 @@ export const ChatPageInput: FC<ChatPageInputProps> = ({
 			chatOrganizationId={organizationId}
 			selectedWorkspaceId={selectedWorkspaceId}
 			onWorkspaceChange={onWorkspaceChange}
-			isWorkspaceLoading={isWorkspaceLoading}
+			isWorkspaceLoading={workspacesQuery.isLoading || isWorkspaceLoading}
 			mcpServers={mcpServers}
 			selectedMCPServerIds={selectedMCPServerIds}
 			onMCPSelectionChange={onMCPSelectionChange}


### PR DESCRIPTION
Stop drilling `workspaceOptions` from the chat page into the composer. `ChatPageInput` now loads the owner-me workspace list and merges in the linked workspace, so the page only passes `onWorkspaceChange` and mutation-pending.

- Drop `workspaceOptions` from `AgentChatPage` and `AgentChatPageView`.
- Seed `workspacesKey({ q: "owner:me", limit: 0 })` in chat stories instead of passing the list as a prop.
- Leave create-chat alone; `AgentCreateForm` still owns that list.
