### PR TITLE
feat(site): share org in personal agent model settings

### DIFF
--- a/site/src/api/queries/chats.ts
+++ b/site/src/api/queries/chats.ts
@@ -2136,23 +2136,30 @@ export const userChatPersonalModelOverrides = (
 });
 
 type UpdateUserChatPersonalModelOverrideArgs = {
+	organizationId: string;
 	context: TypesGen.ChatPersonalModelOverrideContext;
 	req: TypesGen.UpdateUserChatPersonalModelOverrideRequest;
 };
 
 export const updateUserChatPersonalModelOverride = (
 	queryClient: QueryClient,
-	organizationId: string,
 	user = "me",
 ) => ({
-	mutationFn: ({ context, req }: UpdateUserChatPersonalModelOverrideArgs) =>
+	mutationFn: ({
+		organizationId,
+		context,
+		req,
+	}: UpdateUserChatPersonalModelOverrideArgs) =>
 		API.experimental.updateUserChatPersonalModelOverride(
 			organizationId,
 			user,
 			context,
 			req,
 		),
-	onSuccess: async () => {
+	onSuccess: async (
+		_data: unknown,
+		{ organizationId }: UpdateUserChatPersonalModelOverrideArgs,
+	) => {
 		await queryClient.invalidateQueries({
 			queryKey: userChatPersonalModelOverridesKey(organizationId, user),
 		});

--- a/site/src/modules/aiModels/ModelSelector.tsx
+++ b/site/src/modules/aiModels/ModelSelector.tsx
@@ -163,12 +163,18 @@ export const ModelSelector: FC<ModelSelectorProps> = ({
 					type="button"
 					variant="subtle"
 					className={cn(
-						"h-7 min-w-0 shrink justify-start gap-1 rounded-full border-0 bg-surface-secondary px-2 py-0.5 text-xs font-medium shadow-none transition-colors hover:bg-surface-tertiary hover:text-content-primary focus:ring-0 focus-visible:ring-2 focus-visible:ring-content-link [&>svg]:size-3.5! [&>svg]:p-0 [&>svg]:shrink-0 [&>svg]:transition hover:[&>svg]:text-content-primary [&>img]:size-3! [&>img]:p-0!",
+						"h-7 min-w-0 shrink justify-start gap-1",
+						"rounded-full border-0 bg-surface-secondary",
+						"px-2 py-0.5 text-xs font-medium shadow-none transition-colors",
+						"hover:bg-surface-tertiary hover:text-content-primary",
+						"focus:ring-0 focus-visible:ring-2 focus-visible:ring-content-link",
+						"[&>svg]:p-0 [&>svg]:shrink-0 [&>svg]:transition",
+						"hover:[&>svg]:text-content-primary [&>img]:size-3! [&>img]:p-0!",
 						className,
 					)}
 					onTouchStart={onTriggerTouchStart}
 				>
-					<span className="flex min-w-0 items-center gap-1">
+					<span className="flex min-w-0 items-center gap-2.5">
 						{selectedModel && (
 							<span
 								className="flex shrink-0 items-center"
@@ -177,13 +183,15 @@ export const ModelSelector: FC<ModelSelectorProps> = ({
 								<ProviderIcon
 									provider={selectedModel.provider}
 									icon={selectedModel.providerIcon}
-									className="size-3 shrink-0"
+									className="size-icon-sm shrink-0"
 								/>
 							</span>
 						)}
-						<span className="truncate">{triggerLabel}</span>
+						<span className="truncate flex-1">{triggerLabel}</span>
 					</span>
-					<ChevronDownIcon open={open} />
+					<span className="flex shrink-0 items-center">
+						<ChevronDownIcon open={open} className="size-icon-sm" />
+					</span>
 				</Button>
 			</PopoverTrigger>
 			<PopoverContent

--- a/site/src/pages/AgentsPage/AgentSettingsUserAgentsPage.tsx
+++ b/site/src/pages/AgentsPage/AgentSettingsUserAgentsPage.tsx
@@ -15,17 +15,22 @@ import type {
 import { getOrganizationLabel } from "#/components/OrganizationAutocomplete/OrganizationAutocomplete";
 import { useDashboard } from "#/modules/dashboard/useDashboard";
 import { AgentSettingsUserAgentsPageView } from "./AgentSettingsUserAgentsPageView";
-import { PERSONAL_OVERRIDE_COPY } from "./components/PersonalModelOverrideRow";
 import { resolveModelSelector } from "./utils/modelOptions";
 
 const organizationSearchParam = "org";
+
+const overrideSaveLabel = {
+	root: "Root agent model",
+	general: "General subagent model",
+	explore: "Explore subagent model",
+} as const satisfies Record<ChatPersonalModelOverrideContext, string>;
 
 const overrideSaveToast = (
 	organizations: readonly Organization[],
 	organizationId: string,
 	context: ChatPersonalModelOverrideContext,
 ): { success: string; error: string } => {
-	const label = PERSONAL_OVERRIDE_COPY[context].title;
+	const label = overrideSaveLabel[context];
 	const organization =
 		organizations.length > 1
 			? organizations.find((org) => org.id === organizationId)

--- a/site/src/pages/AgentsPage/AgentSettingsUserAgentsPage.tsx
+++ b/site/src/pages/AgentsPage/AgentSettingsUserAgentsPage.tsx
@@ -1,139 +1,107 @@
-import { type FC, useState } from "react";
+import type { FC } from "react";
 import { useMutation, useQuery, useQueryClient } from "react-query";
+import { useSearchParams } from "react-router";
+import { toast } from "sonner";
+import { getErrorDetail, getErrorMessage } from "#/api/errors";
 import {
 	chatModels,
 	updateUserChatPersonalModelOverride,
 	userChatPersonalModelOverrides,
 } from "#/api/queries/chats";
 import type * as TypesGen from "#/api/typesGenerated";
-import {
-	getDefaultOrganizationId,
-	useDashboard,
-} from "#/modules/dashboard/useDashboard";
+import { useDashboard } from "#/modules/dashboard/useDashboard";
 import { AgentSettingsUserAgentsPageView } from "./AgentSettingsUserAgentsPageView";
 import { resolveModelSelector } from "./utils/modelOptions";
 
+const organizationSearchParam = "org";
+
+const overrideSaveToast = {
+	root: {
+		success: "Root agent model saved.",
+		error: "Failed to save root agent model.",
+	},
+	general: {
+		success: "General subagent model saved.",
+		error: "Failed to save general subagent model.",
+	},
+	explore: {
+		success: "Explore subagent model saved.",
+		error: "Failed to save Explore subagent model.",
+	},
+} as const satisfies Record<
+	TypesGen.ChatPersonalModelOverrideContext,
+	{ success: string; error: string }
+>;
+
 const AgentSettingsUserAgentsPage: FC = () => {
 	const { organizations } = useDashboard();
-	const defaultOrganizationId = getDefaultOrganizationId(organizations);
-	const [selectedOrganizationId, setSelectedOrganizationId] = useState(
-		defaultOrganizationId,
-	);
+	const [searchParams, setSearchParams] = useSearchParams();
 	const selectedOrganization =
 		organizations.find(
-			(organization) => organization.id === selectedOrganizationId,
+			(organization) =>
+				organization.name === searchParams.get(organizationSearchParam),
 		) ??
-		organizations.find(
-			(organization) => organization.id === defaultOrganizationId,
-		) ??
+		organizations.find((organization) => organization.is_default) ??
 		organizations[0];
 	const organizationId = selectedOrganization?.id ?? "";
-	// Remount on organization change so mutation state (pending saves,
-	// errors) from one organization never renders on another's form.
-	return (
-		<AgentSettingsUserAgentsPageContent
-			key={organizationId}
-			organizations={organizations}
-			selectedOrganization={selectedOrganization}
-			organizationId={organizationId}
-			onSelectOrganization={(organization) =>
-				setSelectedOrganizationId(organization.id)
-			}
-		/>
-	);
-};
-
-interface AgentSettingsUserAgentsPageContentProps {
-	organizations: readonly TypesGen.Organization[];
-	selectedOrganization: TypesGen.Organization | undefined;
-	organizationId: string;
-	onSelectOrganization: (organization: TypesGen.Organization) => void;
-}
-
-const AgentSettingsUserAgentsPageContent: FC<
-	AgentSettingsUserAgentsPageContentProps
-> = ({
-	organizations,
-	selectedOrganization,
-	organizationId,
-	onSelectOrganization,
-}) => {
 	const queryClient = useQueryClient();
+
 	const overridesQuery = useQuery(
 		userChatPersonalModelOverrides(organizationId),
 	);
 	const modelsQuery = useQuery(chatModels(organizationId));
-	const saveRootModelOverrideMutation = useMutation(
-		updateUserChatPersonalModelOverride(queryClient, organizationId),
-	);
-	const saveGeneralModelOverrideMutation = useMutation(
-		updateUserChatPersonalModelOverride(queryClient, organizationId),
-	);
-	const saveExploreModelOverrideMutation = useMutation(
-		updateUserChatPersonalModelOverride(queryClient, organizationId),
-	);
 
-	const organizationModelConfigs = modelsQuery.data?.models ?? [];
+	const saveOverrideOptions = updateUserChatPersonalModelOverride(queryClient);
+	const saveOverride = useMutation({
+		...saveOverrideOptions,
+		onSuccess: async (data, variables) => {
+			await saveOverrideOptions.onSuccess?.(data, variables);
+			toast.success(overrideSaveToast[variables.context].success);
+		},
+		onError: (error, variables) => {
+			toast.error(
+				getErrorMessage(error, overrideSaveToast[variables.context].error),
+				{
+					description: getErrorDetail(error),
+				},
+			);
+		},
+	});
 
 	const { options: modelOptions, isModelCatalogLoading } = resolveModelSelector(
 		organizationId,
 		modelsQuery,
 	);
-	const hasNoOrganizationModels =
-		organizationId !== "" &&
-		!modelsQuery.isLoading &&
-		modelsQuery.error === null &&
-		modelsQuery.data !== undefined &&
-		modelOptions.length === 0;
-
-	const saveModelOverride = (
-		context: TypesGen.ChatPersonalModelOverrideContext,
-		mutation: typeof saveRootModelOverrideMutation,
-	) => {
-		return (
-			req: TypesGen.UpdateUserChatPersonalModelOverrideRequest,
-			options?: { onSuccess?: () => void; onError?: () => void },
-		) => {
-			mutation.mutate({ context, req }, options);
-		};
-	};
+	const saveMatchesOrganization =
+		saveOverride.variables?.organizationId === organizationId;
 
 	return (
 		<AgentSettingsUserAgentsPageView
+			key={organizationId}
 			overridesData={overridesQuery.data}
 			overridesError={overridesQuery.error}
 			onRetryOverrides={() => {
 				void overridesQuery.refetch();
 			}}
 			isRetryingOverrides={overridesQuery.isFetching}
-			isLoadingOverrides={overridesQuery.isLoading}
+			isLoading={overridesQuery.isLoading || isModelCatalogLoading}
 			modelOptions={modelOptions}
 			organizations={organizations}
 			selectedOrganization={selectedOrganization}
-			onSelectOrganization={onSelectOrganization}
-			models={organizationModelConfigs}
+			onSelectOrganization={(organization) => {
+				setSearchParams((params) => {
+					const next = new URLSearchParams(params);
+					next.set(organizationSearchParam, organization.name);
+					return next;
+				});
+			}}
+			models={modelsQuery.data?.models ?? []}
 			modelsError={modelsQuery.error}
-			isLoadingModels={isModelCatalogLoading}
-			isOrganizationUnresolved={organizationId === ""}
-			hasNoOrganizationModels={hasNoOrganizationModels}
-			onSaveRootModelOverride={saveModelOverride(
-				"root",
-				saveRootModelOverrideMutation,
-			)}
-			isSavingRootModelOverride={saveRootModelOverrideMutation.isPending}
-			isSaveRootModelOverrideError={saveRootModelOverrideMutation.isError}
-			onSaveGeneralModelOverride={saveModelOverride(
-				"general",
-				saveGeneralModelOverrideMutation,
-			)}
-			isSavingGeneralModelOverride={saveGeneralModelOverrideMutation.isPending}
-			isSaveGeneralModelOverrideError={saveGeneralModelOverrideMutation.isError}
-			onSaveExploreModelOverride={saveModelOverride(
-				"explore",
-				saveExploreModelOverrideMutation,
-			)}
-			isSavingExploreModelOverride={saveExploreModelOverrideMutation.isPending}
-			isSaveExploreModelOverrideError={saveExploreModelOverrideMutation.isError}
+			onSaveOverride={saveOverride.mutate}
+			isSaving={saveOverride.isPending && saveMatchesOrganization}
+			saveContext={
+				saveMatchesOrganization ? saveOverride.variables?.context : undefined
+			}
 		/>
 	);
 };

--- a/site/src/pages/AgentsPage/AgentSettingsUserAgentsPage.tsx
+++ b/site/src/pages/AgentsPage/AgentSettingsUserAgentsPage.tsx
@@ -8,30 +8,40 @@ import {
 	updateUserChatPersonalModelOverride,
 	userChatPersonalModelOverrides,
 } from "#/api/queries/chats";
-import type * as TypesGen from "#/api/typesGenerated";
+import type {
+	ChatPersonalModelOverrideContext,
+	Organization,
+} from "#/api/typesGenerated";
+import { getOrganizationLabel } from "#/components/OrganizationAutocomplete/OrganizationAutocomplete";
 import { useDashboard } from "#/modules/dashboard/useDashboard";
 import { AgentSettingsUserAgentsPageView } from "./AgentSettingsUserAgentsPageView";
+import { PERSONAL_OVERRIDE_COPY } from "./components/PersonalModelOverrideRow";
 import { resolveModelSelector } from "./utils/modelOptions";
 
 const organizationSearchParam = "org";
 
-const overrideSaveToast = {
-	root: {
-		success: "Root agent model saved.",
-		error: "Failed to save root agent model.",
-	},
-	general: {
-		success: "General subagent model saved.",
-		error: "Failed to save general subagent model.",
-	},
-	explore: {
-		success: "Explore subagent model saved.",
-		error: "Failed to save Explore subagent model.",
-	},
-} as const satisfies Record<
-	TypesGen.ChatPersonalModelOverrideContext,
-	{ success: string; error: string }
->;
+const overrideSaveToast = (
+	organizations: readonly Organization[],
+	organizationId: string,
+	context: ChatPersonalModelOverrideContext,
+): { success: string; error: string } => {
+	const label = PERSONAL_OVERRIDE_COPY[context].title;
+	const organization =
+		organizations.length > 1
+			? organizations.find((org) => org.id === organizationId)
+			: undefined;
+	if (!organization) {
+		return {
+			success: `${label} saved successfully.`,
+			error: `Failed to save ${label}.`,
+		};
+	}
+	const organizationLabel = getOrganizationLabel(organization, organizations);
+	return {
+		success: `${label} for "${organizationLabel}" saved successfully.`,
+		error: `Failed to save ${label} for "${organizationLabel}".`,
+	};
+};
 
 const AgentSettingsUserAgentsPage: FC = () => {
 	const { organizations } = useDashboard();
@@ -56,11 +66,24 @@ const AgentSettingsUserAgentsPage: FC = () => {
 		...saveOverrideOptions,
 		onSuccess: async (data, variables) => {
 			await saveOverrideOptions.onSuccess?.(data, variables);
-			toast.success(overrideSaveToast[variables.context].success);
+			toast.success(
+				overrideSaveToast(
+					organizations,
+					variables.organizationId,
+					variables.context,
+				).success,
+			);
 		},
 		onError: (error, variables) => {
 			toast.error(
-				getErrorMessage(error, overrideSaveToast[variables.context].error),
+				getErrorMessage(
+					error,
+					overrideSaveToast(
+						organizations,
+						variables.organizationId,
+						variables.context,
+					).error,
+				),
 				{
 					description: getErrorDetail(error),
 				},

--- a/site/src/pages/AgentsPage/AgentSettingsUserAgentsPageView.stories.tsx
+++ b/site/src/pages/AgentsPage/AgentSettingsUserAgentsPageView.stories.tsx
@@ -172,25 +172,15 @@ const buildArgs = (
 	overridesError: undefined,
 	onRetryOverrides: fn(),
 	isRetryingOverrides: false,
-	isLoadingOverrides: false,
+	isLoading: false,
 	modelOptions,
 	models,
 	modelsError: undefined,
-	isLoadingModels: false,
 	organizations: [MockDefaultOrganization],
 	selectedOrganization: MockDefaultOrganization,
 	onSelectOrganization: fn(),
-	isOrganizationUnresolved: false,
-	hasNoOrganizationModels: false,
-	onSaveRootModelOverride: fn(),
-	isSavingRootModelOverride: false,
-	isSaveRootModelOverrideError: false,
-	onSaveGeneralModelOverride: fn(),
-	isSavingGeneralModelOverride: false,
-	isSaveGeneralModelOverrideError: false,
-	onSaveExploreModelOverride: fn(),
-	isSavingExploreModelOverride: false,
-	isSaveExploreModelOverrideError: false,
+	onSaveOverride: fn(),
+	isSaving: false,
 	...overrides,
 });
 
@@ -336,8 +326,12 @@ export const EnabledWithSavedValues: Story = {
 		});
 		await userEvent.click(rootSaveButton);
 		await waitFor(() => {
-			expect(args.onSaveRootModelOverride).toHaveBeenCalledWith(
-				{ mode: "model", model_config_id: claudeModelConfig.id },
+			expect(args.onSaveOverride).toHaveBeenCalledWith(
+				{
+					organizationId: MockDefaultOrganization.id,
+					context: "root",
+					req: { mode: "model", model_config_id: claudeModelConfig.id },
+				},
 				expect.anything(),
 			);
 		});
@@ -357,8 +351,12 @@ export const EnabledWithSavedValues: Story = {
 		);
 
 		await waitFor(() => {
-			expect(args.onSaveGeneralModelOverride).toHaveBeenCalledWith(
-				{ mode: "chat_default", model_config_id: "" },
+			expect(args.onSaveOverride).toHaveBeenCalledWith(
+				{
+					organizationId: MockDefaultOrganization.id,
+					context: "general",
+					req: { mode: "chat_default", model_config_id: "" },
+				},
 				expect.anything(),
 			);
 		});
@@ -431,11 +429,15 @@ export const SavedReasoningModel: Story = {
 			within(rootSection).getByRole("button", { name: "Save" }),
 		);
 		await waitFor(() => {
-			expect(args.onSaveRootModelOverride).toHaveBeenCalledWith(
+			expect(args.onSaveOverride).toHaveBeenCalledWith(
 				{
-					mode: "model",
-					model_config_id: reasoningModelConfig.id,
-					reasoning_effort: "high",
+					organizationId: MockDefaultOrganization.id,
+					context: "root",
+					req: {
+						mode: "model",
+						model_config_id: reasoningModelConfig.id,
+						reasoning_effort: "high",
+					},
 				},
 				expect.anything(),
 			);
@@ -575,9 +577,8 @@ export const ModelsError: Story = {
 export const LoadingState: Story = {
 	args: buildArgs({
 		overridesData: undefined,
-		isLoadingOverrides: true,
+		isLoading: true,
 		modelOptions: [],
-		isLoadingModels: true,
 	}),
 	play: async ({ canvasElement }) => {
 		const rootSection = await getSection(canvasElement, "Root agent model");
@@ -652,26 +653,8 @@ export const SwitchOrganizations: Story = {
 	},
 };
 
-export const SaveErrorState: Story = {
-	args: buildArgs({
-		isSaveGeneralModelOverrideError: true,
-	}),
-	play: async ({ canvasElement }) => {
-		const generalSection = await getSection(
-			canvasElement,
-			"General subagent model",
-		);
-		expect(
-			within(generalSection).getByText(
-				"Failed to save general subagent model override.",
-			),
-		).toBeInTheDocument();
-	},
-};
-
 export const NoAvailableOrganizationModels: Story = {
 	args: buildArgs({
-		hasNoOrganizationModels: true,
 		modelOptions: [],
 		models: [disabledModelConfig],
 		overridesData: buildOverridesResponse({
@@ -703,8 +686,12 @@ export const NoAvailableOrganizationModels: Story = {
 		await waitFor(() => expect(save).toBeEnabled());
 		await userEvent.click(save);
 		await waitFor(() => {
-			expect(args.onSaveRootModelOverride).toHaveBeenCalledWith(
-				{ mode: "chat_default", model_config_id: "" },
+			expect(args.onSaveOverride).toHaveBeenCalledWith(
+				{
+					organizationId: MockDefaultOrganization.id,
+					context: "root",
+					req: { mode: "chat_default", model_config_id: "" },
+				},
 				expect.anything(),
 			);
 		});
@@ -713,7 +700,7 @@ export const NoAvailableOrganizationModels: Story = {
 
 export const DefaultOrganizationUnresolved: Story = {
 	args: buildArgs({
-		isOrganizationUnresolved: true,
+		selectedOrganization: undefined,
 		modelOptions: [],
 		models: [],
 	}),
@@ -790,8 +777,12 @@ export const InvalidRootDeploymentDefault: Story = {
 			within(rootSection).getByRole("button", { name: "Save" }),
 		);
 		await waitFor(() => {
-			expect(args.onSaveRootModelOverride).toHaveBeenCalledWith(
-				{ mode: "chat_default", model_config_id: "" },
+			expect(args.onSaveOverride).toHaveBeenCalledWith(
+				{
+					organizationId: MockDefaultOrganization.id,
+					context: "root",
+					req: { mode: "chat_default", model_config_id: "" },
+				},
 				expect.anything(),
 			);
 		});

--- a/site/src/pages/AgentsPage/AgentSettingsUserAgentsPageView.stories.tsx
+++ b/site/src/pages/AgentsPage/AgentSettingsUserAgentsPageView.stories.tsx
@@ -656,7 +656,7 @@ export const SwitchOrganizations: Story = {
 export const NoAvailableOrganizationModels: Story = {
 	args: buildArgs({
 		modelOptions: [],
-		models: [disabledModelConfig],
+		models: [],
 		overridesData: buildOverridesResponse({
 			root: buildOverride("root", {
 				mode: "model",
@@ -665,53 +665,67 @@ export const NoAvailableOrganizationModels: Story = {
 			}),
 		}),
 	}),
-	play: async ({ args, canvasElement }) => {
+	play: async ({ canvasElement }) => {
 		const canvas = within(canvasElement);
 		expect(
 			canvas.getByText(/selected organization has no available chat models/i),
 		).toBeInTheDocument();
-		// A stale saved model override must remain replaceable with the
-		// model-free default modes even though no model can be selected.
 		const rootSection = await getSection(canvasElement, "Root agent model");
-		await userEvent.click(
+		const generalSection = await getSection(
+			canvasElement,
+			"General subagent model",
+		);
+		expect(
 			within(rootSection).getByRole("combobox", {
 				name: /^Root agent model behavior/,
 			}),
-		);
-		const body = within(canvasElement.ownerDocument.body);
-		await userEvent.click(
-			await body.findByRole("option", { name: /Chat default/i }),
-		);
-		const save = within(rootSection).getByRole("button", { name: "Save" });
-		await waitFor(() => expect(save).toBeEnabled());
-		await userEvent.click(save);
-		await waitFor(() => {
-			expect(args.onSaveOverride).toHaveBeenCalledWith(
-				{
-					organizationId: MockDefaultOrganization.id,
-					context: "root",
-					req: { mode: "chat_default", model_config_id: "" },
-				},
-				expect.anything(),
-			);
-		});
+		).toBeDisabled();
+		expect(
+			within(rootSection).getByRole("button", { name: "Save" }),
+		).toBeDisabled();
+		expect(
+			within(generalSection).getByRole("combobox", {
+				name: /^General subagent model behavior/,
+			}),
+		).toBeDisabled();
+		expect(
+			within(generalSection).getByRole("button", { name: "Save" }),
+		).toBeDisabled();
 	},
 };
 
 export const DefaultOrganizationUnresolved: Story = {
 	args: buildArgs({
 		selectedOrganization: undefined,
+		organizations: [],
 		modelOptions: [],
 		models: [],
 	}),
 	play: async ({ canvasElement }) => {
 		const canvas = within(canvasElement);
 		expect(
-			canvas.getByText(/organization is not available/i),
+			canvas.getByText(/do not have access to any organizations/i),
 		).toBeInTheDocument();
 		const rootSection = await getSection(canvasElement, "Root agent model");
+		const generalSection = await getSection(
+			canvasElement,
+			"General subagent model",
+		);
+		expect(
+			within(rootSection).getByRole("combobox", {
+				name: /^Root agent model behavior/,
+			}),
+		).toBeDisabled();
 		expect(
 			within(rootSection).getByRole("button", { name: "Save" }),
+		).toBeDisabled();
+		expect(
+			within(generalSection).getByRole("combobox", {
+				name: /^General subagent model behavior/,
+			}),
+		).toBeDisabled();
+		expect(
+			within(generalSection).getByRole("button", { name: "Save" }),
 		).toBeDisabled();
 	},
 };
@@ -735,6 +749,10 @@ export const AdminDisabledReadOnly: Story = {
 			),
 		).toBeInTheDocument();
 		const rootSection = await getSection(canvasElement, "Root agent model");
+		const generalSection = await getSection(
+			canvasElement,
+			"General subagent model",
+		);
 		expect(
 			within(rootSection).getByRole("combobox", {
 				name: "Root agent model behavior, GPT 4.1 Mini",
@@ -742,6 +760,14 @@ export const AdminDisabledReadOnly: Story = {
 		).toBeDisabled();
 		expect(
 			within(rootSection).getByRole("button", { name: "Save" }),
+		).toBeDisabled();
+		expect(
+			within(generalSection).getByRole("combobox", {
+				name: /^General subagent model behavior/,
+			}),
+		).toBeDisabled();
+		expect(
+			within(generalSection).getByRole("button", { name: "Save" }),
 		).toBeDisabled();
 	},
 };

--- a/site/src/pages/AgentsPage/AgentSettingsUserAgentsPageView.tsx
+++ b/site/src/pages/AgentsPage/AgentSettingsUserAgentsPageView.tsx
@@ -63,11 +63,11 @@ export const AgentSettingsUserAgentsPageView: FC<
 		!modelsError &&
 		modelOptions.length === 0;
 
-	// Rows stay enabled when the organization has no models so the model-free
-	// default modes can still replace a stale saved model override; mode
-	// "model" cannot be saved without a valid model anyway.
 	const isDisabled =
-		isLoading || !personalOverridesEnabled || !selectedOrganization;
+		isLoading ||
+		!personalOverridesEnabled ||
+		!selectedOrganization ||
+		hasNoOrganizationModels;
 
 	return (
 		<div className="flex flex-col gap-8">
@@ -89,7 +89,7 @@ export const AgentSettingsUserAgentsPageView: FC<
 					}}
 				/>
 			)}
-			{overridesError ? (
+			{Boolean(overridesError) && (
 				<div className="flex flex-col gap-2">
 					<ErrorAlert error={overridesError} />
 					<Button
@@ -102,7 +102,7 @@ export const AgentSettingsUserAgentsPageView: FC<
 						Retry
 					</Button>
 				</div>
-			) : null}
+			)}
 			{!personalOverridesEnabled && (
 				<Alert severity="info">
 					<AlertDescription>
@@ -114,17 +114,17 @@ export const AgentSettingsUserAgentsPageView: FC<
 			{!selectedOrganization && (
 				<Alert severity="info">
 					<AlertDescription>
-						An organization is not available. Personal model overrides cannot be
-						changed.
+						You do not have access to any organizations. Personal model
+						overrides cannot be changed.
 					</AlertDescription>
 				</Alert>
 			)}
 			{hasNoOrganizationModels && (
 				<Alert severity="info">
 					<AlertDescription>
-						The selected organization has no available chat models. Default
-						options can still be saved. Ask an organization administrator to add
-						and enable a model before you choose a specific model.
+						The selected organization has no available chat models. Ask an
+						organization administrator to add and enable a model before you
+						choose a specific model.
 					</AlertDescription>
 				</Alert>
 			)}

--- a/site/src/pages/AgentsPage/AgentSettingsUserAgentsPageView.tsx
+++ b/site/src/pages/AgentsPage/AgentSettingsUserAgentsPageView.tsx
@@ -8,37 +8,35 @@ import {
 	OrganizationAutocomplete,
 } from "#/components/OrganizationAutocomplete/OrganizationAutocomplete";
 import type { ModelSelectorOption } from "#/modules/aiModels/ModelSelector";
-import {
-	PersonalModelOverrideRow,
-	type SavePersonalOverride,
-} from "./components/PersonalModelOverrideRow";
+import { PersonalModelOverrideRow } from "./components/PersonalModelOverrideRow";
 import { SectionHeader } from "./components/SectionHeader";
 
 export interface AgentSettingsUserAgentsPageViewProps {
 	overridesData?: TypesGen.UserChatPersonalModelOverridesResponse;
 	overridesError: unknown;
-	onRetryOverrides?: () => void;
-	isRetryingOverrides?: boolean;
-	isLoadingOverrides: boolean;
+	onRetryOverrides: () => void;
+	isRetryingOverrides: boolean;
+	isLoading: boolean;
 	modelOptions: readonly ModelSelectorOption[];
 	models: readonly TypesGen.ChatModel[];
 	modelsError: unknown;
-	isLoadingModels: boolean;
 	organizations: readonly TypesGen.Organization[];
 	selectedOrganization: TypesGen.Organization | undefined;
 	onSelectOrganization: (organization: TypesGen.Organization) => void;
-	isOrganizationUnresolved: boolean;
-	hasNoOrganizationModels: boolean;
-	onSaveRootModelOverride: SavePersonalOverride;
-	isSavingRootModelOverride: boolean;
-	isSaveRootModelOverrideError: boolean;
-	onSaveGeneralModelOverride: SavePersonalOverride;
-	isSavingGeneralModelOverride: boolean;
-	isSaveGeneralModelOverrideError: boolean;
-	onSaveExploreModelOverride: SavePersonalOverride;
-	isSavingExploreModelOverride: boolean;
-	isSaveExploreModelOverrideError: boolean;
+	onSaveOverride: (
+		args: {
+			organizationId: string;
+			context: TypesGen.ChatPersonalModelOverrideContext;
+			req: TypesGen.UpdateUserChatPersonalModelOverrideRequest;
+		},
+		options?: { onSuccess?: () => void; onError?: () => void },
+	) => void;
+	isSaving: boolean;
+	saveContext?: TypesGen.ChatPersonalModelOverrideContext;
 }
+
+// Generated ChatPersonalModelOverrideContexts is alphabetical, not display order.
+const PERSONAL_OVERRIDE_CONTEXTS = ["root", "general", "explore"] as const;
 
 export const AgentSettingsUserAgentsPageView: FC<
 	AgentSettingsUserAgentsPageViewProps
@@ -46,34 +44,30 @@ export const AgentSettingsUserAgentsPageView: FC<
 	overridesData,
 	overridesError,
 	onRetryOverrides,
-	isRetryingOverrides = false,
-	isLoadingOverrides,
+	isRetryingOverrides,
+	isLoading,
 	modelOptions,
 	models,
 	modelsError,
-	isLoadingModels,
 	organizations,
 	selectedOrganization,
 	onSelectOrganization,
-	isOrganizationUnresolved,
-	hasNoOrganizationModels,
-	onSaveRootModelOverride,
-	isSavingRootModelOverride,
-	isSaveRootModelOverrideError,
-	onSaveGeneralModelOverride,
-	isSavingGeneralModelOverride,
-	isSaveGeneralModelOverrideError,
-	onSaveExploreModelOverride,
-	isSavingExploreModelOverride,
-	isSaveExploreModelOverrideError,
+	onSaveOverride,
+	isSaving,
+	saveContext,
 }) => {
 	const personalOverridesEnabled = overridesData?.enabled ?? true;
-	const isLoading = isLoadingOverrides || isLoadingModels;
+	const hasNoOrganizationModels =
+		selectedOrganization !== undefined &&
+		!isLoading &&
+		!modelsError &&
+		modelOptions.length === 0;
+
 	// Rows stay enabled when the organization has no models so the model-free
 	// default modes can still replace a stale saved model override; mode
 	// "model" cannot be saved without a valid model anyway.
 	const isDisabled =
-		isLoading || !personalOverridesEnabled || isOrganizationUnresolved;
+		isLoading || !personalOverridesEnabled || !selectedOrganization;
 
 	return (
 		<div className="flex flex-col gap-8">
@@ -89,24 +83,24 @@ export const AgentSettingsUserAgentsPageView: FC<
 					triggerClassName="w-60"
 					optionsTabbable
 					onChange={(organization) => {
-						if (organization) onSelectOrganization(organization);
+						if (organization) {
+							onSelectOrganization(organization);
+						}
 					}}
 				/>
 			)}
 			{overridesError ? (
 				<div className="flex flex-col gap-2">
 					<ErrorAlert error={overridesError} />
-					{onRetryOverrides && (
-						<Button
-							disabled={isRetryingOverrides}
-							onClick={onRetryOverrides}
-							size="sm"
-							type="button"
-							variant="outline"
-						>
-							Retry
-						</Button>
-					)}
+					<Button
+						disabled={isRetryingOverrides}
+						onClick={onRetryOverrides}
+						size="sm"
+						type="button"
+						variant="outline"
+					>
+						Retry
+					</Button>
 				</div>
 			) : null}
 			{!personalOverridesEnabled && (
@@ -117,7 +111,7 @@ export const AgentSettingsUserAgentsPageView: FC<
 					</AlertDescription>
 				</Alert>
 			)}
-			{isOrganizationUnresolved && (
+			{!selectedOrganization && (
 				<Alert severity="info">
 					<AlertDescription>
 						An organization is not available. Personal model overrides cannot be
@@ -134,53 +128,37 @@ export const AgentSettingsUserAgentsPageView: FC<
 					</AlertDescription>
 				</Alert>
 			)}
-			<PersonalModelOverrideRow
-				context="root"
-				title="Root agent model"
-				description="Choose the model behavior for new root agents."
-				overrideData={overridesData?.root}
-				modelOptions={modelOptions}
-				models={models}
-				modelsError={modelsError}
-				isLoading={isLoading}
-				onSave={onSaveRootModelOverride}
-				isSaving={isSavingRootModelOverride}
-				isSaveError={isSaveRootModelOverrideError}
-				saveErrorMessage="Failed to save root agent model override."
-				disabled={isDisabled}
-			/>
-			<PersonalModelOverrideRow
-				context="general"
-				title="General subagent model"
-				description="Choose the model behavior for delegated agents with write capabilities."
-				overrideData={overridesData?.general}
-				deploymentDefault={overridesData?.deployment_defaults.general}
-				modelOptions={modelOptions}
-				models={models}
-				modelsError={modelsError}
-				isLoading={isLoading}
-				onSave={onSaveGeneralModelOverride}
-				isSaving={isSavingGeneralModelOverride}
-				isSaveError={isSaveGeneralModelOverrideError}
-				saveErrorMessage="Failed to save general subagent model override."
-				disabled={isDisabled}
-			/>
-			<PersonalModelOverrideRow
-				context="explore"
-				title="Explore subagent model"
-				description="Choose the model behavior for read-only Explore subagents."
-				overrideData={overridesData?.explore}
-				deploymentDefault={overridesData?.deployment_defaults.explore}
-				modelOptions={modelOptions}
-				models={models}
-				modelsError={modelsError}
-				isLoading={isLoading}
-				onSave={onSaveExploreModelOverride}
-				isSaving={isSavingExploreModelOverride}
-				isSaveError={isSaveExploreModelOverrideError}
-				saveErrorMessage="Failed to save Explore subagent model override."
-				disabled={isDisabled}
-			/>
+			{PERSONAL_OVERRIDE_CONTEXTS.map((context) => (
+				<PersonalModelOverrideRow
+					key={context}
+					context={context}
+					overrideData={overridesData?.[context]}
+					deploymentDefault={
+						context === "root"
+							? undefined
+							: overridesData?.deployment_defaults[context]
+					}
+					modelOptions={modelOptions}
+					models={models}
+					modelsError={modelsError}
+					isLoading={isLoading}
+					onSave={(req, options) => {
+						if (!selectedOrganization) {
+							return;
+						}
+						onSaveOverride(
+							{
+								organizationId: selectedOrganization.id,
+								context,
+								req,
+							},
+							options,
+						);
+					}}
+					isSaving={isSaving && saveContext === context}
+					disabled={isDisabled}
+				/>
+			))}
 		</div>
 	);
 };

--- a/site/src/pages/AgentsPage/components/PersonalModelOverrideRow.tsx
+++ b/site/src/pages/AgentsPage/components/PersonalModelOverrideRow.tsx
@@ -46,7 +46,7 @@ interface PersonalModelOverrideRowProps {
 	disabled: boolean;
 }
 
-const PERSONAL_OVERRIDE_COPY: Record<
+export const PERSONAL_OVERRIDE_COPY: Record<
 	PersonalOverrideContext,
 	{ title: string; description: string }
 > = {

--- a/site/src/pages/AgentsPage/components/PersonalModelOverrideRow.tsx
+++ b/site/src/pages/AgentsPage/components/PersonalModelOverrideRow.tsx
@@ -35,8 +35,6 @@ interface PersonalOverrideFormValues {
 
 interface PersonalModelOverrideRowProps {
 	context: PersonalOverrideContext;
-	title: string;
-	description: string;
 	overrideData: PersonalOverride | undefined;
 	deploymentDefault?: TypesGen.ChatModelOverrideResponse;
 	modelOptions: readonly ModelSelectorOption[];
@@ -45,10 +43,27 @@ interface PersonalModelOverrideRowProps {
 	isLoading: boolean;
 	onSave: SavePersonalOverride;
 	isSaving: boolean;
-	isSaveError: boolean;
-	saveErrorMessage: string;
 	disabled: boolean;
 }
+
+const PERSONAL_OVERRIDE_COPY: Record<
+	PersonalOverrideContext,
+	{ title: string; description: string }
+> = {
+	root: {
+		title: "Root agent model",
+		description: "Choose the model behavior for new root agents.",
+	},
+	general: {
+		title: "General subagent model",
+		description:
+			"Choose the model behavior for delegated agents with write capabilities.",
+	},
+	explore: {
+		title: "Explore subagent model",
+		description: "Choose the model behavior for read-only Explore subagents.",
+	},
+};
 
 const getDefaultMode = (
 	context: PersonalOverrideContext,
@@ -159,8 +174,6 @@ const isDefaultModeOption = (
 
 export const PersonalModelOverrideRow: FC<PersonalModelOverrideRowProps> = ({
 	context,
-	title,
-	description,
 	overrideData,
 	deploymentDefault,
 	modelOptions,
@@ -169,10 +182,9 @@ export const PersonalModelOverrideRow: FC<PersonalModelOverrideRowProps> = ({
 	isLoading,
 	onSave,
 	isSaving,
-	isSaveError,
-	saveErrorMessage,
 	disabled,
 }) => {
+	const { title, description } = PERSONAL_OVERRIDE_COPY[context];
 	const hasLoadedOverride = overrideData !== undefined;
 	const form = useFormik<PersonalOverrideFormValues>({
 		enableReinitialize: true,
@@ -312,11 +324,6 @@ export const PersonalModelOverrideRow: FC<PersonalModelOverrideRowProps> = ({
 						Save
 					</Button>
 				</div>
-				{isSaveError && (
-					<p className="m-0 text-xs text-content-destructive">
-						{saveErrorMessage}
-					</p>
-				)}
 			</form>
 		</section>
 	);

--- a/site/src/pages/AgentsPage/components/PersonalModelOverrideRow.tsx
+++ b/site/src/pages/AgentsPage/components/PersonalModelOverrideRow.tsx
@@ -46,7 +46,7 @@ interface PersonalModelOverrideRowProps {
 	disabled: boolean;
 }
 
-export const PERSONAL_OVERRIDE_COPY: Record<
+const PERSONAL_OVERRIDE_COPY: Record<
 	PersonalOverrideContext,
 	{ title: string; description: string }
 > = {
@@ -294,9 +294,9 @@ export const PersonalModelOverrideRow: FC<PersonalModelOverrideRowProps> = ({
 						void form.setFieldValue("reasoning_effort", value)
 					}
 				/>
-				{modelOptions.length === 0 && (
+				{isLoading && modelOptions.length === 0 && (
 					<p role="status" className="m-0 text-xs text-content-secondary">
-						{isLoading ? "Loading models..." : "No enabled models found."}
+						Loading models...
 					</p>
 				)}
 


### PR DESCRIPTION
Personal model overrides now pick the org from the `org` search param the same way models and MCP settings do, and save through one mutation that invalidates that org. Save feedback is toasts, with the org name quoted only when more than one org is in play.

- Empty org list is treated as no access, not a missing default.
- No models for the org disables the selector and Save.
- A models catalog error is one page-level alert; rows stay usable so defaults can still be saved.
- `ModelSelector` wraps the chevron so the trigger icon stays small when the control is styled as a form field.