### PR TITLE
feat: return per-app session counts from workspace agent stats queries

### DIFF
--- a/coderd/database/dbauthz/dbauthz.go
+++ b/coderd/database/dbauthz/dbauthz.go
@@ -3878,6 +3878,14 @@ func (q *querier) GetDeploymentID(ctx context.Context) (string, error) {
 	return q.db.GetDeploymentID(ctx)
 }
 
+func (q *querier) GetDeploymentWorkspaceAgentStats(ctx context.Context, createdAt time.Time) (database.GetDeploymentWorkspaceAgentStatsRow, error) {
+	return q.db.GetDeploymentWorkspaceAgentStats(ctx, createdAt)
+}
+
+func (q *querier) GetDeploymentWorkspaceAgentUsageStats(ctx context.Context, createdAt time.Time) (database.GetDeploymentWorkspaceAgentUsageStatsRow, error) {
+	return q.db.GetDeploymentWorkspaceAgentUsageStats(ctx, createdAt)
+}
+
 func (q *querier) GetDeploymentWorkspaceStats(ctx context.Context) (database.GetDeploymentWorkspaceStatsRow, error) {
 	return q.db.GetDeploymentWorkspaceStats(ctx)
 }
@@ -5609,6 +5617,22 @@ func (q *querier) GetWorkspaceAgentScriptsByAgentIDs(ctx context.Context, ids []
 		return nil, err
 	}
 	return q.db.GetWorkspaceAgentScriptsByAgentIDs(ctx, ids)
+}
+
+func (q *querier) GetWorkspaceAgentStats(ctx context.Context, createdAt time.Time) ([]database.GetWorkspaceAgentStatsRow, error) {
+	return q.db.GetWorkspaceAgentStats(ctx, createdAt)
+}
+
+func (q *querier) GetWorkspaceAgentStatsAndLabels(ctx context.Context, createdAt time.Time) ([]database.GetWorkspaceAgentStatsAndLabelsRow, error) {
+	return q.db.GetWorkspaceAgentStatsAndLabels(ctx, createdAt)
+}
+
+func (q *querier) GetWorkspaceAgentUsageStats(ctx context.Context, createdAt time.Time) ([]database.GetWorkspaceAgentUsageStatsRow, error) {
+	return q.db.GetWorkspaceAgentUsageStats(ctx, createdAt)
+}
+
+func (q *querier) GetWorkspaceAgentUsageStatsAndLabels(ctx context.Context, createdAt time.Time) ([]database.GetWorkspaceAgentUsageStatsAndLabelsRow, error) {
+	return q.db.GetWorkspaceAgentUsageStatsAndLabels(ctx, createdAt)
 }
 
 func (q *querier) GetWorkspaceAgentsByInstanceID(ctx context.Context, authInstanceID string) ([]database.WorkspaceAgent, error) {

--- a/coderd/database/dbauthz/dbauthz_test.go
+++ b/coderd/database/dbauthz/dbauthz_test.go
@@ -5536,20 +5536,14 @@ func (s *MethodTestSuite) TestSystemFunctions() {
 		check.Args("foo").Asserts(rbac.ResourceDeploymentConfig, policy.ActionUpdate)
 	}))
 	s.Run("GetDeploymentWorkspaceAgentStats", s.Mocked(func(dbm *dbmock.MockStore, _ *gofakeit.Faker, check *expects) {
-		arg := database.GetDeploymentWorkspaceAgentStatsParams{
-			CreatedAt:   time.Time{},
-			AppFamilies: codersdk.SessionCountAppFamiliesJSON(),
-		}
-		dbm.EXPECT().GetDeploymentWorkspaceAgentStats(gomock.Any(), arg).Return(database.GetDeploymentWorkspaceAgentStatsRow{}, nil).AnyTimes()
-		check.Args(arg).Asserts()
+		t := time.Time{}
+		dbm.EXPECT().GetDeploymentWorkspaceAgentStats(gomock.Any(), t).Return(database.GetDeploymentWorkspaceAgentStatsRow{}, nil).AnyTimes()
+		check.Args(t).Asserts()
 	}))
 	s.Run("GetDeploymentWorkspaceAgentUsageStats", s.Mocked(func(dbm *dbmock.MockStore, _ *gofakeit.Faker, check *expects) {
-		arg := database.GetDeploymentWorkspaceAgentUsageStatsParams{
-			CreatedAt:   time.Time{},
-			AppFamilies: codersdk.SessionCountAppFamiliesJSON(),
-		}
-		dbm.EXPECT().GetDeploymentWorkspaceAgentUsageStats(gomock.Any(), arg).Return(database.GetDeploymentWorkspaceAgentUsageStatsRow{}, nil).AnyTimes()
-		check.Args(arg).Asserts()
+		t := time.Time{}
+		dbm.EXPECT().GetDeploymentWorkspaceAgentUsageStats(gomock.Any(), t).Return(database.GetDeploymentWorkspaceAgentUsageStatsRow{}, nil).AnyTimes()
+		check.Args(t).Asserts()
 	}))
 	s.Run("GetDeploymentWorkspaceStats", s.Mocked(func(dbm *dbmock.MockStore, _ *gofakeit.Faker, check *expects) {
 		dbm.EXPECT().GetDeploymentWorkspaceStats(gomock.Any()).Return(database.GetDeploymentWorkspaceStatsRow{}, nil).AnyTimes()
@@ -5577,36 +5571,24 @@ func (s *MethodTestSuite) TestSystemFunctions() {
 		check.Args(arg).Asserts(rbac.ResourceSystem, policy.ActionUpdate)
 	}))
 	s.Run("GetWorkspaceAgentStatsAndLabels", s.Mocked(func(dbm *dbmock.MockStore, _ *gofakeit.Faker, check *expects) {
-		arg := database.GetWorkspaceAgentStatsAndLabelsParams{
-			CreatedAt:   time.Time{},
-			AppFamilies: codersdk.SessionCountAppFamiliesJSON(),
-		}
-		dbm.EXPECT().GetWorkspaceAgentStatsAndLabels(gomock.Any(), arg).Return([]database.GetWorkspaceAgentStatsAndLabelsRow{}, nil).AnyTimes()
-		check.Args(arg).Asserts()
+		t := time.Time{}
+		dbm.EXPECT().GetWorkspaceAgentStatsAndLabels(gomock.Any(), t).Return([]database.GetWorkspaceAgentStatsAndLabelsRow{}, nil).AnyTimes()
+		check.Args(t).Asserts()
 	}))
 	s.Run("GetWorkspaceAgentUsageStatsAndLabels", s.Mocked(func(dbm *dbmock.MockStore, _ *gofakeit.Faker, check *expects) {
-		arg := database.GetWorkspaceAgentUsageStatsAndLabelsParams{
-			CreatedAt:   time.Time{},
-			AppFamilies: codersdk.SessionCountAppFamiliesJSON(),
-		}
-		dbm.EXPECT().GetWorkspaceAgentUsageStatsAndLabels(gomock.Any(), arg).Return([]database.GetWorkspaceAgentUsageStatsAndLabelsRow{}, nil).AnyTimes()
-		check.Args(arg).Asserts()
+		t := time.Time{}
+		dbm.EXPECT().GetWorkspaceAgentUsageStatsAndLabels(gomock.Any(), t).Return([]database.GetWorkspaceAgentUsageStatsAndLabelsRow{}, nil).AnyTimes()
+		check.Args(t).Asserts()
 	}))
 	s.Run("GetWorkspaceAgentStats", s.Mocked(func(dbm *dbmock.MockStore, _ *gofakeit.Faker, check *expects) {
-		arg := database.GetWorkspaceAgentStatsParams{
-			CreatedAt:   time.Time{},
-			AppFamilies: codersdk.SessionCountAppFamiliesJSON(),
-		}
-		dbm.EXPECT().GetWorkspaceAgentStats(gomock.Any(), arg).Return([]database.GetWorkspaceAgentStatsRow{}, nil).AnyTimes()
-		check.Args(arg).Asserts()
+		t := time.Time{}
+		dbm.EXPECT().GetWorkspaceAgentStats(gomock.Any(), t).Return([]database.GetWorkspaceAgentStatsRow{}, nil).AnyTimes()
+		check.Args(t).Asserts()
 	}))
 	s.Run("GetWorkspaceAgentUsageStats", s.Mocked(func(dbm *dbmock.MockStore, _ *gofakeit.Faker, check *expects) {
-		arg := database.GetWorkspaceAgentUsageStatsParams{
-			CreatedAt:   time.Time{},
-			AppFamilies: codersdk.SessionCountAppFamiliesJSON(),
-		}
-		dbm.EXPECT().GetWorkspaceAgentUsageStats(gomock.Any(), arg).Return([]database.GetWorkspaceAgentUsageStatsRow{}, nil).AnyTimes()
-		check.Args(arg).Asserts()
+		t := time.Time{}
+		dbm.EXPECT().GetWorkspaceAgentUsageStats(gomock.Any(), t).Return([]database.GetWorkspaceAgentUsageStatsRow{}, nil).AnyTimes()
+		check.Args(t).Asserts()
 	}))
 	s.Run("GetWorkspaceProxyByHostname", s.Mocked(func(dbm *dbmock.MockStore, faker *gofakeit.Faker, check *expects) {
 		p := testutil.Fake(s.T(), faker, database.WorkspaceProxy{WildcardHostname: "*.example.com"})
@@ -7968,8 +7950,8 @@ func TestAsExternalAuthChecker(t *testing.T) {
 	})
 }
 
-// TestSessionCountAppFamiliesRequired ensures the session count queries fail
-// loudly when the app family registry is empty, so a forgotten parameter
+// TestSessionCountAppFamiliesRequired ensures the queries that take the app
+// family registry fail loudly when it is empty, so a forgotten parameter
 // surfaces as an error instead of silently dropping every family's sessions
 // from usage reporting.
 func TestSessionCountAppFamiliesRequired(t *testing.T) {
@@ -7982,19 +7964,7 @@ func TestSessionCountAppFamiliesRequired(t *testing.T) {
 	q := dbauthz.New(dbm, &coderdtest.RecordingAuthorizer{Wrapped: &coderdtest.FakeAuthorizer{}}, slog.Make(), coderdtest.AccessControlStorePointer())
 	ctx := dbauthz.As(context.Background(), coderdtest.RandomRBACSubject())
 
-	_, err := q.GetDeploymentWorkspaceAgentStats(ctx, database.GetDeploymentWorkspaceAgentStatsParams{})
-	require.ErrorContains(t, err, "developer error")
-	_, err = q.GetDeploymentWorkspaceAgentUsageStats(ctx, database.GetDeploymentWorkspaceAgentUsageStatsParams{})
-	require.ErrorContains(t, err, "developer error")
-	_, err = q.GetWorkspaceAgentStats(ctx, database.GetWorkspaceAgentStatsParams{})
-	require.ErrorContains(t, err, "developer error")
-	_, err = q.GetWorkspaceAgentStatsAndLabels(ctx, database.GetWorkspaceAgentStatsAndLabelsParams{})
-	require.ErrorContains(t, err, "developer error")
-	_, err = q.GetWorkspaceAgentUsageStats(ctx, database.GetWorkspaceAgentUsageStatsParams{})
-	require.ErrorContains(t, err, "developer error")
-	_, err = q.GetWorkspaceAgentUsageStatsAndLabels(ctx, database.GetWorkspaceAgentUsageStatsAndLabelsParams{})
-	require.ErrorContains(t, err, "developer error")
-	_, err = q.GetTemplateInsightsByTemplate(ctx, database.GetTemplateInsightsByTemplateParams{})
+	_, err := q.GetTemplateInsightsByTemplate(ctx, database.GetTemplateInsightsByTemplateParams{})
 	require.ErrorContains(t, err, "developer error")
 	err = q.UpsertTemplateUsageStats(ctx, nil)
 	require.ErrorContains(t, err, "developer error")
@@ -8050,7 +8020,7 @@ func TestSessionCountAppFamiliesMustMatchQueries(t *testing.T) {
 			q := dbauthz.New(dbm, &coderdtest.RecordingAuthorizer{Wrapped: &coderdtest.FakeAuthorizer{}}, slog.Make(), coderdtest.AccessControlStorePointer())
 			ctx := dbauthz.As(context.Background(), coderdtest.RandomRBACSubject())
 
-			_, err := q.GetDeploymentWorkspaceAgentStats(ctx, database.GetDeploymentWorkspaceAgentStatsParams{AppFamilies: tc.appFamilies})
+			_, err := q.GetTemplateInsightsByTemplate(ctx, database.GetTemplateInsightsByTemplateParams{AppFamilies: tc.appFamilies})
 			require.ErrorContains(t, err, tc.errContains)
 			err = q.UpsertTemplateUsageStats(ctx, tc.appFamilies)
 			require.ErrorContains(t, err, tc.errContains)

--- a/coderd/database/dbauthz/sessioncountparams.go
+++ b/coderd/database/dbauthz/sessioncountparams.go
@@ -13,16 +13,16 @@ import (
 	"github.com/coder/coder/v2/codersdk"
 )
 
-// The session count read queries take the app family attribution registry as
-// a single jsonb parameter. Every query hardcodes one probe per family, so a
-// registry that is empty, malformed, or keyed differently from
-// codersdk.AttributedAppFamilies would still run and return zero counts for
-// the affected families, silently dropping sessions from deployment stats,
-// insights, Prometheus, and telemetry. dbauthz wraps every production store,
-// including the transaction stores used by the rollup, so validating here
-// makes a wrong registry fail the call loudly instead of failing the data
-// quietly. These methods override the generated ones in dbauthz.go;
-// scripts/dbgen preserves methods defined outside that file.
+// The template insights read query and the usage stats rollup take the app
+// family attribution registry as a single jsonb parameter. Both hardcode one
+// probe per family, so a registry that is empty, malformed, or keyed
+// differently from codersdk.AttributedAppFamilies would still run and return
+// zero counts for the affected families, silently dropping sessions from
+// insights and Prometheus. dbauthz wraps every production store, including
+// the transaction stores used by the rollup, so validating here makes a wrong
+// registry fail the call loudly instead of failing the data quietly. These
+// methods override the generated ones in dbauthz.go; scripts/dbgen preserves
+// methods defined outside that file.
 
 // validateSessionCountAppFamilies checks that the registry has exactly the
 // families the queries probe, each with at least one app name.
@@ -52,48 +52,6 @@ func validateSessionCountAppFamilies(appFamilies json.RawMessage) error {
 		}
 	}
 	return nil
-}
-
-func (q *querier) GetDeploymentWorkspaceAgentStats(ctx context.Context, arg database.GetDeploymentWorkspaceAgentStatsParams) (database.GetDeploymentWorkspaceAgentStatsRow, error) {
-	if err := validateSessionCountAppFamilies(arg.AppFamilies); err != nil {
-		return database.GetDeploymentWorkspaceAgentStatsRow{}, err
-	}
-	return q.db.GetDeploymentWorkspaceAgentStats(ctx, arg)
-}
-
-func (q *querier) GetDeploymentWorkspaceAgentUsageStats(ctx context.Context, arg database.GetDeploymentWorkspaceAgentUsageStatsParams) (database.GetDeploymentWorkspaceAgentUsageStatsRow, error) {
-	if err := validateSessionCountAppFamilies(arg.AppFamilies); err != nil {
-		return database.GetDeploymentWorkspaceAgentUsageStatsRow{}, err
-	}
-	return q.db.GetDeploymentWorkspaceAgentUsageStats(ctx, arg)
-}
-
-func (q *querier) GetWorkspaceAgentStats(ctx context.Context, arg database.GetWorkspaceAgentStatsParams) ([]database.GetWorkspaceAgentStatsRow, error) {
-	if err := validateSessionCountAppFamilies(arg.AppFamilies); err != nil {
-		return nil, err
-	}
-	return q.db.GetWorkspaceAgentStats(ctx, arg)
-}
-
-func (q *querier) GetWorkspaceAgentStatsAndLabels(ctx context.Context, arg database.GetWorkspaceAgentStatsAndLabelsParams) ([]database.GetWorkspaceAgentStatsAndLabelsRow, error) {
-	if err := validateSessionCountAppFamilies(arg.AppFamilies); err != nil {
-		return nil, err
-	}
-	return q.db.GetWorkspaceAgentStatsAndLabels(ctx, arg)
-}
-
-func (q *querier) GetWorkspaceAgentUsageStats(ctx context.Context, arg database.GetWorkspaceAgentUsageStatsParams) ([]database.GetWorkspaceAgentUsageStatsRow, error) {
-	if err := validateSessionCountAppFamilies(arg.AppFamilies); err != nil {
-		return nil, err
-	}
-	return q.db.GetWorkspaceAgentUsageStats(ctx, arg)
-}
-
-func (q *querier) GetWorkspaceAgentUsageStatsAndLabels(ctx context.Context, arg database.GetWorkspaceAgentUsageStatsAndLabelsParams) ([]database.GetWorkspaceAgentUsageStatsAndLabelsRow, error) {
-	if err := validateSessionCountAppFamilies(arg.AppFamilies); err != nil {
-		return nil, err
-	}
-	return q.db.GetWorkspaceAgentUsageStatsAndLabels(ctx, arg)
 }
 
 func (q *querier) GetTemplateInsightsByTemplate(ctx context.Context, arg database.GetTemplateInsightsByTemplateParams) ([]database.GetTemplateInsightsByTemplateRow, error) {

--- a/coderd/database/dbmetrics/querymetrics.go
+++ b/coderd/database/dbmetrics/querymetrics.go
@@ -2025,7 +2025,7 @@ func (m queryMetricsStore) GetDeploymentID(ctx context.Context) (string, error) 
 	return r0, r1
 }
 
-func (m queryMetricsStore) GetDeploymentWorkspaceAgentStats(ctx context.Context, arg database.GetDeploymentWorkspaceAgentStatsParams) (database.GetDeploymentWorkspaceAgentStatsRow, error) {
+func (m queryMetricsStore) GetDeploymentWorkspaceAgentStats(ctx context.Context, arg time.Time) (database.GetDeploymentWorkspaceAgentStatsRow, error) {
 	start := time.Now()
 	r0, r1 := m.s.GetDeploymentWorkspaceAgentStats(ctx, arg)
 	m.queryLatencies.WithLabelValues("GetDeploymentWorkspaceAgentStats").Observe(time.Since(start).Seconds())
@@ -2033,7 +2033,7 @@ func (m queryMetricsStore) GetDeploymentWorkspaceAgentStats(ctx context.Context,
 	return r0, r1
 }
 
-func (m queryMetricsStore) GetDeploymentWorkspaceAgentUsageStats(ctx context.Context, arg database.GetDeploymentWorkspaceAgentUsageStatsParams) (database.GetDeploymentWorkspaceAgentUsageStatsRow, error) {
+func (m queryMetricsStore) GetDeploymentWorkspaceAgentUsageStats(ctx context.Context, arg time.Time) (database.GetDeploymentWorkspaceAgentUsageStatsRow, error) {
 	start := time.Now()
 	r0, r1 := m.s.GetDeploymentWorkspaceAgentUsageStats(ctx, arg)
 	m.queryLatencies.WithLabelValues("GetDeploymentWorkspaceAgentUsageStats").Observe(time.Since(start).Seconds())
@@ -3657,7 +3657,7 @@ func (m queryMetricsStore) GetWorkspaceAgentScriptsByAgentIDs(ctx context.Contex
 	return r0, r1
 }
 
-func (m queryMetricsStore) GetWorkspaceAgentStats(ctx context.Context, arg database.GetWorkspaceAgentStatsParams) ([]database.GetWorkspaceAgentStatsRow, error) {
+func (m queryMetricsStore) GetWorkspaceAgentStats(ctx context.Context, arg time.Time) ([]database.GetWorkspaceAgentStatsRow, error) {
 	start := time.Now()
 	r0, r1 := m.s.GetWorkspaceAgentStats(ctx, arg)
 	m.queryLatencies.WithLabelValues("GetWorkspaceAgentStats").Observe(time.Since(start).Seconds())
@@ -3665,7 +3665,7 @@ func (m queryMetricsStore) GetWorkspaceAgentStats(ctx context.Context, arg datab
 	return r0, r1
 }
 
-func (m queryMetricsStore) GetWorkspaceAgentStatsAndLabels(ctx context.Context, arg database.GetWorkspaceAgentStatsAndLabelsParams) ([]database.GetWorkspaceAgentStatsAndLabelsRow, error) {
+func (m queryMetricsStore) GetWorkspaceAgentStatsAndLabels(ctx context.Context, arg time.Time) ([]database.GetWorkspaceAgentStatsAndLabelsRow, error) {
 	start := time.Now()
 	r0, r1 := m.s.GetWorkspaceAgentStatsAndLabels(ctx, arg)
 	m.queryLatencies.WithLabelValues("GetWorkspaceAgentStatsAndLabels").Observe(time.Since(start).Seconds())
@@ -3673,7 +3673,7 @@ func (m queryMetricsStore) GetWorkspaceAgentStatsAndLabels(ctx context.Context, 
 	return r0, r1
 }
 
-func (m queryMetricsStore) GetWorkspaceAgentUsageStats(ctx context.Context, arg database.GetWorkspaceAgentUsageStatsParams) ([]database.GetWorkspaceAgentUsageStatsRow, error) {
+func (m queryMetricsStore) GetWorkspaceAgentUsageStats(ctx context.Context, arg time.Time) ([]database.GetWorkspaceAgentUsageStatsRow, error) {
 	start := time.Now()
 	r0, r1 := m.s.GetWorkspaceAgentUsageStats(ctx, arg)
 	m.queryLatencies.WithLabelValues("GetWorkspaceAgentUsageStats").Observe(time.Since(start).Seconds())
@@ -3681,7 +3681,7 @@ func (m queryMetricsStore) GetWorkspaceAgentUsageStats(ctx context.Context, arg 
 	return r0, r1
 }
 
-func (m queryMetricsStore) GetWorkspaceAgentUsageStatsAndLabels(ctx context.Context, arg database.GetWorkspaceAgentUsageStatsAndLabelsParams) ([]database.GetWorkspaceAgentUsageStatsAndLabelsRow, error) {
+func (m queryMetricsStore) GetWorkspaceAgentUsageStatsAndLabels(ctx context.Context, arg time.Time) ([]database.GetWorkspaceAgentUsageStatsAndLabelsRow, error) {
 	start := time.Now()
 	r0, r1 := m.s.GetWorkspaceAgentUsageStatsAndLabels(ctx, arg)
 	m.queryLatencies.WithLabelValues("GetWorkspaceAgentUsageStatsAndLabels").Observe(time.Since(start).Seconds())

--- a/coderd/database/dbmock/dbmock.go
+++ b/coderd/database/dbmock/dbmock.go
@@ -3796,33 +3796,33 @@ func (mr *MockStoreMockRecorder) GetDeploymentID(ctx any) *gomock.Call {
 }
 
 // GetDeploymentWorkspaceAgentStats mocks base method.
-func (m *MockStore) GetDeploymentWorkspaceAgentStats(ctx context.Context, arg database.GetDeploymentWorkspaceAgentStatsParams) (database.GetDeploymentWorkspaceAgentStatsRow, error) {
+func (m *MockStore) GetDeploymentWorkspaceAgentStats(ctx context.Context, createdAt time.Time) (database.GetDeploymentWorkspaceAgentStatsRow, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetDeploymentWorkspaceAgentStats", ctx, arg)
+	ret := m.ctrl.Call(m, "GetDeploymentWorkspaceAgentStats", ctx, createdAt)
 	ret0, _ := ret[0].(database.GetDeploymentWorkspaceAgentStatsRow)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // GetDeploymentWorkspaceAgentStats indicates an expected call of GetDeploymentWorkspaceAgentStats.
-func (mr *MockStoreMockRecorder) GetDeploymentWorkspaceAgentStats(ctx, arg any) *gomock.Call {
+func (mr *MockStoreMockRecorder) GetDeploymentWorkspaceAgentStats(ctx, createdAt any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetDeploymentWorkspaceAgentStats", reflect.TypeOf((*MockStore)(nil).GetDeploymentWorkspaceAgentStats), ctx, arg)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetDeploymentWorkspaceAgentStats", reflect.TypeOf((*MockStore)(nil).GetDeploymentWorkspaceAgentStats), ctx, createdAt)
 }
 
 // GetDeploymentWorkspaceAgentUsageStats mocks base method.
-func (m *MockStore) GetDeploymentWorkspaceAgentUsageStats(ctx context.Context, arg database.GetDeploymentWorkspaceAgentUsageStatsParams) (database.GetDeploymentWorkspaceAgentUsageStatsRow, error) {
+func (m *MockStore) GetDeploymentWorkspaceAgentUsageStats(ctx context.Context, createdAt time.Time) (database.GetDeploymentWorkspaceAgentUsageStatsRow, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetDeploymentWorkspaceAgentUsageStats", ctx, arg)
+	ret := m.ctrl.Call(m, "GetDeploymentWorkspaceAgentUsageStats", ctx, createdAt)
 	ret0, _ := ret[0].(database.GetDeploymentWorkspaceAgentUsageStatsRow)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // GetDeploymentWorkspaceAgentUsageStats indicates an expected call of GetDeploymentWorkspaceAgentUsageStats.
-func (mr *MockStoreMockRecorder) GetDeploymentWorkspaceAgentUsageStats(ctx, arg any) *gomock.Call {
+func (mr *MockStoreMockRecorder) GetDeploymentWorkspaceAgentUsageStats(ctx, createdAt any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetDeploymentWorkspaceAgentUsageStats", reflect.TypeOf((*MockStore)(nil).GetDeploymentWorkspaceAgentUsageStats), ctx, arg)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetDeploymentWorkspaceAgentUsageStats", reflect.TypeOf((*MockStore)(nil).GetDeploymentWorkspaceAgentUsageStats), ctx, createdAt)
 }
 
 // GetDeploymentWorkspaceStats mocks base method.
@@ -6886,63 +6886,63 @@ func (mr *MockStoreMockRecorder) GetWorkspaceAgentScriptsByAgentIDs(ctx, ids any
 }
 
 // GetWorkspaceAgentStats mocks base method.
-func (m *MockStore) GetWorkspaceAgentStats(ctx context.Context, arg database.GetWorkspaceAgentStatsParams) ([]database.GetWorkspaceAgentStatsRow, error) {
+func (m *MockStore) GetWorkspaceAgentStats(ctx context.Context, createdAt time.Time) ([]database.GetWorkspaceAgentStatsRow, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetWorkspaceAgentStats", ctx, arg)
+	ret := m.ctrl.Call(m, "GetWorkspaceAgentStats", ctx, createdAt)
 	ret0, _ := ret[0].([]database.GetWorkspaceAgentStatsRow)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // GetWorkspaceAgentStats indicates an expected call of GetWorkspaceAgentStats.
-func (mr *MockStoreMockRecorder) GetWorkspaceAgentStats(ctx, arg any) *gomock.Call {
+func (mr *MockStoreMockRecorder) GetWorkspaceAgentStats(ctx, createdAt any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetWorkspaceAgentStats", reflect.TypeOf((*MockStore)(nil).GetWorkspaceAgentStats), ctx, arg)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetWorkspaceAgentStats", reflect.TypeOf((*MockStore)(nil).GetWorkspaceAgentStats), ctx, createdAt)
 }
 
 // GetWorkspaceAgentStatsAndLabels mocks base method.
-func (m *MockStore) GetWorkspaceAgentStatsAndLabels(ctx context.Context, arg database.GetWorkspaceAgentStatsAndLabelsParams) ([]database.GetWorkspaceAgentStatsAndLabelsRow, error) {
+func (m *MockStore) GetWorkspaceAgentStatsAndLabels(ctx context.Context, createdAt time.Time) ([]database.GetWorkspaceAgentStatsAndLabelsRow, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetWorkspaceAgentStatsAndLabels", ctx, arg)
+	ret := m.ctrl.Call(m, "GetWorkspaceAgentStatsAndLabels", ctx, createdAt)
 	ret0, _ := ret[0].([]database.GetWorkspaceAgentStatsAndLabelsRow)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // GetWorkspaceAgentStatsAndLabels indicates an expected call of GetWorkspaceAgentStatsAndLabels.
-func (mr *MockStoreMockRecorder) GetWorkspaceAgentStatsAndLabels(ctx, arg any) *gomock.Call {
+func (mr *MockStoreMockRecorder) GetWorkspaceAgentStatsAndLabels(ctx, createdAt any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetWorkspaceAgentStatsAndLabels", reflect.TypeOf((*MockStore)(nil).GetWorkspaceAgentStatsAndLabels), ctx, arg)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetWorkspaceAgentStatsAndLabels", reflect.TypeOf((*MockStore)(nil).GetWorkspaceAgentStatsAndLabels), ctx, createdAt)
 }
 
 // GetWorkspaceAgentUsageStats mocks base method.
-func (m *MockStore) GetWorkspaceAgentUsageStats(ctx context.Context, arg database.GetWorkspaceAgentUsageStatsParams) ([]database.GetWorkspaceAgentUsageStatsRow, error) {
+func (m *MockStore) GetWorkspaceAgentUsageStats(ctx context.Context, createdAt time.Time) ([]database.GetWorkspaceAgentUsageStatsRow, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetWorkspaceAgentUsageStats", ctx, arg)
+	ret := m.ctrl.Call(m, "GetWorkspaceAgentUsageStats", ctx, createdAt)
 	ret0, _ := ret[0].([]database.GetWorkspaceAgentUsageStatsRow)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // GetWorkspaceAgentUsageStats indicates an expected call of GetWorkspaceAgentUsageStats.
-func (mr *MockStoreMockRecorder) GetWorkspaceAgentUsageStats(ctx, arg any) *gomock.Call {
+func (mr *MockStoreMockRecorder) GetWorkspaceAgentUsageStats(ctx, createdAt any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetWorkspaceAgentUsageStats", reflect.TypeOf((*MockStore)(nil).GetWorkspaceAgentUsageStats), ctx, arg)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetWorkspaceAgentUsageStats", reflect.TypeOf((*MockStore)(nil).GetWorkspaceAgentUsageStats), ctx, createdAt)
 }
 
 // GetWorkspaceAgentUsageStatsAndLabels mocks base method.
-func (m *MockStore) GetWorkspaceAgentUsageStatsAndLabels(ctx context.Context, arg database.GetWorkspaceAgentUsageStatsAndLabelsParams) ([]database.GetWorkspaceAgentUsageStatsAndLabelsRow, error) {
+func (m *MockStore) GetWorkspaceAgentUsageStatsAndLabels(ctx context.Context, createdAt time.Time) ([]database.GetWorkspaceAgentUsageStatsAndLabelsRow, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetWorkspaceAgentUsageStatsAndLabels", ctx, arg)
+	ret := m.ctrl.Call(m, "GetWorkspaceAgentUsageStatsAndLabels", ctx, createdAt)
 	ret0, _ := ret[0].([]database.GetWorkspaceAgentUsageStatsAndLabelsRow)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // GetWorkspaceAgentUsageStatsAndLabels indicates an expected call of GetWorkspaceAgentUsageStatsAndLabels.
-func (mr *MockStoreMockRecorder) GetWorkspaceAgentUsageStatsAndLabels(ctx, arg any) *gomock.Call {
+func (mr *MockStoreMockRecorder) GetWorkspaceAgentUsageStatsAndLabels(ctx, createdAt any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetWorkspaceAgentUsageStatsAndLabels", reflect.TypeOf((*MockStore)(nil).GetWorkspaceAgentUsageStatsAndLabels), ctx, arg)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetWorkspaceAgentUsageStatsAndLabels", reflect.TypeOf((*MockStore)(nil).GetWorkspaceAgentUsageStatsAndLabels), ctx, createdAt)
 }
 
 // GetWorkspaceAgentsByInstanceID mocks base method.

--- a/coderd/database/dbpurge/dbpurge_test.go
+++ b/coderd/database/dbpurge/dbpurge_test.go
@@ -352,7 +352,6 @@ func TestDeleteOldWorkspaceAgentStats(t *testing.T) {
 	clk := quartz.NewReal()
 	db, _ := dbtestutil.NewDB(t)
 	logger := slogtest.Make(t, &slogtest.Options{IgnoreErrors: true}).Leveled(slog.LevelDebug)
-	appFamilies := codersdk.SessionCountAppFamiliesJSON()
 
 	defer func() {
 		if t.Failed() {
@@ -361,10 +360,7 @@ func TestDeleteOldWorkspaceAgentStats(t *testing.T) {
 			buf := &bytes.Buffer{}
 			enc := json.NewEncoder(buf)
 			enc.SetIndent("", "\t")
-			wasRows, err := db.GetWorkspaceAgentStats(ctx, database.GetWorkspaceAgentStatsParams{
-				CreatedAt:   now.AddDate(0, -7, 0),
-				AppFamilies: appFamilies,
-			})
+			wasRows, err := db.GetWorkspaceAgentStats(ctx, now.AddDate(0, -7, 0))
 			if err == nil {
 				_, _ = fmt.Fprintf(buf, "workspace agent stats: ")
 				_ = enc.Encode(wasRows)
@@ -426,10 +422,7 @@ func TestDeleteOldWorkspaceAgentStats(t *testing.T) {
 	var err error
 	require.Eventuallyf(t, func() bool {
 		// Query all stats created not earlier than ~7 months ago
-		stats, err = db.GetWorkspaceAgentStats(ctx, database.GetWorkspaceAgentStatsParams{
-			CreatedAt:   now.AddDate(0, 0, -210),
-			AppFamilies: appFamilies,
-		})
+		stats, err = db.GetWorkspaceAgentStats(ctx, now.AddDate(0, 0, -210))
 		if err != nil {
 			return false
 		}
@@ -452,10 +445,7 @@ func TestDeleteOldWorkspaceAgentStats(t *testing.T) {
 	// then
 	require.Eventuallyf(t, func() bool {
 		// Query all stats created not earlier than ~7 months ago
-		stats, err = db.GetWorkspaceAgentStats(ctx, database.GetWorkspaceAgentStatsParams{
-			CreatedAt:   now.AddDate(0, 0, -210),
-			AppFamilies: appFamilies,
-		})
+		stats, err = db.GetWorkspaceAgentStats(ctx, now.AddDate(0, 0, -210))
 		if err != nil {
 			return false
 		}

--- a/coderd/database/querier.go
+++ b/coderd/database/querier.go
@@ -584,15 +584,12 @@ type sqlcQuerier interface {
 	GetDefaultOrganization(ctx context.Context) (Organization, error)
 	GetDefaultProxyConfig(ctx context.Context) (GetDefaultProxyConfigRow, error)
 	GetDeploymentID(ctx context.Context) (string, error)
-	// app_families maps each attributed family to its app names, so the probes
-	// below stay one expression per family: adding a family needs a new list in
-	// fams plus one probe here, because sqlc output columns are static.
-	// fams turns the jsonb parameter into arrays once for the whole query. The
-	// lateral decomposes session_counts once per row and sums each family from
-	// that single pass, which measured ~3x faster than probing the jsonb once
-	// per family. The subplan only runs for rows that survive the gate.
-	GetDeploymentWorkspaceAgentStats(ctx context.Context, arg GetDeploymentWorkspaceAgentStatsParams) (GetDeploymentWorkspaceAgentStatsRow, error)
-	GetDeploymentWorkspaceAgentUsageStats(ctx context.Context, arg GetDeploymentWorkspaceAgentUsageStatsParams) (GetDeploymentWorkspaceAgentUsageStatsRow, error)
+	// The session count sum runs in its own subquery: decomposing session_counts
+	// in the FROM clause would emit one row per app name and multiply the byte and
+	// latency aggregates below. Summing per app name and folding the names into
+	// families in Go keeps a session reported under a new name counted.
+	GetDeploymentWorkspaceAgentStats(ctx context.Context, createdAt time.Time) (GetDeploymentWorkspaceAgentStatsRow, error)
+	GetDeploymentWorkspaceAgentUsageStats(ctx context.Context, createdAt time.Time) (GetDeploymentWorkspaceAgentUsageStatsRow, error)
 	GetDeploymentWorkspaceStats(ctx context.Context) (GetDeploymentWorkspaceStatsRow, error)
 	GetEligibleProvisionerDaemonsByProvisionerJobIDs(ctx context.Context, provisionerJobIds []uuid.UUID) ([]GetEligibleProvisionerDaemonsByProvisionerJobIDsRow, error)
 	// Providers can be disabled independently of their model configs.
@@ -1044,10 +1041,10 @@ type sqlcQuerier interface {
 	GetWorkspaceAgentPortShare(ctx context.Context, arg GetWorkspaceAgentPortShareParams) (WorkspaceAgentPortShare, error)
 	GetWorkspaceAgentScriptTimingsByBuildID(ctx context.Context, id uuid.UUID) ([]GetWorkspaceAgentScriptTimingsByBuildIDRow, error)
 	GetWorkspaceAgentScriptsByAgentIDs(ctx context.Context, ids []uuid.UUID) ([]GetWorkspaceAgentScriptsByAgentIDsRow, error)
-	GetWorkspaceAgentStats(ctx context.Context, arg GetWorkspaceAgentStatsParams) ([]GetWorkspaceAgentStatsRow, error)
-	GetWorkspaceAgentStatsAndLabels(ctx context.Context, arg GetWorkspaceAgentStatsAndLabelsParams) ([]GetWorkspaceAgentStatsAndLabelsRow, error)
-	GetWorkspaceAgentUsageStats(ctx context.Context, arg GetWorkspaceAgentUsageStatsParams) ([]GetWorkspaceAgentUsageStatsRow, error)
-	GetWorkspaceAgentUsageStatsAndLabels(ctx context.Context, arg GetWorkspaceAgentUsageStatsAndLabelsParams) ([]GetWorkspaceAgentUsageStatsAndLabelsRow, error)
+	GetWorkspaceAgentStats(ctx context.Context, createdAt time.Time) ([]GetWorkspaceAgentStatsRow, error)
+	GetWorkspaceAgentStatsAndLabels(ctx context.Context, createdAt time.Time) ([]GetWorkspaceAgentStatsAndLabelsRow, error)
+	GetWorkspaceAgentUsageStats(ctx context.Context, createdAt time.Time) ([]GetWorkspaceAgentUsageStatsRow, error)
+	GetWorkspaceAgentUsageStatsAndLabels(ctx context.Context, createdAt time.Time) ([]GetWorkspaceAgentUsageStatsAndLabelsRow, error)
 	GetWorkspaceAgentsByInstanceID(ctx context.Context, authInstanceID string) ([]WorkspaceAgent, error)
 	GetWorkspaceAgentsByParentID(ctx context.Context, parentID uuid.UUID) ([]WorkspaceAgent, error)
 	GetWorkspaceAgentsByResourceIDs(ctx context.Context, ids []uuid.UUID) ([]WorkspaceAgent, error)

--- a/coderd/database/querier_test.go
+++ b/coderd/database/querier_test.go
@@ -67,18 +67,14 @@ func TestGetDeploymentWorkspaceAgentStats(t *testing.T) {
 			ConnectionMedianLatencyMS: 2,
 			SessionCounts:             dbgen.SessionCounts(t, map[string]int64{"vscode": 1}),
 		})
-		appFamilies := codersdk.SessionCountAppFamiliesJSON()
-		stats, err := db.GetDeploymentWorkspaceAgentStats(ctx, database.GetDeploymentWorkspaceAgentStatsParams{
-			CreatedAt:   dbtime.Now().Add(-time.Hour),
-			AppFamilies: appFamilies,
-		})
+		stats, err := db.GetDeploymentWorkspaceAgentStats(ctx, dbtime.Now().Add(-time.Hour))
 		require.NoError(t, err)
 
 		require.Equal(t, int64(2), stats.WorkspaceTxBytes)
 		require.Equal(t, int64(2), stats.WorkspaceRxBytes)
 		require.Equal(t, 1.5, stats.WorkspaceConnectionLatency50)
 		require.Equal(t, 1.95, stats.WorkspaceConnectionLatency95)
-		require.Equal(t, int64(2), stats.SessionCountVSCode)
+		require.Equal(t, int64(2), sessionFamilyCounts(t, stats.SessionCounts)["vscode"])
 	})
 
 	t.Run("GroupsByAgentID", func(t *testing.T) {
@@ -108,19 +104,95 @@ func TestGetDeploymentWorkspaceAgentStats(t *testing.T) {
 			ConnectionMedianLatencyMS: 2,
 			SessionCounts:             dbgen.SessionCounts(t, map[string]int64{"vscode": 1}),
 		})
-		appFamilies := codersdk.SessionCountAppFamiliesJSON()
-		stats, err := db.GetDeploymentWorkspaceAgentStats(ctx, database.GetDeploymentWorkspaceAgentStatsParams{
-			CreatedAt:   dbtime.Now().Add(-time.Hour),
-			AppFamilies: appFamilies,
-		})
+		stats, err := db.GetDeploymentWorkspaceAgentStats(ctx, dbtime.Now().Add(-time.Hour))
 		require.NoError(t, err)
 
 		require.Equal(t, int64(2), stats.WorkspaceTxBytes)
 		require.Equal(t, int64(2), stats.WorkspaceRxBytes)
 		require.Equal(t, 1.5, stats.WorkspaceConnectionLatency50)
 		require.Equal(t, 1.95, stats.WorkspaceConnectionLatency95)
-		require.Equal(t, int64(1), stats.SessionCountVSCode)
+		require.Equal(t, int64(1), sessionFamilyCounts(t, stats.SessionCounts)["vscode"])
 	})
+
+	// The per-app sums live in their own subquery, because decomposing
+	// session_counts in the FROM clause emits one row per app name and
+	// multiplies every other aggregate.
+	t.Run("MultipleAppNamesDoNotMultiplyAggregates", func(t *testing.T) {
+		t.Parallel()
+
+		sqlDB := testSQLDB(t)
+		err := migrations.Up(sqlDB)
+		require.NoError(t, err)
+		db := database.New(sqlDB)
+		ctx := context.Background()
+		dbgen.WorkspaceAgentStat(t, db, database.WorkspaceAgentStat{
+			AgentID:                   uuid.New(),
+			TxBytes:                   1,
+			RxBytes:                   1,
+			ConnectionMedianLatencyMS: 1,
+			SessionCounts:             dbgen.SessionCounts(t, map[string]int64{"vscode": 1, "jetbrains": 1, "ssh": 1}),
+		})
+
+		stats, err := db.GetDeploymentWorkspaceAgentStats(ctx, dbtime.Now().Add(-time.Hour))
+		require.NoError(t, err)
+
+		require.Equal(t, int64(1), stats.WorkspaceTxBytes, "bytes must not be multiplied by the app name count")
+		require.Equal(t, int64(1), stats.WorkspaceRxBytes)
+		require.Equal(t, float64(1), stats.WorkspaceConnectionLatency50)
+		require.Equal(t, float64(1), stats.WorkspaceConnectionLatency95)
+		counts := sessionFamilyCounts(t, stats.SessionCounts)
+		require.Equal(t, int64(1), counts["vscode"])
+		require.Equal(t, int64(1), counts["jetbrains"])
+		require.Equal(t, int64(1), counts["ssh"])
+	})
+}
+
+// The per-agent sessions come from a separate CTE that is joined back, so an
+// agent whose latest row reports no sessions must keep its row with zero
+// sessions instead of disappearing or inheriting the previous row's counts.
+func TestGetWorkspaceAgentStats(t *testing.T) {
+	t.Parallel()
+	if testing.Short() {
+		t.SkipNow()
+	}
+
+	sqlDB := testSQLDB(t)
+	require.NoError(t, migrations.Up(sqlDB))
+	db := database.New(sqlDB)
+	ctx := context.Background()
+	now := dbtime.Now()
+
+	// The query groups by the owner columns, so both rows must share them.
+	owner := database.WorkspaceAgentStat{
+		UserID:      uuid.New(),
+		AgentID:     uuid.New(),
+		WorkspaceID: uuid.New(),
+		TemplateID:  uuid.New(),
+	}
+
+	stat := owner
+	stat.CreatedAt = now.Add(-2 * time.Minute)
+	stat.RxBytes = 10
+	stat.TxBytes = 1
+	stat.ConnectionMedianLatencyMS = 5
+	stat.SessionCounts = dbgen.SessionCounts(t, map[string]int64{"vscode": 2})
+	dbgen.WorkspaceAgentStat(t, db, stat)
+
+	stat = owner
+	stat.CreatedAt = now.Add(-time.Minute)
+	stat.RxBytes = 10
+	stat.TxBytes = 1
+	stat.ConnectionMedianLatencyMS = 5
+	dbgen.WorkspaceAgentStat(t, db, stat)
+
+	stats, err := db.GetWorkspaceAgentStats(ctx, now.Add(-time.Hour))
+	require.NoError(t, err)
+	require.Len(t, stats, 1, "an agent whose latest row reports no sessions must keep its row")
+	require.Equal(t, owner.AgentID, stats[0].AgentID)
+	require.Empty(t, sessionFamilyCounts(t, stats[0].SessionCounts),
+		"the previous row's sessions must not be resurrected")
+	require.Equal(t, int64(20), stats[0].WorkspaceRxBytes)
+	require.Equal(t, int64(2), stats[0].WorkspaceTxBytes)
 }
 
 func TestGetDeploymentWorkspaceAgentUsageStats(t *testing.T) {
@@ -181,21 +253,17 @@ func TestGetDeploymentWorkspaceAgentUsageStats(t *testing.T) {
 			SessionCounts: dbgen.SessionCounts(t, map[string]int64{"ssh": 1}),
 		})
 
-		appFamilies := codersdk.SessionCountAppFamiliesJSON()
-		stats, err := db.GetDeploymentWorkspaceAgentUsageStats(ctx, database.GetDeploymentWorkspaceAgentUsageStatsParams{
-			CreatedAt:   dbtime.Now().Add(-time.Hour),
-			AppFamilies: appFamilies,
-		})
+		stats, err := db.GetDeploymentWorkspaceAgentUsageStats(ctx, dbtime.Now().Add(-time.Hour))
 		require.NoError(t, err)
 
 		require.Equal(t, int64(2), stats.WorkspaceTxBytes)
 		require.Equal(t, int64(2), stats.WorkspaceRxBytes)
 		require.Equal(t, 1.5, stats.WorkspaceConnectionLatency50)
 		require.Equal(t, 1.95, stats.WorkspaceConnectionLatency95)
-		require.Equal(t, int64(1), stats.SessionCountVSCode)
-		require.Equal(t, int64(1), stats.SessionCountSSH)
-		require.Equal(t, int64(0), stats.SessionCountReconnectingPTY)
-		require.Equal(t, int64(0), stats.SessionCountJetBrains)
+		require.Equal(t, int64(1), sessionFamilyCounts(t, stats.SessionCounts)["vscode"])
+		require.Equal(t, int64(1), sessionFamilyCounts(t, stats.SessionCounts)["ssh"])
+		require.Equal(t, int64(0), sessionFamilyCounts(t, stats.SessionCounts)["reconnecting_pty"])
+		require.Equal(t, int64(0), sessionFamilyCounts(t, stats.SessionCounts)["jetbrains"])
 	})
 
 	t.Run("ExcludesStatsBeforeCutoffInSameMinute", func(t *testing.T) {
@@ -222,14 +290,10 @@ func TestGetDeploymentWorkspaceAgentUsageStats(t *testing.T) {
 			SessionCounts: dbgen.SessionCounts(t, map[string]int64{"ssh": 1}),
 		})
 
-		appFamilies := codersdk.SessionCountAppFamiliesJSON()
-		stats, err := db.GetDeploymentWorkspaceAgentUsageStats(ctx, database.GetDeploymentWorkspaceAgentUsageStatsParams{
-			CreatedAt:   cutoff,
-			AppFamilies: appFamilies,
-		})
+		stats, err := db.GetDeploymentWorkspaceAgentUsageStats(ctx, cutoff)
 		require.NoError(t, err)
-		require.Zero(t, stats.SessionCountVSCode)
-		require.Equal(t, int64(1), stats.SessionCountSSH)
+		require.Zero(t, sessionFamilyCounts(t, stats.SessionCounts)["vscode"])
+		require.Equal(t, int64(1), sessionFamilyCounts(t, stats.SessionCounts)["ssh"])
 	})
 
 	t.Run("NoUsage", func(t *testing.T) {
@@ -252,19 +316,15 @@ func TestGetDeploymentWorkspaceAgentUsageStats(t *testing.T) {
 			SessionCounts:             dbgen.SessionCounts(t, map[string]int64{"ssh": 3, "vscode": 1}), // Should be ignored.
 		})
 
-		appFamilies := codersdk.SessionCountAppFamiliesJSON()
-		stats, err := db.GetDeploymentWorkspaceAgentUsageStats(ctx, database.GetDeploymentWorkspaceAgentUsageStatsParams{
-			CreatedAt:   dbtime.Now().Add(-time.Hour),
-			AppFamilies: appFamilies,
-		})
+		stats, err := db.GetDeploymentWorkspaceAgentUsageStats(ctx, dbtime.Now().Add(-time.Hour))
 		require.NoError(t, err)
 
 		require.Equal(t, int64(3), stats.WorkspaceTxBytes)
 		require.Equal(t, int64(4), stats.WorkspaceRxBytes)
-		require.Equal(t, int64(0), stats.SessionCountVSCode)
-		require.Equal(t, int64(0), stats.SessionCountSSH)
-		require.Equal(t, int64(0), stats.SessionCountReconnectingPTY)
-		require.Equal(t, int64(0), stats.SessionCountJetBrains)
+		require.Equal(t, int64(0), sessionFamilyCounts(t, stats.SessionCounts)["vscode"])
+		require.Equal(t, int64(0), sessionFamilyCounts(t, stats.SessionCounts)["ssh"])
+		require.Equal(t, int64(0), sessionFamilyCounts(t, stats.SessionCounts)["reconnecting_pty"])
+		require.Equal(t, int64(0), sessionFamilyCounts(t, stats.SessionCounts)["jetbrains"])
 	})
 }
 
@@ -939,11 +999,7 @@ func TestGetWorkspaceAgentUsageStats(t *testing.T) {
 		})
 
 		reqTime := dbtime.Now().Add(-time.Hour)
-		appFamilies := codersdk.SessionCountAppFamiliesJSON()
-		stats, err := db.GetWorkspaceAgentUsageStats(ctx, database.GetWorkspaceAgentUsageStatsParams{
-			CreatedAt:   reqTime,
-			AppFamilies: appFamilies,
-		})
+		stats, err := db.GetWorkspaceAgentUsageStats(ctx, reqTime)
 		require.NoError(t, err)
 
 		ws1Stats, ws2Stats := stats[0], stats[1]
@@ -952,17 +1008,17 @@ func TestGetWorkspaceAgentUsageStats(t *testing.T) {
 		}
 		require.Equal(t, int64(3), ws1Stats.WorkspaceTxBytes)
 		require.Equal(t, int64(3), ws1Stats.WorkspaceRxBytes)
-		require.Equal(t, int64(1), ws1Stats.SessionCountVSCode)
-		require.Equal(t, int64(1), ws1Stats.SessionCountJetBrains)
-		require.Equal(t, int64(0), ws1Stats.SessionCountSSH)
-		require.Equal(t, int64(0), ws1Stats.SessionCountReconnectingPTY)
+		require.Equal(t, int64(1), sessionFamilyCounts(t, ws1Stats.SessionCounts)["vscode"])
+		require.Equal(t, int64(1), sessionFamilyCounts(t, ws1Stats.SessionCounts)["jetbrains"])
+		require.Equal(t, int64(0), sessionFamilyCounts(t, ws1Stats.SessionCounts)["ssh"])
+		require.Equal(t, int64(0), sessionFamilyCounts(t, ws1Stats.SessionCounts)["reconnecting_pty"])
 
 		require.Equal(t, int64(6), ws2Stats.WorkspaceTxBytes)
 		require.Equal(t, int64(11), ws2Stats.WorkspaceRxBytes)
-		require.Equal(t, int64(1), ws2Stats.SessionCountSSH)
-		require.Equal(t, int64(1), ws2Stats.SessionCountJetBrains)
-		require.Equal(t, int64(0), ws2Stats.SessionCountVSCode)
-		require.Equal(t, int64(0), ws2Stats.SessionCountReconnectingPTY)
+		require.Equal(t, int64(1), sessionFamilyCounts(t, ws2Stats.SessionCounts)["ssh"])
+		require.Equal(t, int64(1), sessionFamilyCounts(t, ws2Stats.SessionCounts)["jetbrains"])
+		require.Equal(t, int64(0), sessionFamilyCounts(t, ws2Stats.SessionCounts)["vscode"])
+		require.Equal(t, int64(0), sessionFamilyCounts(t, ws2Stats.SessionCounts)["reconnecting_pty"])
 	})
 
 	t.Run("NoUsage", func(t *testing.T) {
@@ -986,20 +1042,16 @@ func TestGetWorkspaceAgentUsageStats(t *testing.T) {
 			SessionCounts:             dbgen.SessionCounts(t, map[string]int64{"ssh": 3, "vscode": 1}), // Should be ignored.
 		})
 
-		appFamilies := codersdk.SessionCountAppFamiliesJSON()
-		stats, err := db.GetWorkspaceAgentUsageStats(ctx, database.GetWorkspaceAgentUsageStatsParams{
-			CreatedAt:   dbtime.Now().Add(-time.Hour),
-			AppFamilies: appFamilies,
-		})
+		stats, err := db.GetWorkspaceAgentUsageStats(ctx, dbtime.Now().Add(-time.Hour))
 		require.NoError(t, err)
 
 		require.Len(t, stats, 1)
 		require.Equal(t, int64(3), stats[0].WorkspaceTxBytes)
 		require.Equal(t, int64(4), stats[0].WorkspaceRxBytes)
-		require.Equal(t, int64(0), stats[0].SessionCountVSCode)
-		require.Equal(t, int64(0), stats[0].SessionCountSSH)
-		require.Equal(t, int64(0), stats[0].SessionCountReconnectingPTY)
-		require.Equal(t, int64(0), stats[0].SessionCountJetBrains)
+		require.Equal(t, int64(0), sessionFamilyCounts(t, stats[0].SessionCounts)["vscode"])
+		require.Equal(t, int64(0), sessionFamilyCounts(t, stats[0].SessionCounts)["ssh"])
+		require.Equal(t, int64(0), sessionFamilyCounts(t, stats[0].SessionCounts)["reconnecting_pty"])
+		require.Equal(t, int64(0), sessionFamilyCounts(t, stats[0].SessionCounts)["jetbrains"])
 	})
 }
 
@@ -1225,23 +1277,18 @@ func TestGetWorkspaceAgentUsageStatsAndLabels(t *testing.T) {
 			SessionCounts: dbgen.SessionCounts(t, map[string]int64{"ssh": 1}),
 		})
 
-		appFamilies := codersdk.SessionCountAppFamiliesJSON()
-		stats, err := db.GetWorkspaceAgentUsageStatsAndLabels(ctx, database.GetWorkspaceAgentUsageStatsAndLabelsParams{
-			CreatedAt:   insertTime.Add(-time.Hour),
-			AppFamilies: appFamilies,
-		})
+		stats, err := db.GetWorkspaceAgentUsageStatsAndLabels(ctx, insertTime.Add(-time.Hour))
 		require.NoError(t, err)
 
 		require.Len(t, stats, 2)
 		require.Contains(t, stats, database.GetWorkspaceAgentUsageStatsAndLabelsRow{
-			Username:                    user1.Username,
-			AgentName:                   agent1.Name,
-			WorkspaceName:               workspace1.Name,
-			TxBytes:                     3,
-			RxBytes:                     3,
-			SessionCountJetBrains:       1,
-			SessionCountReconnectingPTY: 1,
-			ConnectionMedianLatencyMS:   1,
+			Username:                  user1.Username,
+			AgentName:                 agent1.Name,
+			WorkspaceName:             workspace1.Name,
+			TxBytes:                   3,
+			RxBytes:                   3,
+			SessionCounts:             json.RawMessage(`{"jetbrains": 1, "reconnecting_pty": 1}`),
+			ConnectionMedianLatencyMS: 1,
 		})
 
 		require.Contains(t, stats, database.GetWorkspaceAgentUsageStatsAndLabelsRow{
@@ -1250,8 +1297,7 @@ func TestGetWorkspaceAgentUsageStatsAndLabels(t *testing.T) {
 			WorkspaceName:             workspace2.Name,
 			RxBytes:                   8,
 			TxBytes:                   4,
-			SessionCountVSCode:        1,
-			SessionCountSSH:           1,
+			SessionCounts:             json.RawMessage(`{"ssh": 1, "vscode": 1}`),
 			ConnectionMedianLatencyMS: 1,
 		})
 	})
@@ -1296,11 +1342,7 @@ func TestGetWorkspaceAgentUsageStatsAndLabels(t *testing.T) {
 			SessionCounts:             dbgen.SessionCounts(t, map[string]int64{"vscode": 3, "ssh": 1}), // Should be ignored.
 		})
 
-		appFamilies := codersdk.SessionCountAppFamiliesJSON()
-		stats, err := db.GetWorkspaceAgentUsageStatsAndLabels(ctx, database.GetWorkspaceAgentUsageStatsAndLabelsParams{
-			CreatedAt:   insertTime.Add(-time.Hour),
-			AppFamilies: appFamilies,
-		})
+		stats, err := db.GetWorkspaceAgentUsageStatsAndLabels(ctx, insertTime.Add(-time.Hour))
 		require.NoError(t, err)
 
 		require.Len(t, stats, 1)
@@ -1310,6 +1352,7 @@ func TestGetWorkspaceAgentUsageStatsAndLabels(t *testing.T) {
 			WorkspaceName:             workspace.Name,
 			RxBytes:                   4,
 			TxBytes:                   5,
+			SessionCounts:             json.RawMessage(`{}`),
 			ConnectionMedianLatencyMS: 1,
 		})
 	})
@@ -19992,15 +20035,12 @@ func TestSessionCountsAttributeByFamily(t *testing.T) {
 	appFamilies := codersdk.SessionCountAppFamiliesJSON()
 
 	// A VS Code fork counts as VS Code, and Zed counts as SSH.
-	stats, err := db.GetDeploymentWorkspaceAgentStats(ctx, database.GetDeploymentWorkspaceAgentStatsParams{
-		CreatedAt:   dbtime.Now().Add(-time.Hour),
-		AppFamilies: appFamilies,
-	})
+	stats, err := db.GetDeploymentWorkspaceAgentStats(ctx, dbtime.Now().Add(-time.Hour))
 	require.NoError(t, err)
-	require.Equal(t, int64(2), stats.SessionCountVSCode)
-	require.Equal(t, int64(1), stats.SessionCountSSH)
-	require.Zero(t, stats.SessionCountJetBrains)
-	require.Zero(t, stats.SessionCountReconnectingPTY)
+	require.Equal(t, int64(2), sessionFamilyCounts(t, stats.SessionCounts)["vscode"])
+	require.Equal(t, int64(1), sessionFamilyCounts(t, stats.SessionCounts)["ssh"])
+	require.Zero(t, sessionFamilyCounts(t, stats.SessionCounts)["jetbrains"])
+	require.Zero(t, sessionFamilyCounts(t, stats.SessionCounts)["reconnecting_pty"])
 
 	insights, err := db.GetTemplateInsightsByTemplate(ctx, database.GetTemplateInsightsByTemplateParams{
 		StartTime:   dbtime.Now().Add(-time.Hour),
@@ -20099,4 +20139,11 @@ func TestUpsertTemplateUsageStatsAttributesSessionCountsByFamily(t *testing.T) {
 	require.Zero(t, unknown.SshMins)
 	require.Zero(t, unknown.JetbrainsMins)
 	require.Zero(t, unknown.ReconnectingPtyMins)
+}
+
+func sessionFamilyCounts(t *testing.T, data json.RawMessage) map[codersdk.AppFamilyName]int64 {
+	t.Helper()
+	counts, err := codersdk.SessionCountsByFamilyJSON(data)
+	require.NoError(t, err)
+	return counts
 }

--- a/coderd/database/queries.sql.go
+++ b/coderd/database/queries.sql.go
@@ -36156,34 +36156,14 @@ WITH agent_stats AS (
 ), latest_stats AS (
 	SELECT id, created_at, user_id, agent_id, workspace_id, template_id, connections_by_proto, connection_count, rx_packets, rx_bytes, tx_packets, tx_bytes, connection_median_latency_ms, usage, session_counts, ROW_NUMBER() OVER(PARTITION BY agent_id ORDER BY created_at DESC) AS rn
 	FROM workspace_agent_stats WHERE created_at > $1
-), latest_sessions AS (
-	-- Two levels: the inner query sums each app name on the latest row per
-	-- agent, the outer one folds those sums back into a single jsonb object.
-	-- rn = 1 leaves one row per agent, so grouping by agent_id alone matches
-	-- the per-agent grouping of agent_stats above.
+), latest_agent_stats AS (
+	-- rn = 1 leaves one row per agent, and that row's session_counts is
+	-- already the object this query reports, empty map included.
 	SELECT
 		agent_id,
-		coalesce(jsonb_object_agg(app_name, app_sessions), '{}'::jsonb)::jsonb AS session_counts
-	FROM (
-		SELECT
-			a.agent_id,
-			sess.app_name,
-			SUM(sess.sessions::bigint) AS app_sessions
-		FROM latest_stats AS a, jsonb_each_text(a.session_counts) AS sess(app_name, sessions)
-		WHERE a.rn = 1
-		GROUP BY a.agent_id, sess.app_name
-	) AS app_totals
-	GROUP BY agent_id
-), latest_agent_stats AS (
-	-- Joined rather than selected from latest_sessions so an agent whose
-	-- latest row reports no sessions at all keeps its row here.
-	SELECT
-		a.agent_id,
-		coalesce(latest_sessions.session_counts, '{}'::jsonb)::jsonb AS session_counts
-	FROM latest_stats AS a
-	LEFT JOIN latest_sessions ON latest_sessions.agent_id = a.agent_id
-	WHERE a.rn = 1
-	GROUP BY a.user_id, a.agent_id, a.workspace_id, a.template_id, latest_sessions.session_counts
+		session_counts
+	FROM latest_stats
+	WHERE rn = 1
 )
 SELECT user_id, agent_stats.agent_id, workspace_id, template_id, aggregated_from, workspace_rx_bytes, workspace_tx_bytes, workspace_connection_latency_50, workspace_connection_latency_95, latest_agent_stats.agent_id, session_counts FROM agent_stats JOIN latest_agent_stats ON agent_stats.agent_id = latest_agent_stats.agent_id
 `
@@ -36253,32 +36233,16 @@ WITH agent_stats AS (
 	FROM workspace_agent_stats
 	-- The greater than 0 is to support legacy agents that don't report connection_median_latency_ms.
 	WHERE created_at > $1 AND connection_median_latency_ms > 0
-), latest_sessions AS (
-	-- Summed per app name here so the connection aggregates below keep seeing
-	-- one row per agent instead of one row per app name.
+), latest_agent_stats AS (
+	-- rn = 1 leaves one row per agent, so the session object, connection
+	-- count, and latency are that row's own columns, empty map included.
 	SELECT
 		agent_id,
-		coalesce(jsonb_object_agg(app_name, app_sessions), '{}'::jsonb)::jsonb AS session_counts
-	FROM (
-		SELECT
-			a.agent_id,
-			sess.app_name,
-			SUM(sess.sessions::bigint) AS app_sessions
-		FROM latest_stats AS a, jsonb_each_text(a.session_counts) AS sess(app_name, sessions)
-		WHERE a.rn = 1
-		GROUP BY a.agent_id, sess.app_name
-	) AS app_totals
-	GROUP BY agent_id
-), latest_agent_stats AS (
-	SELECT
-		a.agent_id,
-		coalesce(latest_sessions.session_counts, '{}'::jsonb)::jsonb AS session_counts,
-		coalesce(SUM(a.connection_count), 0)::bigint AS connection_count,
-		coalesce(MAX(a.connection_median_latency_ms), 0)::float AS connection_median_latency_ms
-	FROM latest_stats AS a
-	LEFT JOIN latest_sessions ON latest_sessions.agent_id = a.agent_id
-	WHERE a.rn = 1
-	GROUP BY a.user_id, a.agent_id, a.workspace_id, latest_sessions.session_counts
+		session_counts,
+		connection_count,
+		connection_median_latency_ms
+	FROM latest_stats
+	WHERE rn = 1
 )
 SELECT
 	users.username, workspace_agents.name AS agent_name, workspaces.name AS workspace_name, rx_bytes, tx_bytes,

--- a/coderd/database/queries.sql.go
+++ b/coderd/database/queries.sql.go
@@ -36006,13 +36006,7 @@ func (q *sqlQuerier) DeleteOldWorkspaceAgentStats(ctx context.Context) error {
 }
 
 const getDeploymentWorkspaceAgentStats = `-- name: GetDeploymentWorkspaceAgentStats :one
-WITH fams AS (
-	SELECT
-		ARRAY(SELECT jsonb_array_elements_text($2::jsonb -> 'vscode')) AS vscode,
-		ARRAY(SELECT jsonb_array_elements_text($2::jsonb -> 'ssh')) AS ssh,
-		ARRAY(SELECT jsonb_array_elements_text($2::jsonb -> 'jetbrains')) AS jetbrains,
-		ARRAY(SELECT jsonb_array_elements_text($2::jsonb -> 'reconnecting_pty')) AS reconnecting_pty
-), stats AS (
+WITH stats AS (
 	SELECT
 		agent_id,
 		created_at,
@@ -36030,71 +36024,49 @@ SELECT
 	-- The greater than 0 is to support legacy agents that don't report connection_median_latency_ms.
 	coalesce((PERCENTILE_CONT(0.5) WITHIN GROUP (ORDER BY connection_median_latency_ms) FILTER (WHERE connection_median_latency_ms > 0)), -1)::FLOAT AS workspace_connection_latency_50,
 	coalesce((PERCENTILE_CONT(0.95) WITHIN GROUP (ORDER BY connection_median_latency_ms) FILTER (WHERE connection_median_latency_ms > 0)), -1)::FLOAT AS workspace_connection_latency_95,
-	coalesce(SUM(sc.vscode) FILTER (WHERE rn = 1), 0)::bigint AS session_count_vscode,
-	coalesce(SUM(sc.ssh) FILTER (WHERE rn = 1), 0)::bigint AS session_count_ssh,
-	coalesce(SUM(sc.jetbrains) FILTER (WHERE rn = 1), 0)::bigint AS session_count_jetbrains,
-	coalesce(SUM(sc.reconnecting_pty) FILTER (WHERE rn = 1), 0)::bigint AS session_count_reconnecting_pty
+	coalesce((
+		SELECT
+			jsonb_object_agg(app_name, app_sessions)
+		FROM (
+			SELECT
+				sess.app_name,
+				SUM(sess.sessions::bigint) AS app_sessions
+			FROM stats, jsonb_each_text(stats.session_counts) AS sess(app_name, sessions)
+			-- Only the latest row per agent holds current sessions.
+			WHERE stats.rn = 1
+			GROUP BY sess.app_name
+		) AS app_totals
+	), '{}'::jsonb)::jsonb AS session_counts
 FROM stats
-CROSS JOIN LATERAL (
-	SELECT
-		coalesce(SUM(sess.value::bigint) FILTER (WHERE sess.key = ANY (fams.vscode)), 0) AS vscode,
-		coalesce(SUM(sess.value::bigint) FILTER (WHERE sess.key = ANY (fams.ssh)), 0) AS ssh,
-		coalesce(SUM(sess.value::bigint) FILTER (WHERE sess.key = ANY (fams.jetbrains)), 0) AS jetbrains,
-		coalesce(SUM(sess.value::bigint) FILTER (WHERE sess.key = ANY (fams.reconnecting_pty)), 0) AS reconnecting_pty
-	FROM fams, jsonb_each_text(stats.session_counts) AS sess
-	-- Gate on the same condition as the aggregate filters above so the
-	-- decompose runs only for the rows that are counted (one-time filter).
-	WHERE stats.rn = 1
-) AS sc
 `
 
-type GetDeploymentWorkspaceAgentStatsParams struct {
-	CreatedAt   time.Time       `db:"created_at" json:"created_at"`
-	AppFamilies json.RawMessage `db:"app_families" json:"app_families"`
-}
-
 type GetDeploymentWorkspaceAgentStatsRow struct {
-	WorkspaceRxBytes             int64   `db:"workspace_rx_bytes" json:"workspace_rx_bytes"`
-	WorkspaceTxBytes             int64   `db:"workspace_tx_bytes" json:"workspace_tx_bytes"`
-	WorkspaceConnectionLatency50 float64 `db:"workspace_connection_latency_50" json:"workspace_connection_latency_50"`
-	WorkspaceConnectionLatency95 float64 `db:"workspace_connection_latency_95" json:"workspace_connection_latency_95"`
-	SessionCountVSCode           int64   `db:"session_count_vscode" json:"session_count_vscode"`
-	SessionCountSSH              int64   `db:"session_count_ssh" json:"session_count_ssh"`
-	SessionCountJetBrains        int64   `db:"session_count_jetbrains" json:"session_count_jetbrains"`
-	SessionCountReconnectingPTY  int64   `db:"session_count_reconnecting_pty" json:"session_count_reconnecting_pty"`
+	WorkspaceRxBytes             int64           `db:"workspace_rx_bytes" json:"workspace_rx_bytes"`
+	WorkspaceTxBytes             int64           `db:"workspace_tx_bytes" json:"workspace_tx_bytes"`
+	WorkspaceConnectionLatency50 float64         `db:"workspace_connection_latency_50" json:"workspace_connection_latency_50"`
+	WorkspaceConnectionLatency95 float64         `db:"workspace_connection_latency_95" json:"workspace_connection_latency_95"`
+	SessionCounts                json.RawMessage `db:"session_counts" json:"session_counts"`
 }
 
-// app_families maps each attributed family to its app names, so the probes
-// below stay one expression per family: adding a family needs a new list in
-// fams plus one probe here, because sqlc output columns are static.
-// fams turns the jsonb parameter into arrays once for the whole query. The
-// lateral decomposes session_counts once per row and sums each family from
-// that single pass, which measured ~3x faster than probing the jsonb once
-// per family. The subplan only runs for rows that survive the gate.
-func (q *sqlQuerier) GetDeploymentWorkspaceAgentStats(ctx context.Context, arg GetDeploymentWorkspaceAgentStatsParams) (GetDeploymentWorkspaceAgentStatsRow, error) {
-	row := q.db.QueryRowContext(ctx, getDeploymentWorkspaceAgentStats, arg.CreatedAt, arg.AppFamilies)
+// The session count sum runs in its own subquery: decomposing session_counts
+// in the FROM clause would emit one row per app name and multiply the byte and
+// latency aggregates below. Summing per app name and folding the names into
+// families in Go keeps a session reported under a new name counted.
+func (q *sqlQuerier) GetDeploymentWorkspaceAgentStats(ctx context.Context, createdAt time.Time) (GetDeploymentWorkspaceAgentStatsRow, error) {
+	row := q.db.QueryRowContext(ctx, getDeploymentWorkspaceAgentStats, createdAt)
 	var i GetDeploymentWorkspaceAgentStatsRow
 	err := row.Scan(
 		&i.WorkspaceRxBytes,
 		&i.WorkspaceTxBytes,
 		&i.WorkspaceConnectionLatency50,
 		&i.WorkspaceConnectionLatency95,
-		&i.SessionCountVSCode,
-		&i.SessionCountSSH,
-		&i.SessionCountJetBrains,
-		&i.SessionCountReconnectingPTY,
+		&i.SessionCounts,
 	)
 	return i, err
 }
 
 const getDeploymentWorkspaceAgentUsageStats = `-- name: GetDeploymentWorkspaceAgentUsageStats :one
-WITH fams AS (
-	SELECT
-		ARRAY(SELECT jsonb_array_elements_text($2::jsonb -> 'vscode')) AS vscode,
-		ARRAY(SELECT jsonb_array_elements_text($2::jsonb -> 'ssh')) AS ssh,
-		ARRAY(SELECT jsonb_array_elements_text($2::jsonb -> 'jetbrains')) AS jetbrains,
-		ARRAY(SELECT jsonb_array_elements_text($2::jsonb -> 'reconnecting_pty')) AS reconnecting_pty
-), agent_stats AS (
+WITH agent_stats AS (
 	SELECT
 		coalesce(SUM(rx_bytes), 0)::bigint AS workspace_rx_bytes,
 		coalesce(SUM(tx_bytes), 0)::bigint AS workspace_tx_bytes,
@@ -36119,73 +36091,54 @@ latest_minutes AS (
 		agent_id
 ),
 latest_agent_stats AS (
+	-- Aggregating the per app name sums separately keeps the byte and latency
+	-- aggregates in agent_stats free of the decomposed rows.
 	SELECT
-		coalesce(SUM(sc.vscode), 0)::bigint AS session_count_vscode,
-		coalesce(SUM(sc.ssh), 0)::bigint AS session_count_ssh,
-		coalesce(SUM(sc.jetbrains), 0)::bigint AS session_count_jetbrains,
-		coalesce(SUM(sc.reconnecting_pty), 0)::bigint AS session_count_reconnecting_pty
-	FROM
-		latest_minutes
-	JOIN
-		workspace_agent_stats AS stats
-	ON
-		stats.agent_id = latest_minutes.agent_id
-		AND stats.created_at >= $1
-		AND stats.created_at >= latest_minutes.minute_bucket
-		AND stats.created_at < latest_minutes.minute_bucket + '1 minute'::interval
-		AND stats.usage
-	CROSS JOIN LATERAL (
+		coalesce(jsonb_object_agg(app_name, app_sessions), '{}'::jsonb)::jsonb AS session_counts
+	FROM (
 		SELECT
-			coalesce(SUM(sess.value::bigint) FILTER (WHERE sess.key = ANY (fams.vscode)), 0) AS vscode,
-			coalesce(SUM(sess.value::bigint) FILTER (WHERE sess.key = ANY (fams.ssh)), 0) AS ssh,
-			coalesce(SUM(sess.value::bigint) FILTER (WHERE sess.key = ANY (fams.jetbrains)), 0) AS jetbrains,
-			coalesce(SUM(sess.value::bigint) FILTER (WHERE sess.key = ANY (fams.reconnecting_pty)), 0) AS reconnecting_pty
-		FROM fams, jsonb_each_text(stats.session_counts) AS sess
-	) AS sc
+			sess.app_name,
+			SUM(sess.sessions::bigint) AS app_sessions
+		FROM
+			latest_minutes
+		JOIN
+			workspace_agent_stats AS stats
+		ON
+			stats.agent_id = latest_minutes.agent_id
+			AND stats.created_at >= $1
+			AND stats.created_at >= latest_minutes.minute_bucket
+			AND stats.created_at < latest_minutes.minute_bucket + '1 minute'::interval
+			AND stats.usage,
+			jsonb_each_text(stats.session_counts) AS sess(app_name, sessions)
+		GROUP BY sess.app_name
+	) AS app_totals
 )
-SELECT workspace_rx_bytes, workspace_tx_bytes, workspace_connection_latency_50, workspace_connection_latency_95, session_count_vscode, session_count_ssh, session_count_jetbrains, session_count_reconnecting_pty FROM agent_stats, latest_agent_stats
+SELECT workspace_rx_bytes, workspace_tx_bytes, workspace_connection_latency_50, workspace_connection_latency_95, session_counts FROM agent_stats, latest_agent_stats
 `
 
-type GetDeploymentWorkspaceAgentUsageStatsParams struct {
-	CreatedAt   time.Time       `db:"created_at" json:"created_at"`
-	AppFamilies json.RawMessage `db:"app_families" json:"app_families"`
-}
-
 type GetDeploymentWorkspaceAgentUsageStatsRow struct {
-	WorkspaceRxBytes             int64   `db:"workspace_rx_bytes" json:"workspace_rx_bytes"`
-	WorkspaceTxBytes             int64   `db:"workspace_tx_bytes" json:"workspace_tx_bytes"`
-	WorkspaceConnectionLatency50 float64 `db:"workspace_connection_latency_50" json:"workspace_connection_latency_50"`
-	WorkspaceConnectionLatency95 float64 `db:"workspace_connection_latency_95" json:"workspace_connection_latency_95"`
-	SessionCountVSCode           int64   `db:"session_count_vscode" json:"session_count_vscode"`
-	SessionCountSSH              int64   `db:"session_count_ssh" json:"session_count_ssh"`
-	SessionCountJetBrains        int64   `db:"session_count_jetbrains" json:"session_count_jetbrains"`
-	SessionCountReconnectingPTY  int64   `db:"session_count_reconnecting_pty" json:"session_count_reconnecting_pty"`
+	WorkspaceRxBytes             int64           `db:"workspace_rx_bytes" json:"workspace_rx_bytes"`
+	WorkspaceTxBytes             int64           `db:"workspace_tx_bytes" json:"workspace_tx_bytes"`
+	WorkspaceConnectionLatency50 float64         `db:"workspace_connection_latency_50" json:"workspace_connection_latency_50"`
+	WorkspaceConnectionLatency95 float64         `db:"workspace_connection_latency_95" json:"workspace_connection_latency_95"`
+	SessionCounts                json.RawMessage `db:"session_counts" json:"session_counts"`
 }
 
-func (q *sqlQuerier) GetDeploymentWorkspaceAgentUsageStats(ctx context.Context, arg GetDeploymentWorkspaceAgentUsageStatsParams) (GetDeploymentWorkspaceAgentUsageStatsRow, error) {
-	row := q.db.QueryRowContext(ctx, getDeploymentWorkspaceAgentUsageStats, arg.CreatedAt, arg.AppFamilies)
+func (q *sqlQuerier) GetDeploymentWorkspaceAgentUsageStats(ctx context.Context, createdAt time.Time) (GetDeploymentWorkspaceAgentUsageStatsRow, error) {
+	row := q.db.QueryRowContext(ctx, getDeploymentWorkspaceAgentUsageStats, createdAt)
 	var i GetDeploymentWorkspaceAgentUsageStatsRow
 	err := row.Scan(
 		&i.WorkspaceRxBytes,
 		&i.WorkspaceTxBytes,
 		&i.WorkspaceConnectionLatency50,
 		&i.WorkspaceConnectionLatency95,
-		&i.SessionCountVSCode,
-		&i.SessionCountSSH,
-		&i.SessionCountJetBrains,
-		&i.SessionCountReconnectingPTY,
+		&i.SessionCounts,
 	)
 	return i, err
 }
 
 const getWorkspaceAgentStats = `-- name: GetWorkspaceAgentStats :many
-WITH fams AS (
-	SELECT
-		ARRAY(SELECT jsonb_array_elements_text($2::jsonb -> 'vscode')) AS vscode,
-		ARRAY(SELECT jsonb_array_elements_text($2::jsonb -> 'ssh')) AS ssh,
-		ARRAY(SELECT jsonb_array_elements_text($2::jsonb -> 'jetbrains')) AS jetbrains,
-		ARRAY(SELECT jsonb_array_elements_text($2::jsonb -> 'reconnecting_pty')) AS reconnecting_pty
-), agent_stats AS (
+WITH agent_stats AS (
 	SELECT
 		user_id,
 		agent_id,
@@ -36200,55 +36153,57 @@ WITH fams AS (
 	-- The greater than 0 is to support legacy agents that don't report connection_median_latency_ms.
 	WHERE workspace_agent_stats.created_at > $1 AND connection_median_latency_ms > 0
 	GROUP BY user_id, agent_id, workspace_id, template_id
+), latest_stats AS (
+	SELECT id, created_at, user_id, agent_id, workspace_id, template_id, connections_by_proto, connection_count, rx_packets, rx_bytes, tx_packets, tx_bytes, connection_median_latency_ms, usage, session_counts, ROW_NUMBER() OVER(PARTITION BY agent_id ORDER BY created_at DESC) AS rn
+	FROM workspace_agent_stats WHERE created_at > $1
+), latest_sessions AS (
+	-- Two levels: the inner query sums each app name on the latest row per
+	-- agent, the outer one folds those sums back into a single jsonb object.
+	-- rn = 1 leaves one row per agent, so grouping by agent_id alone matches
+	-- the per-agent grouping of agent_stats above.
+	SELECT
+		agent_id,
+		coalesce(jsonb_object_agg(app_name, app_sessions), '{}'::jsonb)::jsonb AS session_counts
+	FROM (
+		SELECT
+			a.agent_id,
+			sess.app_name,
+			SUM(sess.sessions::bigint) AS app_sessions
+		FROM latest_stats AS a, jsonb_each_text(a.session_counts) AS sess(app_name, sessions)
+		WHERE a.rn = 1
+		GROUP BY a.agent_id, sess.app_name
+	) AS app_totals
+	GROUP BY agent_id
 ), latest_agent_stats AS (
+	-- Joined rather than selected from latest_sessions so an agent whose
+	-- latest row reports no sessions at all keeps its row here.
 	SELECT
 		a.agent_id,
-		coalesce(SUM(sc.vscode), 0)::bigint AS session_count_vscode,
-		coalesce(SUM(sc.ssh), 0)::bigint AS session_count_ssh,
-		coalesce(SUM(sc.jetbrains), 0)::bigint AS session_count_jetbrains,
-		coalesce(SUM(sc.reconnecting_pty), 0)::bigint AS session_count_reconnecting_pty
-	 FROM (
-		SELECT id, created_at, user_id, agent_id, workspace_id, template_id, connections_by_proto, connection_count, rx_packets, rx_bytes, tx_packets, tx_bytes, connection_median_latency_ms, usage, session_counts, ROW_NUMBER() OVER(PARTITION BY agent_id ORDER BY created_at DESC) AS rn
-		FROM workspace_agent_stats WHERE created_at > $1
-	) AS a
-	CROSS JOIN LATERAL (
-		SELECT
-			coalesce(SUM(sess.value::bigint) FILTER (WHERE sess.key = ANY (fams.vscode)), 0) AS vscode,
-			coalesce(SUM(sess.value::bigint) FILTER (WHERE sess.key = ANY (fams.ssh)), 0) AS ssh,
-			coalesce(SUM(sess.value::bigint) FILTER (WHERE sess.key = ANY (fams.jetbrains)), 0) AS jetbrains,
-			coalesce(SUM(sess.value::bigint) FILTER (WHERE sess.key = ANY (fams.reconnecting_pty)), 0) AS reconnecting_pty
-		FROM fams, jsonb_each_text(a.session_counts) AS sess
-	) AS sc
+		coalesce(latest_sessions.session_counts, '{}'::jsonb)::jsonb AS session_counts
+	FROM latest_stats AS a
+	LEFT JOIN latest_sessions ON latest_sessions.agent_id = a.agent_id
 	WHERE a.rn = 1
-	GROUP BY a.user_id, a.agent_id, a.workspace_id, a.template_id
+	GROUP BY a.user_id, a.agent_id, a.workspace_id, a.template_id, latest_sessions.session_counts
 )
-SELECT user_id, agent_stats.agent_id, workspace_id, template_id, aggregated_from, workspace_rx_bytes, workspace_tx_bytes, workspace_connection_latency_50, workspace_connection_latency_95, latest_agent_stats.agent_id, session_count_vscode, session_count_ssh, session_count_jetbrains, session_count_reconnecting_pty FROM agent_stats JOIN latest_agent_stats ON agent_stats.agent_id = latest_agent_stats.agent_id
+SELECT user_id, agent_stats.agent_id, workspace_id, template_id, aggregated_from, workspace_rx_bytes, workspace_tx_bytes, workspace_connection_latency_50, workspace_connection_latency_95, latest_agent_stats.agent_id, session_counts FROM agent_stats JOIN latest_agent_stats ON agent_stats.agent_id = latest_agent_stats.agent_id
 `
 
-type GetWorkspaceAgentStatsParams struct {
-	CreatedAt   time.Time       `db:"created_at" json:"created_at"`
-	AppFamilies json.RawMessage `db:"app_families" json:"app_families"`
-}
-
 type GetWorkspaceAgentStatsRow struct {
-	UserID                       uuid.UUID `db:"user_id" json:"user_id"`
-	AgentID                      uuid.UUID `db:"agent_id" json:"agent_id"`
-	WorkspaceID                  uuid.UUID `db:"workspace_id" json:"workspace_id"`
-	TemplateID                   uuid.UUID `db:"template_id" json:"template_id"`
-	AggregatedFrom               time.Time `db:"aggregated_from" json:"aggregated_from"`
-	WorkspaceRxBytes             int64     `db:"workspace_rx_bytes" json:"workspace_rx_bytes"`
-	WorkspaceTxBytes             int64     `db:"workspace_tx_bytes" json:"workspace_tx_bytes"`
-	WorkspaceConnectionLatency50 float64   `db:"workspace_connection_latency_50" json:"workspace_connection_latency_50"`
-	WorkspaceConnectionLatency95 float64   `db:"workspace_connection_latency_95" json:"workspace_connection_latency_95"`
-	AgentID_2                    uuid.UUID `db:"agent_id_2" json:"agent_id_2"`
-	SessionCountVSCode           int64     `db:"session_count_vscode" json:"session_count_vscode"`
-	SessionCountSSH              int64     `db:"session_count_ssh" json:"session_count_ssh"`
-	SessionCountJetBrains        int64     `db:"session_count_jetbrains" json:"session_count_jetbrains"`
-	SessionCountReconnectingPTY  int64     `db:"session_count_reconnecting_pty" json:"session_count_reconnecting_pty"`
+	UserID                       uuid.UUID       `db:"user_id" json:"user_id"`
+	AgentID                      uuid.UUID       `db:"agent_id" json:"agent_id"`
+	WorkspaceID                  uuid.UUID       `db:"workspace_id" json:"workspace_id"`
+	TemplateID                   uuid.UUID       `db:"template_id" json:"template_id"`
+	AggregatedFrom               time.Time       `db:"aggregated_from" json:"aggregated_from"`
+	WorkspaceRxBytes             int64           `db:"workspace_rx_bytes" json:"workspace_rx_bytes"`
+	WorkspaceTxBytes             int64           `db:"workspace_tx_bytes" json:"workspace_tx_bytes"`
+	WorkspaceConnectionLatency50 float64         `db:"workspace_connection_latency_50" json:"workspace_connection_latency_50"`
+	WorkspaceConnectionLatency95 float64         `db:"workspace_connection_latency_95" json:"workspace_connection_latency_95"`
+	AgentID_2                    uuid.UUID       `db:"agent_id_2" json:"agent_id_2"`
+	SessionCounts                json.RawMessage `db:"session_counts" json:"session_counts"`
 }
 
-func (q *sqlQuerier) GetWorkspaceAgentStats(ctx context.Context, arg GetWorkspaceAgentStatsParams) ([]GetWorkspaceAgentStatsRow, error) {
-	rows, err := q.db.QueryContext(ctx, getWorkspaceAgentStats, arg.CreatedAt, arg.AppFamilies)
+func (q *sqlQuerier) GetWorkspaceAgentStats(ctx context.Context, createdAt time.Time) ([]GetWorkspaceAgentStatsRow, error) {
+	rows, err := q.db.QueryContext(ctx, getWorkspaceAgentStats, createdAt)
 	if err != nil {
 		return nil, err
 	}
@@ -36267,10 +36222,7 @@ func (q *sqlQuerier) GetWorkspaceAgentStats(ctx context.Context, arg GetWorkspac
 			&i.WorkspaceConnectionLatency50,
 			&i.WorkspaceConnectionLatency95,
 			&i.AgentID_2,
-			&i.SessionCountVSCode,
-			&i.SessionCountSSH,
-			&i.SessionCountJetBrains,
-			&i.SessionCountReconnectingPTY,
+			&i.SessionCounts,
 		); err != nil {
 			return nil, err
 		}
@@ -36286,13 +36238,7 @@ func (q *sqlQuerier) GetWorkspaceAgentStats(ctx context.Context, arg GetWorkspac
 }
 
 const getWorkspaceAgentStatsAndLabels = `-- name: GetWorkspaceAgentStatsAndLabels :many
-WITH fams AS (
-	SELECT
-		ARRAY(SELECT jsonb_array_elements_text($2::jsonb -> 'vscode')) AS vscode,
-		ARRAY(SELECT jsonb_array_elements_text($2::jsonb -> 'ssh')) AS ssh,
-		ARRAY(SELECT jsonb_array_elements_text($2::jsonb -> 'jetbrains')) AS jetbrains,
-		ARRAY(SELECT jsonb_array_elements_text($2::jsonb -> 'reconnecting_pty')) AS reconnecting_pty
-), agent_stats AS (
+WITH agent_stats AS (
 	SELECT
 		user_id,
 		agent_id,
@@ -36302,35 +36248,41 @@ WITH fams AS (
 	 FROM workspace_agent_stats
 		WHERE workspace_agent_stats.created_at > $1
 		GROUP BY user_id, agent_id, workspace_id
+), latest_stats AS (
+	SELECT id, created_at, user_id, agent_id, workspace_id, template_id, connections_by_proto, connection_count, rx_packets, rx_bytes, tx_packets, tx_bytes, connection_median_latency_ms, usage, session_counts, ROW_NUMBER() OVER(PARTITION BY agent_id ORDER BY created_at DESC) AS rn
+	FROM workspace_agent_stats
+	-- The greater than 0 is to support legacy agents that don't report connection_median_latency_ms.
+	WHERE created_at > $1 AND connection_median_latency_ms > 0
+), latest_sessions AS (
+	-- Summed per app name here so the connection aggregates below keep seeing
+	-- one row per agent instead of one row per app name.
+	SELECT
+		agent_id,
+		coalesce(jsonb_object_agg(app_name, app_sessions), '{}'::jsonb)::jsonb AS session_counts
+	FROM (
+		SELECT
+			a.agent_id,
+			sess.app_name,
+			SUM(sess.sessions::bigint) AS app_sessions
+		FROM latest_stats AS a, jsonb_each_text(a.session_counts) AS sess(app_name, sessions)
+		WHERE a.rn = 1
+		GROUP BY a.agent_id, sess.app_name
+	) AS app_totals
+	GROUP BY agent_id
 ), latest_agent_stats AS (
 	SELECT
 		a.agent_id,
-		coalesce(SUM(sc.vscode), 0)::bigint AS session_count_vscode,
-		coalesce(SUM(sc.ssh), 0)::bigint AS session_count_ssh,
-		coalesce(SUM(sc.jetbrains), 0)::bigint AS session_count_jetbrains,
-		coalesce(SUM(sc.reconnecting_pty), 0)::bigint AS session_count_reconnecting_pty,
+		coalesce(latest_sessions.session_counts, '{}'::jsonb)::jsonb AS session_counts,
 		coalesce(SUM(a.connection_count), 0)::bigint AS connection_count,
 		coalesce(MAX(a.connection_median_latency_ms), 0)::float AS connection_median_latency_ms
-	 FROM (
-		SELECT id, created_at, user_id, agent_id, workspace_id, template_id, connections_by_proto, connection_count, rx_packets, rx_bytes, tx_packets, tx_bytes, connection_median_latency_ms, usage, session_counts, ROW_NUMBER() OVER(PARTITION BY agent_id ORDER BY created_at DESC) AS rn
-		FROM workspace_agent_stats
-		-- The greater than 0 is to support legacy agents that don't report connection_median_latency_ms.
-		WHERE created_at > $1 AND connection_median_latency_ms > 0
-	) AS a
-	CROSS JOIN LATERAL (
-		SELECT
-			coalesce(SUM(sess.value::bigint) FILTER (WHERE sess.key = ANY (fams.vscode)), 0) AS vscode,
-			coalesce(SUM(sess.value::bigint) FILTER (WHERE sess.key = ANY (fams.ssh)), 0) AS ssh,
-			coalesce(SUM(sess.value::bigint) FILTER (WHERE sess.key = ANY (fams.jetbrains)), 0) AS jetbrains,
-			coalesce(SUM(sess.value::bigint) FILTER (WHERE sess.key = ANY (fams.reconnecting_pty)), 0) AS reconnecting_pty
-		FROM fams, jsonb_each_text(a.session_counts) AS sess
-	) AS sc
+	FROM latest_stats AS a
+	LEFT JOIN latest_sessions ON latest_sessions.agent_id = a.agent_id
 	WHERE a.rn = 1
-	GROUP BY a.user_id, a.agent_id, a.workspace_id
+	GROUP BY a.user_id, a.agent_id, a.workspace_id, latest_sessions.session_counts
 )
 SELECT
 	users.username, workspace_agents.name AS agent_name, workspaces.name AS workspace_name, rx_bytes, tx_bytes,
-	session_count_vscode, session_count_ssh, session_count_jetbrains, session_count_reconnecting_pty,
+	session_counts,
 	connection_count, connection_median_latency_ms
 FROM
 	agent_stats
@@ -36352,27 +36304,19 @@ ON
 	workspaces.id = agent_stats.workspace_id
 `
 
-type GetWorkspaceAgentStatsAndLabelsParams struct {
-	CreatedAt   time.Time       `db:"created_at" json:"created_at"`
-	AppFamilies json.RawMessage `db:"app_families" json:"app_families"`
-}
-
 type GetWorkspaceAgentStatsAndLabelsRow struct {
-	Username                    string  `db:"username" json:"username"`
-	AgentName                   string  `db:"agent_name" json:"agent_name"`
-	WorkspaceName               string  `db:"workspace_name" json:"workspace_name"`
-	RxBytes                     int64   `db:"rx_bytes" json:"rx_bytes"`
-	TxBytes                     int64   `db:"tx_bytes" json:"tx_bytes"`
-	SessionCountVSCode          int64   `db:"session_count_vscode" json:"session_count_vscode"`
-	SessionCountSSH             int64   `db:"session_count_ssh" json:"session_count_ssh"`
-	SessionCountJetBrains       int64   `db:"session_count_jetbrains" json:"session_count_jetbrains"`
-	SessionCountReconnectingPTY int64   `db:"session_count_reconnecting_pty" json:"session_count_reconnecting_pty"`
-	ConnectionCount             int64   `db:"connection_count" json:"connection_count"`
-	ConnectionMedianLatencyMS   float64 `db:"connection_median_latency_ms" json:"connection_median_latency_ms"`
+	Username                  string          `db:"username" json:"username"`
+	AgentName                 string          `db:"agent_name" json:"agent_name"`
+	WorkspaceName             string          `db:"workspace_name" json:"workspace_name"`
+	RxBytes                   int64           `db:"rx_bytes" json:"rx_bytes"`
+	TxBytes                   int64           `db:"tx_bytes" json:"tx_bytes"`
+	SessionCounts             json.RawMessage `db:"session_counts" json:"session_counts"`
+	ConnectionCount           int64           `db:"connection_count" json:"connection_count"`
+	ConnectionMedianLatencyMS float64         `db:"connection_median_latency_ms" json:"connection_median_latency_ms"`
 }
 
-func (q *sqlQuerier) GetWorkspaceAgentStatsAndLabels(ctx context.Context, arg GetWorkspaceAgentStatsAndLabelsParams) ([]GetWorkspaceAgentStatsAndLabelsRow, error) {
-	rows, err := q.db.QueryContext(ctx, getWorkspaceAgentStatsAndLabels, arg.CreatedAt, arg.AppFamilies)
+func (q *sqlQuerier) GetWorkspaceAgentStatsAndLabels(ctx context.Context, createdAt time.Time) ([]GetWorkspaceAgentStatsAndLabelsRow, error) {
+	rows, err := q.db.QueryContext(ctx, getWorkspaceAgentStatsAndLabels, createdAt)
 	if err != nil {
 		return nil, err
 	}
@@ -36386,10 +36330,7 @@ func (q *sqlQuerier) GetWorkspaceAgentStatsAndLabels(ctx context.Context, arg Ge
 			&i.WorkspaceName,
 			&i.RxBytes,
 			&i.TxBytes,
-			&i.SessionCountVSCode,
-			&i.SessionCountSSH,
-			&i.SessionCountJetBrains,
-			&i.SessionCountReconnectingPTY,
+			&i.SessionCounts,
 			&i.ConnectionCount,
 			&i.ConnectionMedianLatencyMS,
 		); err != nil {
@@ -36407,13 +36348,7 @@ func (q *sqlQuerier) GetWorkspaceAgentStatsAndLabels(ctx context.Context, arg Ge
 }
 
 const getWorkspaceAgentUsageStats = `-- name: GetWorkspaceAgentUsageStats :many
-WITH fams AS (
-	SELECT
-		ARRAY(SELECT jsonb_array_elements_text($2::jsonb -> 'vscode')) AS vscode,
-		ARRAY(SELECT jsonb_array_elements_text($2::jsonb -> 'ssh')) AS ssh,
-		ARRAY(SELECT jsonb_array_elements_text($2::jsonb -> 'jetbrains')) AS jetbrains,
-		ARRAY(SELECT jsonb_array_elements_text($2::jsonb -> 'reconnecting_pty')) AS reconnecting_pty
-), stats AS (
+WITH stats AS (
 	SELECT
 		id, created_at, user_id, agent_id, workspace_id, template_id, connections_by_proto, connection_count, rx_packets, rx_bytes, tx_packets, tx_bytes, connection_median_latency_ms, usage, session_counts,
 		-- The greater than 0 is to support legacy agents that don't report connection_median_latency_ms.
@@ -36424,64 +36359,59 @@ WITH fams AS (
 		) OVER (PARTITION BY agent_id) AS in_latest_usage_minute
 	FROM workspace_agent_stats
 	WHERE created_at >= $1
+), latest_sessions AS (
+	-- One row per agent, so joining it below neither multiplies the byte and
+	-- latency aggregates nor adds groups.
+	SELECT
+		agent_id,
+		coalesce(jsonb_object_agg(app_name, app_sessions), '{}'::jsonb)::jsonb AS session_counts
+	FROM (
+		SELECT
+			stats.agent_id,
+			sess.app_name,
+			SUM(sess.sessions::bigint) AS app_sessions
+		FROM stats, jsonb_each_text(stats.session_counts) AS sess(app_name, sessions)
+		WHERE stats.in_latest_usage_minute
+		GROUP BY stats.agent_id, sess.app_name
+	) AS app_totals
+	GROUP BY agent_id
 )
 SELECT
-	user_id,
-	agent_id,
-	workspace_id,
-	template_id,
-	MIN(created_at) FILTER (WHERE reports_latency)::timestamptz AS aggregated_from,
-	coalesce(SUM(rx_bytes) FILTER (WHERE reports_latency), 0)::bigint AS workspace_rx_bytes,
-	coalesce(SUM(tx_bytes) FILTER (WHERE reports_latency), 0)::bigint AS workspace_tx_bytes,
-	coalesce((PERCENTILE_CONT(0.5) WITHIN GROUP (ORDER BY connection_median_latency_ms) FILTER (WHERE reports_latency)), -1)::FLOAT AS workspace_connection_latency_50,
-	coalesce((PERCENTILE_CONT(0.95) WITHIN GROUP (ORDER BY connection_median_latency_ms) FILTER (WHERE reports_latency)), -1)::FLOAT AS workspace_connection_latency_95,
+	stats.user_id,
+	stats.agent_id,
+	stats.workspace_id,
+	stats.template_id,
+	MIN(stats.created_at) FILTER (WHERE reports_latency)::timestamptz AS aggregated_from,
+	coalesce(SUM(stats.rx_bytes) FILTER (WHERE reports_latency), 0)::bigint AS workspace_rx_bytes,
+	coalesce(SUM(stats.tx_bytes) FILTER (WHERE reports_latency), 0)::bigint AS workspace_tx_bytes,
+	coalesce((PERCENTILE_CONT(0.5) WITHIN GROUP (ORDER BY stats.connection_median_latency_ms) FILTER (WHERE reports_latency)), -1)::FLOAT AS workspace_connection_latency_50,
+	coalesce((PERCENTILE_CONT(0.95) WITHIN GROUP (ORDER BY stats.connection_median_latency_ms) FILTER (WHERE reports_latency)), -1)::FLOAT AS workspace_connection_latency_95,
 	-- Repeated so this row keeps the same layout as GetWorkspaceAgentStats, which
 	-- telemetry converts between.
-	agent_id,
-	coalesce(SUM(sc.vscode) FILTER (WHERE in_latest_usage_minute), 0)::bigint AS session_count_vscode,
-	coalesce(SUM(sc.ssh) FILTER (WHERE in_latest_usage_minute), 0)::bigint AS session_count_ssh,
-	coalesce(SUM(sc.jetbrains) FILTER (WHERE in_latest_usage_minute), 0)::bigint AS session_count_jetbrains,
-	coalesce(SUM(sc.reconnecting_pty) FILTER (WHERE in_latest_usage_minute), 0)::bigint AS session_count_reconnecting_pty
+	stats.agent_id,
+	coalesce(latest_sessions.session_counts, '{}'::jsonb)::jsonb AS session_counts
 FROM stats
-CROSS JOIN LATERAL (
-	SELECT
-		coalesce(SUM(sess.value::bigint) FILTER (WHERE sess.key = ANY (fams.vscode)), 0) AS vscode,
-		coalesce(SUM(sess.value::bigint) FILTER (WHERE sess.key = ANY (fams.ssh)), 0) AS ssh,
-		coalesce(SUM(sess.value::bigint) FILTER (WHERE sess.key = ANY (fams.jetbrains)), 0) AS jetbrains,
-		coalesce(SUM(sess.value::bigint) FILTER (WHERE sess.key = ANY (fams.reconnecting_pty)), 0) AS reconnecting_pty
-	FROM fams, jsonb_each_text(stats.session_counts) AS sess
-	-- Gate on the same condition as the aggregate filters above so the
-	-- decompose runs only for the rows that are counted (one-time filter).
-	WHERE stats.in_latest_usage_minute
-) AS sc
-GROUP BY user_id, agent_id, workspace_id, template_id
+LEFT JOIN latest_sessions ON latest_sessions.agent_id = stats.agent_id
+GROUP BY stats.user_id, stats.agent_id, stats.workspace_id, stats.template_id, latest_sessions.session_counts
 HAVING BOOL_OR(reports_latency)
 `
 
-type GetWorkspaceAgentUsageStatsParams struct {
-	CreatedAt   time.Time       `db:"created_at" json:"created_at"`
-	AppFamilies json.RawMessage `db:"app_families" json:"app_families"`
-}
-
 type GetWorkspaceAgentUsageStatsRow struct {
-	UserID                       uuid.UUID `db:"user_id" json:"user_id"`
-	AgentID                      uuid.UUID `db:"agent_id" json:"agent_id"`
-	WorkspaceID                  uuid.UUID `db:"workspace_id" json:"workspace_id"`
-	TemplateID                   uuid.UUID `db:"template_id" json:"template_id"`
-	AggregatedFrom               time.Time `db:"aggregated_from" json:"aggregated_from"`
-	WorkspaceRxBytes             int64     `db:"workspace_rx_bytes" json:"workspace_rx_bytes"`
-	WorkspaceTxBytes             int64     `db:"workspace_tx_bytes" json:"workspace_tx_bytes"`
-	WorkspaceConnectionLatency50 float64   `db:"workspace_connection_latency_50" json:"workspace_connection_latency_50"`
-	WorkspaceConnectionLatency95 float64   `db:"workspace_connection_latency_95" json:"workspace_connection_latency_95"`
-	AgentID_2                    uuid.UUID `db:"agent_id_2" json:"agent_id_2"`
-	SessionCountVSCode           int64     `db:"session_count_vscode" json:"session_count_vscode"`
-	SessionCountSSH              int64     `db:"session_count_ssh" json:"session_count_ssh"`
-	SessionCountJetBrains        int64     `db:"session_count_jetbrains" json:"session_count_jetbrains"`
-	SessionCountReconnectingPTY  int64     `db:"session_count_reconnecting_pty" json:"session_count_reconnecting_pty"`
+	UserID                       uuid.UUID       `db:"user_id" json:"user_id"`
+	AgentID                      uuid.UUID       `db:"agent_id" json:"agent_id"`
+	WorkspaceID                  uuid.UUID       `db:"workspace_id" json:"workspace_id"`
+	TemplateID                   uuid.UUID       `db:"template_id" json:"template_id"`
+	AggregatedFrom               time.Time       `db:"aggregated_from" json:"aggregated_from"`
+	WorkspaceRxBytes             int64           `db:"workspace_rx_bytes" json:"workspace_rx_bytes"`
+	WorkspaceTxBytes             int64           `db:"workspace_tx_bytes" json:"workspace_tx_bytes"`
+	WorkspaceConnectionLatency50 float64         `db:"workspace_connection_latency_50" json:"workspace_connection_latency_50"`
+	WorkspaceConnectionLatency95 float64         `db:"workspace_connection_latency_95" json:"workspace_connection_latency_95"`
+	AgentID_2                    uuid.UUID       `db:"agent_id_2" json:"agent_id_2"`
+	SessionCounts                json.RawMessage `db:"session_counts" json:"session_counts"`
 }
 
-func (q *sqlQuerier) GetWorkspaceAgentUsageStats(ctx context.Context, arg GetWorkspaceAgentUsageStatsParams) ([]GetWorkspaceAgentUsageStatsRow, error) {
-	rows, err := q.db.QueryContext(ctx, getWorkspaceAgentUsageStats, arg.CreatedAt, arg.AppFamilies)
+func (q *sqlQuerier) GetWorkspaceAgentUsageStats(ctx context.Context, createdAt time.Time) ([]GetWorkspaceAgentUsageStatsRow, error) {
+	rows, err := q.db.QueryContext(ctx, getWorkspaceAgentUsageStats, createdAt)
 	if err != nil {
 		return nil, err
 	}
@@ -36500,10 +36430,7 @@ func (q *sqlQuerier) GetWorkspaceAgentUsageStats(ctx context.Context, arg GetWor
 			&i.WorkspaceConnectionLatency50,
 			&i.WorkspaceConnectionLatency95,
 			&i.AgentID_2,
-			&i.SessionCountVSCode,
-			&i.SessionCountSSH,
-			&i.SessionCountJetBrains,
-			&i.SessionCountReconnectingPTY,
+			&i.SessionCounts,
 		); err != nil {
 			return nil, err
 		}
@@ -36519,13 +36446,7 @@ func (q *sqlQuerier) GetWorkspaceAgentUsageStats(ctx context.Context, arg GetWor
 }
 
 const getWorkspaceAgentUsageStatsAndLabels = `-- name: GetWorkspaceAgentUsageStatsAndLabels :many
-WITH fams AS (
-	SELECT
-		ARRAY(SELECT jsonb_array_elements_text($2::jsonb -> 'vscode')) AS vscode,
-		ARRAY(SELECT jsonb_array_elements_text($2::jsonb -> 'ssh')) AS ssh,
-		ARRAY(SELECT jsonb_array_elements_text($2::jsonb -> 'jetbrains')) AS jetbrains,
-		ARRAY(SELECT jsonb_array_elements_text($2::jsonb -> 'reconnecting_pty')) AS reconnecting_pty
-), agent_stats AS (
+WITH agent_stats AS (
 	SELECT
 		user_id,
 		agent_id,
@@ -36537,34 +36458,39 @@ WITH fams AS (
 	-- The greater than 0 is to support legacy agents that don't report connection_median_latency_ms.
 	WHERE workspace_agent_stats.created_at > $1 AND connection_median_latency_ms > 0
 	GROUP BY user_id, agent_id, workspace_id
-), latest_agent_stats AS (
-	SELECT
-		agent_id,
-		coalesce(SUM(sc.vscode), 0)::bigint AS session_count_vscode,
-		coalesce(SUM(sc.ssh), 0)::bigint AS session_count_ssh,
-		coalesce(SUM(sc.jetbrains), 0)::bigint AS session_count_jetbrains,
-		coalesce(SUM(sc.reconnecting_pty), 0)::bigint AS session_count_reconnecting_pty,
-		coalesce(SUM(connection_count), 0)::bigint AS connection_count
+), latest_stats AS (
+	SELECT id, created_at, user_id, agent_id, workspace_id, template_id, connections_by_proto, connection_count, rx_packets, rx_bytes, tx_packets, tx_bytes, connection_median_latency_ms, usage, session_counts
 	FROM workspace_agent_stats
-	CROSS JOIN LATERAL (
-		SELECT
-			coalesce(SUM(sess.value::bigint) FILTER (WHERE sess.key = ANY (fams.vscode)), 0) AS vscode,
-			coalesce(SUM(sess.value::bigint) FILTER (WHERE sess.key = ANY (fams.ssh)), 0) AS ssh,
-			coalesce(SUM(sess.value::bigint) FILTER (WHERE sess.key = ANY (fams.jetbrains)), 0) AS jetbrains,
-			coalesce(SUM(sess.value::bigint) FILTER (WHERE sess.key = ANY (fams.reconnecting_pty)), 0) AS reconnecting_pty
-		FROM fams, jsonb_each_text(workspace_agent_stats.session_counts) AS sess
-	) AS sc
 	-- We only want the latest stats, but those stats might be
 	-- spread across multiple rows.
 	WHERE usage AND created_at > now() - '1 minute'::interval
-	GROUP BY user_id, agent_id, workspace_id
+), latest_sessions AS (
+	-- Summed per app name here so the connection count below keeps seeing one
+	-- row per agent instead of one row per app name.
+	SELECT
+		agent_id,
+		coalesce(jsonb_object_agg(app_name, app_sessions), '{}'::jsonb)::jsonb AS session_counts
+	FROM (
+		SELECT
+			latest_stats.agent_id,
+			sess.app_name,
+			SUM(sess.sessions::bigint) AS app_sessions
+		FROM latest_stats, jsonb_each_text(latest_stats.session_counts) AS sess(app_name, sessions)
+		GROUP BY latest_stats.agent_id, sess.app_name
+	) AS app_totals
+	GROUP BY agent_id
+), latest_agent_stats AS (
+	SELECT
+		latest_stats.agent_id,
+		coalesce(latest_sessions.session_counts, '{}'::jsonb)::jsonb AS session_counts,
+		coalesce(SUM(latest_stats.connection_count), 0)::bigint AS connection_count
+	FROM latest_stats
+	LEFT JOIN latest_sessions ON latest_sessions.agent_id = latest_stats.agent_id
+	GROUP BY latest_stats.user_id, latest_stats.agent_id, latest_stats.workspace_id, latest_sessions.session_counts
 )
 SELECT
 	users.username, workspace_agents.name AS agent_name, workspaces.name AS workspace_name, rx_bytes, tx_bytes,
-	coalesce(session_count_vscode, 0)::bigint AS session_count_vscode,
-	coalesce(session_count_ssh, 0)::bigint AS session_count_ssh,
-	coalesce(session_count_jetbrains, 0)::bigint AS session_count_jetbrains,
-	coalesce(session_count_reconnecting_pty, 0)::bigint AS session_count_reconnecting_pty,
+	coalesce(session_counts, '{}'::jsonb)::jsonb AS session_counts,
 	coalesce(connection_count, 0)::bigint AS connection_count,
 	connection_median_latency_ms
 FROM
@@ -36587,27 +36513,19 @@ ON
 	workspaces.id = agent_stats.workspace_id
 `
 
-type GetWorkspaceAgentUsageStatsAndLabelsParams struct {
-	CreatedAt   time.Time       `db:"created_at" json:"created_at"`
-	AppFamilies json.RawMessage `db:"app_families" json:"app_families"`
-}
-
 type GetWorkspaceAgentUsageStatsAndLabelsRow struct {
-	Username                    string  `db:"username" json:"username"`
-	AgentName                   string  `db:"agent_name" json:"agent_name"`
-	WorkspaceName               string  `db:"workspace_name" json:"workspace_name"`
-	RxBytes                     int64   `db:"rx_bytes" json:"rx_bytes"`
-	TxBytes                     int64   `db:"tx_bytes" json:"tx_bytes"`
-	SessionCountVSCode          int64   `db:"session_count_vscode" json:"session_count_vscode"`
-	SessionCountSSH             int64   `db:"session_count_ssh" json:"session_count_ssh"`
-	SessionCountJetBrains       int64   `db:"session_count_jetbrains" json:"session_count_jetbrains"`
-	SessionCountReconnectingPTY int64   `db:"session_count_reconnecting_pty" json:"session_count_reconnecting_pty"`
-	ConnectionCount             int64   `db:"connection_count" json:"connection_count"`
-	ConnectionMedianLatencyMS   float64 `db:"connection_median_latency_ms" json:"connection_median_latency_ms"`
+	Username                  string          `db:"username" json:"username"`
+	AgentName                 string          `db:"agent_name" json:"agent_name"`
+	WorkspaceName             string          `db:"workspace_name" json:"workspace_name"`
+	RxBytes                   int64           `db:"rx_bytes" json:"rx_bytes"`
+	TxBytes                   int64           `db:"tx_bytes" json:"tx_bytes"`
+	SessionCounts             json.RawMessage `db:"session_counts" json:"session_counts"`
+	ConnectionCount           int64           `db:"connection_count" json:"connection_count"`
+	ConnectionMedianLatencyMS float64         `db:"connection_median_latency_ms" json:"connection_median_latency_ms"`
 }
 
-func (q *sqlQuerier) GetWorkspaceAgentUsageStatsAndLabels(ctx context.Context, arg GetWorkspaceAgentUsageStatsAndLabelsParams) ([]GetWorkspaceAgentUsageStatsAndLabelsRow, error) {
-	rows, err := q.db.QueryContext(ctx, getWorkspaceAgentUsageStatsAndLabels, arg.CreatedAt, arg.AppFamilies)
+func (q *sqlQuerier) GetWorkspaceAgentUsageStatsAndLabels(ctx context.Context, createdAt time.Time) ([]GetWorkspaceAgentUsageStatsAndLabelsRow, error) {
+	rows, err := q.db.QueryContext(ctx, getWorkspaceAgentUsageStatsAndLabels, createdAt)
 	if err != nil {
 		return nil, err
 	}
@@ -36621,10 +36539,7 @@ func (q *sqlQuerier) GetWorkspaceAgentUsageStatsAndLabels(ctx context.Context, a
 			&i.WorkspaceName,
 			&i.RxBytes,
 			&i.TxBytes,
-			&i.SessionCountVSCode,
-			&i.SessionCountSSH,
-			&i.SessionCountJetBrains,
-			&i.SessionCountReconnectingPTY,
+			&i.SessionCounts,
 			&i.ConnectionCount,
 			&i.ConnectionMedianLatencyMS,
 		); err != nil {

--- a/coderd/database/queries/workspaceagentstats.sql
+++ b/coderd/database/queries/workspaceagentstats.sql
@@ -172,34 +172,14 @@ WITH agent_stats AS (
 ), latest_stats AS (
 	SELECT *, ROW_NUMBER() OVER(PARTITION BY agent_id ORDER BY created_at DESC) AS rn
 	FROM workspace_agent_stats WHERE created_at > $1
-), latest_sessions AS (
-	-- Two levels: the inner query sums each app name on the latest row per
-	-- agent, the outer one folds those sums back into a single jsonb object.
-	-- rn = 1 leaves one row per agent, so grouping by agent_id alone matches
-	-- the per-agent grouping of agent_stats above.
+), latest_agent_stats AS (
+	-- rn = 1 leaves one row per agent, and that row's session_counts is
+	-- already the object this query reports, empty map included.
 	SELECT
 		agent_id,
-		coalesce(jsonb_object_agg(app_name, app_sessions), '{}'::jsonb)::jsonb AS session_counts
-	FROM (
-		SELECT
-			a.agent_id,
-			sess.app_name,
-			SUM(sess.sessions::bigint) AS app_sessions
-		FROM latest_stats AS a, jsonb_each_text(a.session_counts) AS sess(app_name, sessions)
-		WHERE a.rn = 1
-		GROUP BY a.agent_id, sess.app_name
-	) AS app_totals
-	GROUP BY agent_id
-), latest_agent_stats AS (
-	-- Joined rather than selected from latest_sessions so an agent whose
-	-- latest row reports no sessions at all keeps its row here.
-	SELECT
-		a.agent_id,
-		coalesce(latest_sessions.session_counts, '{}'::jsonb)::jsonb AS session_counts
-	FROM latest_stats AS a
-	LEFT JOIN latest_sessions ON latest_sessions.agent_id = a.agent_id
-	WHERE a.rn = 1
-	GROUP BY a.user_id, a.agent_id, a.workspace_id, a.template_id, latest_sessions.session_counts
+		session_counts
+	FROM latest_stats
+	WHERE rn = 1
 )
 SELECT * FROM agent_stats JOIN latest_agent_stats ON agent_stats.agent_id = latest_agent_stats.agent_id;
 
@@ -267,32 +247,16 @@ WITH agent_stats AS (
 	FROM workspace_agent_stats
 	-- The greater than 0 is to support legacy agents that don't report connection_median_latency_ms.
 	WHERE created_at > $1 AND connection_median_latency_ms > 0
-), latest_sessions AS (
-	-- Summed per app name here so the connection aggregates below keep seeing
-	-- one row per agent instead of one row per app name.
+), latest_agent_stats AS (
+	-- rn = 1 leaves one row per agent, so the session object, connection
+	-- count, and latency are that row's own columns, empty map included.
 	SELECT
 		agent_id,
-		coalesce(jsonb_object_agg(app_name, app_sessions), '{}'::jsonb)::jsonb AS session_counts
-	FROM (
-		SELECT
-			a.agent_id,
-			sess.app_name,
-			SUM(sess.sessions::bigint) AS app_sessions
-		FROM latest_stats AS a, jsonb_each_text(a.session_counts) AS sess(app_name, sessions)
-		WHERE a.rn = 1
-		GROUP BY a.agent_id, sess.app_name
-	) AS app_totals
-	GROUP BY agent_id
-), latest_agent_stats AS (
-	SELECT
-		a.agent_id,
-		coalesce(latest_sessions.session_counts, '{}'::jsonb)::jsonb AS session_counts,
-		coalesce(SUM(a.connection_count), 0)::bigint AS connection_count,
-		coalesce(MAX(a.connection_median_latency_ms), 0)::float AS connection_median_latency_ms
-	FROM latest_stats AS a
-	LEFT JOIN latest_sessions ON latest_sessions.agent_id = a.agent_id
-	WHERE a.rn = 1
-	GROUP BY a.user_id, a.agent_id, a.workspace_id, latest_sessions.session_counts
+		session_counts,
+		connection_count,
+		connection_median_latency_ms
+	FROM latest_stats
+	WHERE rn = 1
 )
 SELECT
 	users.username, workspace_agents.name AS agent_name, workspaces.name AS workspace_name, rx_bytes, tx_bytes,

--- a/coderd/database/queries/workspaceagentstats.sql
+++ b/coderd/database/queries/workspaceagentstats.sql
@@ -66,20 +66,11 @@ WHERE
 	);
 
 -- name: GetDeploymentWorkspaceAgentStats :one
--- app_families maps each attributed family to its app names, so the probes
--- below stay one expression per family: adding a family needs a new list in
--- fams plus one probe here, because sqlc output columns are static.
--- fams turns the jsonb parameter into arrays once for the whole query. The
--- lateral decomposes session_counts once per row and sums each family from
--- that single pass, which measured ~3x faster than probing the jsonb once
--- per family. The subplan only runs for rows that survive the gate.
-WITH fams AS (
-	SELECT
-		ARRAY(SELECT jsonb_array_elements_text(@app_families::jsonb -> 'vscode')) AS vscode,
-		ARRAY(SELECT jsonb_array_elements_text(@app_families::jsonb -> 'ssh')) AS ssh,
-		ARRAY(SELECT jsonb_array_elements_text(@app_families::jsonb -> 'jetbrains')) AS jetbrains,
-		ARRAY(SELECT jsonb_array_elements_text(@app_families::jsonb -> 'reconnecting_pty')) AS reconnecting_pty
-), stats AS (
+-- The session count sum runs in its own subquery: decomposing session_counts
+-- in the FROM clause would emit one row per app name and multiply the byte and
+-- latency aggregates below. Summing per app name and folding the names into
+-- families in Go keeps a session reported under a new name counted.
+WITH stats AS (
 	SELECT
 		agent_id,
 		created_at,
@@ -97,31 +88,23 @@ SELECT
 	-- The greater than 0 is to support legacy agents that don't report connection_median_latency_ms.
 	coalesce((PERCENTILE_CONT(0.5) WITHIN GROUP (ORDER BY connection_median_latency_ms) FILTER (WHERE connection_median_latency_ms > 0)), -1)::FLOAT AS workspace_connection_latency_50,
 	coalesce((PERCENTILE_CONT(0.95) WITHIN GROUP (ORDER BY connection_median_latency_ms) FILTER (WHERE connection_median_latency_ms > 0)), -1)::FLOAT AS workspace_connection_latency_95,
-	coalesce(SUM(sc.vscode) FILTER (WHERE rn = 1), 0)::bigint AS session_count_vscode,
-	coalesce(SUM(sc.ssh) FILTER (WHERE rn = 1), 0)::bigint AS session_count_ssh,
-	coalesce(SUM(sc.jetbrains) FILTER (WHERE rn = 1), 0)::bigint AS session_count_jetbrains,
-	coalesce(SUM(sc.reconnecting_pty) FILTER (WHERE rn = 1), 0)::bigint AS session_count_reconnecting_pty
-FROM stats
-CROSS JOIN LATERAL (
-	SELECT
-		coalesce(SUM(sess.value::bigint) FILTER (WHERE sess.key = ANY (fams.vscode)), 0) AS vscode,
-		coalesce(SUM(sess.value::bigint) FILTER (WHERE sess.key = ANY (fams.ssh)), 0) AS ssh,
-		coalesce(SUM(sess.value::bigint) FILTER (WHERE sess.key = ANY (fams.jetbrains)), 0) AS jetbrains,
-		coalesce(SUM(sess.value::bigint) FILTER (WHERE sess.key = ANY (fams.reconnecting_pty)), 0) AS reconnecting_pty
-	FROM fams, jsonb_each_text(stats.session_counts) AS sess
-	-- Gate on the same condition as the aggregate filters above so the
-	-- decompose runs only for the rows that are counted (one-time filter).
-	WHERE stats.rn = 1
-) AS sc;
+	coalesce((
+		SELECT
+			jsonb_object_agg(app_name, app_sessions)
+		FROM (
+			SELECT
+				sess.app_name,
+				SUM(sess.sessions::bigint) AS app_sessions
+			FROM stats, jsonb_each_text(stats.session_counts) AS sess(app_name, sessions)
+			-- Only the latest row per agent holds current sessions.
+			WHERE stats.rn = 1
+			GROUP BY sess.app_name
+		) AS app_totals
+	), '{}'::jsonb)::jsonb AS session_counts
+FROM stats;
 
 -- name: GetDeploymentWorkspaceAgentUsageStats :one
-WITH fams AS (
-	SELECT
-		ARRAY(SELECT jsonb_array_elements_text(@app_families::jsonb -> 'vscode')) AS vscode,
-		ARRAY(SELECT jsonb_array_elements_text(@app_families::jsonb -> 'ssh')) AS ssh,
-		ARRAY(SELECT jsonb_array_elements_text(@app_families::jsonb -> 'jetbrains')) AS jetbrains,
-		ARRAY(SELECT jsonb_array_elements_text(@app_families::jsonb -> 'reconnecting_pty')) AS reconnecting_pty
-), agent_stats AS (
+WITH agent_stats AS (
 	SELECT
 		coalesce(SUM(rx_bytes), 0)::bigint AS workspace_rx_bytes,
 		coalesce(SUM(tx_bytes), 0)::bigint AS workspace_tx_bytes,
@@ -146,40 +129,32 @@ latest_minutes AS (
 		agent_id
 ),
 latest_agent_stats AS (
+	-- Aggregating the per app name sums separately keeps the byte and latency
+	-- aggregates in agent_stats free of the decomposed rows.
 	SELECT
-		coalesce(SUM(sc.vscode), 0)::bigint AS session_count_vscode,
-		coalesce(SUM(sc.ssh), 0)::bigint AS session_count_ssh,
-		coalesce(SUM(sc.jetbrains), 0)::bigint AS session_count_jetbrains,
-		coalesce(SUM(sc.reconnecting_pty), 0)::bigint AS session_count_reconnecting_pty
-	FROM
-		latest_minutes
-	JOIN
-		workspace_agent_stats AS stats
-	ON
-		stats.agent_id = latest_minutes.agent_id
-		AND stats.created_at >= $1
-		AND stats.created_at >= latest_minutes.minute_bucket
-		AND stats.created_at < latest_minutes.minute_bucket + '1 minute'::interval
-		AND stats.usage
-	CROSS JOIN LATERAL (
+		coalesce(jsonb_object_agg(app_name, app_sessions), '{}'::jsonb)::jsonb AS session_counts
+	FROM (
 		SELECT
-			coalesce(SUM(sess.value::bigint) FILTER (WHERE sess.key = ANY (fams.vscode)), 0) AS vscode,
-			coalesce(SUM(sess.value::bigint) FILTER (WHERE sess.key = ANY (fams.ssh)), 0) AS ssh,
-			coalesce(SUM(sess.value::bigint) FILTER (WHERE sess.key = ANY (fams.jetbrains)), 0) AS jetbrains,
-			coalesce(SUM(sess.value::bigint) FILTER (WHERE sess.key = ANY (fams.reconnecting_pty)), 0) AS reconnecting_pty
-		FROM fams, jsonb_each_text(stats.session_counts) AS sess
-	) AS sc
+			sess.app_name,
+			SUM(sess.sessions::bigint) AS app_sessions
+		FROM
+			latest_minutes
+		JOIN
+			workspace_agent_stats AS stats
+		ON
+			stats.agent_id = latest_minutes.agent_id
+			AND stats.created_at >= $1
+			AND stats.created_at >= latest_minutes.minute_bucket
+			AND stats.created_at < latest_minutes.minute_bucket + '1 minute'::interval
+			AND stats.usage,
+			jsonb_each_text(stats.session_counts) AS sess(app_name, sessions)
+		GROUP BY sess.app_name
+	) AS app_totals
 )
 SELECT * FROM agent_stats, latest_agent_stats;
 
 -- name: GetWorkspaceAgentStats :many
-WITH fams AS (
-	SELECT
-		ARRAY(SELECT jsonb_array_elements_text(@app_families::jsonb -> 'vscode')) AS vscode,
-		ARRAY(SELECT jsonb_array_elements_text(@app_families::jsonb -> 'ssh')) AS ssh,
-		ARRAY(SELECT jsonb_array_elements_text(@app_families::jsonb -> 'jetbrains')) AS jetbrains,
-		ARRAY(SELECT jsonb_array_elements_text(@app_families::jsonb -> 'reconnecting_pty')) AS reconnecting_pty
-), agent_stats AS (
+WITH agent_stats AS (
 	SELECT
 		user_id,
 		agent_id,
@@ -194,38 +169,42 @@ WITH fams AS (
 	-- The greater than 0 is to support legacy agents that don't report connection_median_latency_ms.
 	WHERE workspace_agent_stats.created_at > $1 AND connection_median_latency_ms > 0
 	GROUP BY user_id, agent_id, workspace_id, template_id
+), latest_stats AS (
+	SELECT *, ROW_NUMBER() OVER(PARTITION BY agent_id ORDER BY created_at DESC) AS rn
+	FROM workspace_agent_stats WHERE created_at > $1
+), latest_sessions AS (
+	-- Two levels: the inner query sums each app name on the latest row per
+	-- agent, the outer one folds those sums back into a single jsonb object.
+	-- rn = 1 leaves one row per agent, so grouping by agent_id alone matches
+	-- the per-agent grouping of agent_stats above.
+	SELECT
+		agent_id,
+		coalesce(jsonb_object_agg(app_name, app_sessions), '{}'::jsonb)::jsonb AS session_counts
+	FROM (
+		SELECT
+			a.agent_id,
+			sess.app_name,
+			SUM(sess.sessions::bigint) AS app_sessions
+		FROM latest_stats AS a, jsonb_each_text(a.session_counts) AS sess(app_name, sessions)
+		WHERE a.rn = 1
+		GROUP BY a.agent_id, sess.app_name
+	) AS app_totals
+	GROUP BY agent_id
 ), latest_agent_stats AS (
+	-- Joined rather than selected from latest_sessions so an agent whose
+	-- latest row reports no sessions at all keeps its row here.
 	SELECT
 		a.agent_id,
-		coalesce(SUM(sc.vscode), 0)::bigint AS session_count_vscode,
-		coalesce(SUM(sc.ssh), 0)::bigint AS session_count_ssh,
-		coalesce(SUM(sc.jetbrains), 0)::bigint AS session_count_jetbrains,
-		coalesce(SUM(sc.reconnecting_pty), 0)::bigint AS session_count_reconnecting_pty
-	 FROM (
-		SELECT *, ROW_NUMBER() OVER(PARTITION BY agent_id ORDER BY created_at DESC) AS rn
-		FROM workspace_agent_stats WHERE created_at > $1
-	) AS a
-	CROSS JOIN LATERAL (
-		SELECT
-			coalesce(SUM(sess.value::bigint) FILTER (WHERE sess.key = ANY (fams.vscode)), 0) AS vscode,
-			coalesce(SUM(sess.value::bigint) FILTER (WHERE sess.key = ANY (fams.ssh)), 0) AS ssh,
-			coalesce(SUM(sess.value::bigint) FILTER (WHERE sess.key = ANY (fams.jetbrains)), 0) AS jetbrains,
-			coalesce(SUM(sess.value::bigint) FILTER (WHERE sess.key = ANY (fams.reconnecting_pty)), 0) AS reconnecting_pty
-		FROM fams, jsonb_each_text(a.session_counts) AS sess
-	) AS sc
+		coalesce(latest_sessions.session_counts, '{}'::jsonb)::jsonb AS session_counts
+	FROM latest_stats AS a
+	LEFT JOIN latest_sessions ON latest_sessions.agent_id = a.agent_id
 	WHERE a.rn = 1
-	GROUP BY a.user_id, a.agent_id, a.workspace_id, a.template_id
+	GROUP BY a.user_id, a.agent_id, a.workspace_id, a.template_id, latest_sessions.session_counts
 )
 SELECT * FROM agent_stats JOIN latest_agent_stats ON agent_stats.agent_id = latest_agent_stats.agent_id;
 
 -- name: GetWorkspaceAgentUsageStats :many
-WITH fams AS (
-	SELECT
-		ARRAY(SELECT jsonb_array_elements_text(@app_families::jsonb -> 'vscode')) AS vscode,
-		ARRAY(SELECT jsonb_array_elements_text(@app_families::jsonb -> 'ssh')) AS ssh,
-		ARRAY(SELECT jsonb_array_elements_text(@app_families::jsonb -> 'jetbrains')) AS jetbrains,
-		ARRAY(SELECT jsonb_array_elements_text(@app_families::jsonb -> 'reconnecting_pty')) AS reconnecting_pty
-), stats AS (
+WITH stats AS (
 	SELECT
 		*,
 		-- The greater than 0 is to support legacy agents that don't report connection_median_latency_ms.
@@ -236,47 +215,44 @@ WITH fams AS (
 		) OVER (PARTITION BY agent_id) AS in_latest_usage_minute
 	FROM workspace_agent_stats
 	WHERE created_at >= $1
+), latest_sessions AS (
+	-- One row per agent, so joining it below neither multiplies the byte and
+	-- latency aggregates nor adds groups.
+	SELECT
+		agent_id,
+		coalesce(jsonb_object_agg(app_name, app_sessions), '{}'::jsonb)::jsonb AS session_counts
+	FROM (
+		SELECT
+			stats.agent_id,
+			sess.app_name,
+			SUM(sess.sessions::bigint) AS app_sessions
+		FROM stats, jsonb_each_text(stats.session_counts) AS sess(app_name, sessions)
+		WHERE stats.in_latest_usage_minute
+		GROUP BY stats.agent_id, sess.app_name
+	) AS app_totals
+	GROUP BY agent_id
 )
 SELECT
-	user_id,
-	agent_id,
-	workspace_id,
-	template_id,
-	MIN(created_at) FILTER (WHERE reports_latency)::timestamptz AS aggregated_from,
-	coalesce(SUM(rx_bytes) FILTER (WHERE reports_latency), 0)::bigint AS workspace_rx_bytes,
-	coalesce(SUM(tx_bytes) FILTER (WHERE reports_latency), 0)::bigint AS workspace_tx_bytes,
-	coalesce((PERCENTILE_CONT(0.5) WITHIN GROUP (ORDER BY connection_median_latency_ms) FILTER (WHERE reports_latency)), -1)::FLOAT AS workspace_connection_latency_50,
-	coalesce((PERCENTILE_CONT(0.95) WITHIN GROUP (ORDER BY connection_median_latency_ms) FILTER (WHERE reports_latency)), -1)::FLOAT AS workspace_connection_latency_95,
+	stats.user_id,
+	stats.agent_id,
+	stats.workspace_id,
+	stats.template_id,
+	MIN(stats.created_at) FILTER (WHERE reports_latency)::timestamptz AS aggregated_from,
+	coalesce(SUM(stats.rx_bytes) FILTER (WHERE reports_latency), 0)::bigint AS workspace_rx_bytes,
+	coalesce(SUM(stats.tx_bytes) FILTER (WHERE reports_latency), 0)::bigint AS workspace_tx_bytes,
+	coalesce((PERCENTILE_CONT(0.5) WITHIN GROUP (ORDER BY stats.connection_median_latency_ms) FILTER (WHERE reports_latency)), -1)::FLOAT AS workspace_connection_latency_50,
+	coalesce((PERCENTILE_CONT(0.95) WITHIN GROUP (ORDER BY stats.connection_median_latency_ms) FILTER (WHERE reports_latency)), -1)::FLOAT AS workspace_connection_latency_95,
 	-- Repeated so this row keeps the same layout as GetWorkspaceAgentStats, which
 	-- telemetry converts between.
-	agent_id,
-	coalesce(SUM(sc.vscode) FILTER (WHERE in_latest_usage_minute), 0)::bigint AS session_count_vscode,
-	coalesce(SUM(sc.ssh) FILTER (WHERE in_latest_usage_minute), 0)::bigint AS session_count_ssh,
-	coalesce(SUM(sc.jetbrains) FILTER (WHERE in_latest_usage_minute), 0)::bigint AS session_count_jetbrains,
-	coalesce(SUM(sc.reconnecting_pty) FILTER (WHERE in_latest_usage_minute), 0)::bigint AS session_count_reconnecting_pty
+	stats.agent_id,
+	coalesce(latest_sessions.session_counts, '{}'::jsonb)::jsonb AS session_counts
 FROM stats
-CROSS JOIN LATERAL (
-	SELECT
-		coalesce(SUM(sess.value::bigint) FILTER (WHERE sess.key = ANY (fams.vscode)), 0) AS vscode,
-		coalesce(SUM(sess.value::bigint) FILTER (WHERE sess.key = ANY (fams.ssh)), 0) AS ssh,
-		coalesce(SUM(sess.value::bigint) FILTER (WHERE sess.key = ANY (fams.jetbrains)), 0) AS jetbrains,
-		coalesce(SUM(sess.value::bigint) FILTER (WHERE sess.key = ANY (fams.reconnecting_pty)), 0) AS reconnecting_pty
-	FROM fams, jsonb_each_text(stats.session_counts) AS sess
-	-- Gate on the same condition as the aggregate filters above so the
-	-- decompose runs only for the rows that are counted (one-time filter).
-	WHERE stats.in_latest_usage_minute
-) AS sc
-GROUP BY user_id, agent_id, workspace_id, template_id
+LEFT JOIN latest_sessions ON latest_sessions.agent_id = stats.agent_id
+GROUP BY stats.user_id, stats.agent_id, stats.workspace_id, stats.template_id, latest_sessions.session_counts
 HAVING BOOL_OR(reports_latency);
 
 -- name: GetWorkspaceAgentStatsAndLabels :many
-WITH fams AS (
-	SELECT
-		ARRAY(SELECT jsonb_array_elements_text(@app_families::jsonb -> 'vscode')) AS vscode,
-		ARRAY(SELECT jsonb_array_elements_text(@app_families::jsonb -> 'ssh')) AS ssh,
-		ARRAY(SELECT jsonb_array_elements_text(@app_families::jsonb -> 'jetbrains')) AS jetbrains,
-		ARRAY(SELECT jsonb_array_elements_text(@app_families::jsonb -> 'reconnecting_pty')) AS reconnecting_pty
-), agent_stats AS (
+WITH agent_stats AS (
 	SELECT
 		user_id,
 		agent_id,
@@ -286,35 +262,41 @@ WITH fams AS (
 	 FROM workspace_agent_stats
 		WHERE workspace_agent_stats.created_at > $1
 		GROUP BY user_id, agent_id, workspace_id
+), latest_stats AS (
+	SELECT *, ROW_NUMBER() OVER(PARTITION BY agent_id ORDER BY created_at DESC) AS rn
+	FROM workspace_agent_stats
+	-- The greater than 0 is to support legacy agents that don't report connection_median_latency_ms.
+	WHERE created_at > $1 AND connection_median_latency_ms > 0
+), latest_sessions AS (
+	-- Summed per app name here so the connection aggregates below keep seeing
+	-- one row per agent instead of one row per app name.
+	SELECT
+		agent_id,
+		coalesce(jsonb_object_agg(app_name, app_sessions), '{}'::jsonb)::jsonb AS session_counts
+	FROM (
+		SELECT
+			a.agent_id,
+			sess.app_name,
+			SUM(sess.sessions::bigint) AS app_sessions
+		FROM latest_stats AS a, jsonb_each_text(a.session_counts) AS sess(app_name, sessions)
+		WHERE a.rn = 1
+		GROUP BY a.agent_id, sess.app_name
+	) AS app_totals
+	GROUP BY agent_id
 ), latest_agent_stats AS (
 	SELECT
 		a.agent_id,
-		coalesce(SUM(sc.vscode), 0)::bigint AS session_count_vscode,
-		coalesce(SUM(sc.ssh), 0)::bigint AS session_count_ssh,
-		coalesce(SUM(sc.jetbrains), 0)::bigint AS session_count_jetbrains,
-		coalesce(SUM(sc.reconnecting_pty), 0)::bigint AS session_count_reconnecting_pty,
+		coalesce(latest_sessions.session_counts, '{}'::jsonb)::jsonb AS session_counts,
 		coalesce(SUM(a.connection_count), 0)::bigint AS connection_count,
 		coalesce(MAX(a.connection_median_latency_ms), 0)::float AS connection_median_latency_ms
-	 FROM (
-		SELECT *, ROW_NUMBER() OVER(PARTITION BY agent_id ORDER BY created_at DESC) AS rn
-		FROM workspace_agent_stats
-		-- The greater than 0 is to support legacy agents that don't report connection_median_latency_ms.
-		WHERE created_at > $1 AND connection_median_latency_ms > 0
-	) AS a
-	CROSS JOIN LATERAL (
-		SELECT
-			coalesce(SUM(sess.value::bigint) FILTER (WHERE sess.key = ANY (fams.vscode)), 0) AS vscode,
-			coalesce(SUM(sess.value::bigint) FILTER (WHERE sess.key = ANY (fams.ssh)), 0) AS ssh,
-			coalesce(SUM(sess.value::bigint) FILTER (WHERE sess.key = ANY (fams.jetbrains)), 0) AS jetbrains,
-			coalesce(SUM(sess.value::bigint) FILTER (WHERE sess.key = ANY (fams.reconnecting_pty)), 0) AS reconnecting_pty
-		FROM fams, jsonb_each_text(a.session_counts) AS sess
-	) AS sc
+	FROM latest_stats AS a
+	LEFT JOIN latest_sessions ON latest_sessions.agent_id = a.agent_id
 	WHERE a.rn = 1
-	GROUP BY a.user_id, a.agent_id, a.workspace_id
+	GROUP BY a.user_id, a.agent_id, a.workspace_id, latest_sessions.session_counts
 )
 SELECT
 	users.username, workspace_agents.name AS agent_name, workspaces.name AS workspace_name, rx_bytes, tx_bytes,
-	session_count_vscode, session_count_ssh, session_count_jetbrains, session_count_reconnecting_pty,
+	session_counts,
 	connection_count, connection_median_latency_ms
 FROM
 	agent_stats
@@ -336,13 +318,7 @@ ON
 	workspaces.id = agent_stats.workspace_id;
 
 -- name: GetWorkspaceAgentUsageStatsAndLabels :many
-WITH fams AS (
-	SELECT
-		ARRAY(SELECT jsonb_array_elements_text(@app_families::jsonb -> 'vscode')) AS vscode,
-		ARRAY(SELECT jsonb_array_elements_text(@app_families::jsonb -> 'ssh')) AS ssh,
-		ARRAY(SELECT jsonb_array_elements_text(@app_families::jsonb -> 'jetbrains')) AS jetbrains,
-		ARRAY(SELECT jsonb_array_elements_text(@app_families::jsonb -> 'reconnecting_pty')) AS reconnecting_pty
-), agent_stats AS (
+WITH agent_stats AS (
 	SELECT
 		user_id,
 		agent_id,
@@ -354,34 +330,39 @@ WITH fams AS (
 	-- The greater than 0 is to support legacy agents that don't report connection_median_latency_ms.
 	WHERE workspace_agent_stats.created_at > $1 AND connection_median_latency_ms > 0
 	GROUP BY user_id, agent_id, workspace_id
-), latest_agent_stats AS (
-	SELECT
-		agent_id,
-		coalesce(SUM(sc.vscode), 0)::bigint AS session_count_vscode,
-		coalesce(SUM(sc.ssh), 0)::bigint AS session_count_ssh,
-		coalesce(SUM(sc.jetbrains), 0)::bigint AS session_count_jetbrains,
-		coalesce(SUM(sc.reconnecting_pty), 0)::bigint AS session_count_reconnecting_pty,
-		coalesce(SUM(connection_count), 0)::bigint AS connection_count
+), latest_stats AS (
+	SELECT *
 	FROM workspace_agent_stats
-	CROSS JOIN LATERAL (
-		SELECT
-			coalesce(SUM(sess.value::bigint) FILTER (WHERE sess.key = ANY (fams.vscode)), 0) AS vscode,
-			coalesce(SUM(sess.value::bigint) FILTER (WHERE sess.key = ANY (fams.ssh)), 0) AS ssh,
-			coalesce(SUM(sess.value::bigint) FILTER (WHERE sess.key = ANY (fams.jetbrains)), 0) AS jetbrains,
-			coalesce(SUM(sess.value::bigint) FILTER (WHERE sess.key = ANY (fams.reconnecting_pty)), 0) AS reconnecting_pty
-		FROM fams, jsonb_each_text(workspace_agent_stats.session_counts) AS sess
-	) AS sc
 	-- We only want the latest stats, but those stats might be
 	-- spread across multiple rows.
 	WHERE usage AND created_at > now() - '1 minute'::interval
-	GROUP BY user_id, agent_id, workspace_id
+), latest_sessions AS (
+	-- Summed per app name here so the connection count below keeps seeing one
+	-- row per agent instead of one row per app name.
+	SELECT
+		agent_id,
+		coalesce(jsonb_object_agg(app_name, app_sessions), '{}'::jsonb)::jsonb AS session_counts
+	FROM (
+		SELECT
+			latest_stats.agent_id,
+			sess.app_name,
+			SUM(sess.sessions::bigint) AS app_sessions
+		FROM latest_stats, jsonb_each_text(latest_stats.session_counts) AS sess(app_name, sessions)
+		GROUP BY latest_stats.agent_id, sess.app_name
+	) AS app_totals
+	GROUP BY agent_id
+), latest_agent_stats AS (
+	SELECT
+		latest_stats.agent_id,
+		coalesce(latest_sessions.session_counts, '{}'::jsonb)::jsonb AS session_counts,
+		coalesce(SUM(latest_stats.connection_count), 0)::bigint AS connection_count
+	FROM latest_stats
+	LEFT JOIN latest_sessions ON latest_sessions.agent_id = latest_stats.agent_id
+	GROUP BY latest_stats.user_id, latest_stats.agent_id, latest_stats.workspace_id, latest_sessions.session_counts
 )
 SELECT
 	users.username, workspace_agents.name AS agent_name, workspaces.name AS workspace_name, rx_bytes, tx_bytes,
-	coalesce(session_count_vscode, 0)::bigint AS session_count_vscode,
-	coalesce(session_count_ssh, 0)::bigint AS session_count_ssh,
-	coalesce(session_count_jetbrains, 0)::bigint AS session_count_jetbrains,
-	coalesce(session_count_reconnecting_pty, 0)::bigint AS session_count_reconnecting_pty,
+	coalesce(session_counts, '{}'::jsonb)::jsonb AS session_counts,
 	coalesce(connection_count, 0)::bigint AS connection_count,
 	connection_median_latency_ms
 FROM

--- a/coderd/database/session_counts_latest_test.go
+++ b/coderd/database/session_counts_latest_test.go
@@ -1,0 +1,211 @@
+package database_test
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+
+	"github.com/coder/coder/v2/coderd/database"
+	"github.com/coder/coder/v2/coderd/database/dbgen"
+	"github.com/coder/coder/v2/coderd/database/dbtestutil"
+	"github.com/coder/coder/v2/coderd/database/dbtime"
+	"github.com/coder/coder/v2/codersdk"
+)
+
+// GetWorkspaceAgentStats and GetWorkspaceAgentStatsAndLabels report the
+// sessions of an agent's latest row only, while their byte and latency
+// aggregates cover every row in the window. These tests pin that split: the
+// per-app object must equal the latest row's session_counts exactly, with no
+// contribution from older rows and no row multiplication in the aggregates
+// beside it.
+
+// sessionCountsByApp decodes the per-app session count object a session count
+// query returns. Comparing the decoded map rather than the raw bytes keeps the
+// assertion about the counts instead of about jsonb key ordering.
+func sessionCountsByApp(t *testing.T, data json.RawMessage) map[string]int64 {
+	t.Helper()
+
+	counts := map[string]int64{}
+	if len(data) > 0 {
+		require.NoError(t, json.Unmarshal(data, &counts))
+	}
+	return counts
+}
+
+func TestGetWorkspaceAgentStatsLatestRowSessions(t *testing.T) {
+	t.Parallel()
+
+	db, _ := dbtestutil.NewDB(t)
+	ctx := context.Background()
+	now := dbtime.Now()
+
+	// The query groups by the owner columns, so every row of an agent must
+	// share them.
+	newAgent := func() database.WorkspaceAgentStat {
+		return database.WorkspaceAgentStat{
+			UserID:      uuid.New(),
+			AgentID:     uuid.New(),
+			WorkspaceID: uuid.New(),
+			TemplateID:  uuid.New(),
+		}
+	}
+	insert := func(owner database.WorkspaceAgentStat, createdAt time.Time, counts map[string]int64) {
+		stat := owner
+		stat.CreatedAt = createdAt
+		stat.RxBytes = 10
+		stat.TxBytes = 1
+		// Rows only reach the byte and latency aggregates with a latency
+		// above zero.
+		stat.ConnectionMedianLatencyMS = 5
+		stat.SessionCounts = dbgen.SessionCounts(t, counts)
+		dbgen.WorkspaceAgentStat(t, db, stat)
+	}
+
+	// Superseded: the latest row replaces the older row's apps entirely, and
+	// names the app family registry does not know are reported all the same.
+	superseded := newAgent()
+	insert(superseded, now.Add(-2*time.Minute), map[string]int64{"vscode": 2, "ssh": 1})
+	insert(superseded, now.Add(-time.Minute), map[string]int64{"jetbrains": 1, "some_new_ide": 2})
+
+	// Idle: the latest row reports no sessions, so the agent keeps its row
+	// with no sessions rather than disappearing or inheriting the older row's.
+	idle := newAgent()
+	insert(idle, now.Add(-2*time.Minute), map[string]int64{"ssh": 3})
+	insert(idle, now.Add(-time.Minute), nil)
+
+	// Family: two apps of one family in a single row stay separate per app and
+	// add up per family, which is what the metrics and telemetry paths report.
+	family := newAgent()
+	insert(family, now.Add(-time.Minute), map[string]int64{"cursor": 1, "vscode": 2})
+
+	stats, err := db.GetWorkspaceAgentStats(ctx, now.Add(-time.Hour))
+	require.NoError(t, err)
+
+	byAgent := map[uuid.UUID]database.GetWorkspaceAgentStatsRow{}
+	for _, stat := range stats {
+		byAgent[stat.AgentID] = stat
+	}
+	require.Len(t, byAgent, 3)
+
+	supersededRow := byAgent[superseded.AgentID]
+	require.Equal(t, map[string]int64{"jetbrains": 1, "some_new_ide": 2},
+		sessionCountsByApp(t, supersededRow.SessionCounts),
+		"only the latest row's sessions count")
+	// Both rows still reach the byte aggregates, which is what catches a
+	// decomposed session row multiplying them.
+	require.Equal(t, int64(20), supersededRow.WorkspaceRxBytes)
+	require.Equal(t, int64(2), supersededRow.WorkspaceTxBytes)
+	require.Equal(t, superseded.AgentID, supersededRow.AgentID_2,
+		"the repeated agent_id column keeps the row layout telemetry converts between")
+
+	idleRow := byAgent[idle.AgentID]
+	require.Empty(t, sessionCountsByApp(t, idleRow.SessionCounts),
+		"the previous row's sessions must not be resurrected")
+	require.Equal(t, int64(20), idleRow.WorkspaceRxBytes)
+
+	familyRow := byAgent[family.AgentID]
+	require.Equal(t, map[string]int64{"cursor": 1, "vscode": 2},
+		sessionCountsByApp(t, familyRow.SessionCounts))
+	require.Equal(t, int64(3),
+		sessionFamilyCounts(t, familyRow.SessionCounts)[codersdk.AppFamilyVSCode],
+		"apps of one family add up per family")
+}
+
+func TestGetWorkspaceAgentStatsAndLabelsLatestRowSessions(t *testing.T) {
+	t.Parallel()
+
+	db, _ := dbtestutil.NewDB(t)
+	ctx := context.Background()
+	now := dbtime.Now()
+
+	user := dbgen.User(t, db, database.User{})
+	org := dbgen.Organization(t, db, database.Organization{})
+	template := dbgen.Template(t, db, database.Template{
+		OrganizationID: org.ID,
+		CreatedBy:      user.ID,
+	})
+
+	// newAgent returns the owner columns of an agent that the query can join
+	// to a user, a workspace, and a workspace agent.
+	newAgent := func() (database.WorkspaceAgentStat, database.WorkspaceAgent, database.WorkspaceTable) {
+		job := dbgen.ProvisionerJob(t, db, nil, database.ProvisionerJob{
+			OrganizationID: org.ID,
+		})
+		resource := dbgen.WorkspaceResource(t, db, database.WorkspaceResource{
+			JobID: job.ID,
+		})
+		agent := dbgen.WorkspaceAgent(t, db, database.WorkspaceAgent{
+			ResourceID: resource.ID,
+		})
+		workspace := dbgen.Workspace(t, db, database.WorkspaceTable{
+			OwnerID:        user.ID,
+			OrganizationID: org.ID,
+			TemplateID:     template.ID,
+		})
+		return database.WorkspaceAgentStat{
+			UserID:      user.ID,
+			AgentID:     agent.ID,
+			WorkspaceID: workspace.ID,
+			TemplateID:  template.ID,
+		}, agent, workspace
+	}
+	insert := func(owner database.WorkspaceAgentStat, createdAt time.Time, latencyMS float64, connectionCount int64, counts map[string]int64) {
+		stat := owner
+		stat.CreatedAt = createdAt
+		stat.RxBytes = 4
+		stat.TxBytes = 2
+		// The latest row is the latest one reporting a latency above zero.
+		stat.ConnectionMedianLatencyMS = latencyMS
+		stat.ConnectionCount = connectionCount
+		stat.SessionCounts = dbgen.SessionCounts(t, counts)
+		dbgen.WorkspaceAgentStat(t, db, stat)
+	}
+
+	superseded, supersededAgent, supersededWorkspace := newAgent()
+	insert(superseded, now.Add(-2*time.Minute), 5, 1, map[string]int64{"ssh": 1})
+	insert(superseded, now.Add(-time.Minute), 7, 3, map[string]int64{"cursor": 1, "vscode": 2})
+	// Newest of all, but a latency of zero keeps it out of the latest row
+	// selection, so its sessions and connection count must not be reported.
+	// Legacy agents report no latency, and the byte aggregates still take it.
+	insert(superseded, now.Add(-30*time.Second), 0, 99, map[string]int64{"jetbrains": 5})
+
+	idle, idleAgent, _ := newAgent()
+	insert(idle, now.Add(-2*time.Minute), 5, 1, map[string]int64{"ssh": 9})
+	insert(idle, now.Add(-time.Minute), 5, 2, nil)
+
+	stats, err := db.GetWorkspaceAgentStatsAndLabels(ctx, now.Add(-time.Hour))
+	require.NoError(t, err)
+
+	byAgentName := map[string]database.GetWorkspaceAgentStatsAndLabelsRow{}
+	for _, stat := range stats {
+		byAgentName[stat.AgentName] = stat
+	}
+	require.Len(t, byAgentName, 2)
+
+	supersededRow := byAgentName[supersededAgent.Name]
+	require.Equal(t, user.Username, supersededRow.Username)
+	require.Equal(t, supersededWorkspace.Name, supersededRow.WorkspaceName)
+	require.Equal(t, map[string]int64{"cursor": 1, "vscode": 2},
+		sessionCountsByApp(t, supersededRow.SessionCounts),
+		"only the latest row reporting a latency counts")
+	require.Equal(t, int64(3), supersededRow.ConnectionCount,
+		"the connection count comes from that row alone")
+	require.Equal(t, float64(7), supersededRow.ConnectionMedianLatencyMS)
+	// Every row in the window still reaches the byte aggregates, the zero
+	// latency one included.
+	require.Equal(t, int64(12), supersededRow.RxBytes)
+	require.Equal(t, int64(6), supersededRow.TxBytes)
+	require.Equal(t, int64(3),
+		sessionFamilyCounts(t, supersededRow.SessionCounts)[codersdk.AppFamilyVSCode],
+		"apps of one family add up per family")
+
+	idleRow := byAgentName[idleAgent.Name]
+	require.Empty(t, sessionCountsByApp(t, idleRow.SessionCounts),
+		"the previous row's sessions must not be resurrected")
+	require.Equal(t, int64(2), idleRow.ConnectionCount)
+	require.Equal(t, int64(8), idleRow.RxBytes)
+}

--- a/coderd/metricscache/metricscache.go
+++ b/coderd/metricscache/metricscache.go
@@ -138,22 +138,23 @@ func (c *Cache) refreshDeploymentStats(ctx context.Context) error {
 	)
 
 	if c.usage {
-		agentUsageStats, err := c.database.GetDeploymentWorkspaceAgentUsageStats(ctx, database.GetDeploymentWorkspaceAgentUsageStatsParams{
-			CreatedAt:   from,
-			AppFamilies: codersdk.SessionCountAppFamiliesJSON(),
-		})
+		agentUsageStats, err := c.database.GetDeploymentWorkspaceAgentUsageStats(ctx, from)
 		if err != nil {
 			return err
 		}
 		agentStats = database.GetDeploymentWorkspaceAgentStatsRow(agentUsageStats)
 	} else {
-		agentStats, err = c.database.GetDeploymentWorkspaceAgentStats(ctx, database.GetDeploymentWorkspaceAgentStatsParams{
-			CreatedAt:   from,
-			AppFamilies: codersdk.SessionCountAppFamiliesJSON(),
-		})
+		agentStats, err = c.database.GetDeploymentWorkspaceAgentStats(ctx, from)
 		if err != nil {
 			return err
 		}
+	}
+
+	// The query sums sessions per app name, so a session reported under a name
+	// this version does not know about is counted here rather than dropped.
+	sessionCounts, err := codersdk.SessionCountsByFamilyJSON(agentStats.SessionCounts)
+	if err != nil {
+		return xerrors.Errorf("group deployment session counts by app family: %w", err)
 	}
 
 	workspaceStats, err := c.database.GetDeploymentWorkspaceStats(ctx)
@@ -178,10 +179,10 @@ func (c *Cache) refreshDeploymentStats(ctx context.Context) error {
 			TxBytes: agentStats.WorkspaceTxBytes,
 		},
 		SessionCount: codersdk.SessionCountDeploymentStats{
-			VSCode:          agentStats.SessionCountVSCode,
-			SSH:             agentStats.SessionCountSSH,
-			JetBrains:       agentStats.SessionCountJetBrains,
-			ReconnectingPTY: agentStats.SessionCountReconnectingPTY,
+			VSCode:          sessionCounts[codersdk.AppFamilyVSCode],
+			SSH:             sessionCounts[codersdk.AppFamilySSH],
+			JetBrains:       sessionCounts[codersdk.AppFamilyJetBrains],
+			ReconnectingPTY: sessionCounts[codersdk.AppFamilyReconnectingPTY],
 		},
 	})
 	return nil

--- a/coderd/metricscache/metricscache_test.go
+++ b/coderd/metricscache/metricscache_test.go
@@ -313,7 +313,9 @@ func TestCache_DeploymentStats(t *testing.T) {
 		TxBytes:                   1,
 		ConnectionCount:           1,
 		ConnectionMedianLatencyMS: 10,
-		SessionCounts:             dbgen.SessionCounts(t, map[string]int64{"vscode": 1}),
+		// Names from the same family, one of them an alias, so the fixed
+		// deployment stats fields cover the app name folding.
+		SessionCounts: dbgen.SessionCounts(t, map[string]int64{"vscode": 1, "cursor": 2, "zed": 3}),
 	})
 
 	// Wait for both ticker functions to be created (template build times and deployment stats)
@@ -324,5 +326,6 @@ func TestCache_DeploymentStats(t *testing.T) {
 
 	stat, ok := cache.DeploymentStats()
 	require.True(t, ok, "cache should be populated after refresh")
-	require.Equal(t, int64(1), stat.SessionCount.VSCode)
+	require.Equal(t, int64(3), stat.SessionCount.VSCode)
+	require.Equal(t, int64(3), stat.SessionCount.SSH)
 }

--- a/coderd/prometheusmetrics/prometheusmetrics.go
+++ b/coderd/prometheusmetrics/prometheusmetrics.go
@@ -567,19 +567,13 @@ func AgentStats(ctx context.Context, logger slog.Logger, registerer prometheus.R
 			)
 			if usage {
 				var agentUsageStats []database.GetWorkspaceAgentUsageStatsAndLabelsRow
-				agentUsageStats, err = db.GetWorkspaceAgentUsageStatsAndLabels(ctx, database.GetWorkspaceAgentUsageStatsAndLabelsParams{
-					CreatedAt:   createdAfter,
-					AppFamilies: codersdk.SessionCountAppFamiliesJSON(),
-				})
+				agentUsageStats, err = db.GetWorkspaceAgentUsageStatsAndLabels(ctx, createdAfter)
 				stats = make([]database.GetWorkspaceAgentStatsAndLabelsRow, 0, len(agentUsageStats))
 				for _, agentUsageStat := range agentUsageStats {
 					stats = append(stats, database.GetWorkspaceAgentStatsAndLabelsRow(agentUsageStat))
 				}
 			} else {
-				stats, err = db.GetWorkspaceAgentStatsAndLabels(ctx, database.GetWorkspaceAgentStatsAndLabelsParams{
-					CreatedAt:   createdAfter,
-					AppFamilies: codersdk.SessionCountAppFamiliesJSON(),
-				})
+				stats, err = db.GetWorkspaceAgentStatsAndLabels(ctx, createdAfter)
 			}
 			if err != nil {
 				logger.Error(ctx, "can't get agent stats", slog.Error(err))
@@ -603,10 +597,24 @@ func AgentStats(ctx context.Context, logger slog.Logger, registerer prometheus.R
 					agentStatsConnectionCountGauge.WithLabelValues(VectorOperationSet, float64(agentStat.ConnectionCount), labelValues...)
 					agentStatsConnectionMedianLatencyGauge.WithLabelValues(VectorOperationSet, agentStat.ConnectionMedianLatencyMS/1000.0 /* (to seconds) */, labelValues...)
 
-					agentStatsSessionCountJetBrainsGauge.WithLabelValues(VectorOperationSet, float64(agentStat.SessionCountJetBrains), labelValues...)
-					agentStatsSessionCountReconnectingPTYGauge.WithLabelValues(VectorOperationSet, float64(agentStat.SessionCountReconnectingPTY), labelValues...)
-					agentStatsSessionCountSSHGauge.WithLabelValues(VectorOperationSet, float64(agentStat.SessionCountSSH), labelValues...)
-					agentStatsSessionCountVSCodeGauge.WithLabelValues(VectorOperationSet, float64(agentStat.SessionCountVSCode), labelValues...)
+					// The query sums sessions per app name, so a session reported
+					// under a name this version does not know about is counted
+					// here rather than dropped. A malformed sum leaves the other
+					// gauges for this agent intact.
+					sessionCounts, err := codersdk.SessionCountsByFamilyJSON(agentStat.SessionCounts)
+					if err != nil {
+						logger.Error(ctx, "can't group agent session counts by app family",
+							slog.F("agent_name", agentStat.AgentName),
+							slog.F("workspace_name", agentStat.WorkspaceName),
+							slog.Error(err),
+						)
+						continue
+					}
+
+					agentStatsSessionCountJetBrainsGauge.WithLabelValues(VectorOperationSet, float64(sessionCounts[codersdk.AppFamilyJetBrains]), labelValues...)
+					agentStatsSessionCountReconnectingPTYGauge.WithLabelValues(VectorOperationSet, float64(sessionCounts[codersdk.AppFamilyReconnectingPTY]), labelValues...)
+					agentStatsSessionCountSSHGauge.WithLabelValues(VectorOperationSet, float64(sessionCounts[codersdk.AppFamilySSH]), labelValues...)
+					agentStatsSessionCountVSCodeGauge.WithLabelValues(VectorOperationSet, float64(sessionCounts[codersdk.AppFamilyVSCode]), labelValues...)
 				}
 
 				if len(stats) > 0 {

--- a/coderd/telemetry/telemetry.go
+++ b/coderd/telemetry/telemetry.go
@@ -647,28 +647,30 @@ func (r *remoteReporter) createSnapshot() (*Snapshot, error) {
 	})
 	eg.Go(func() error {
 		if r.options.DeploymentConfig != nil && slices.Contains(r.options.DeploymentConfig.Experiments, string(codersdk.ExperimentWorkspaceUsage)) {
-			agentStats, err := r.options.Database.GetWorkspaceAgentUsageStats(ctx, database.GetWorkspaceAgentUsageStatsParams{
-				CreatedAt:   createdAfter,
-				AppFamilies: codersdk.SessionCountAppFamiliesJSON(),
-			})
+			agentStats, err := r.options.Database.GetWorkspaceAgentUsageStats(ctx, createdAfter)
 			if err != nil {
 				return xerrors.Errorf("get workspace agent stats: %w", err)
 			}
 			snapshot.WorkspaceAgentStats = make([]WorkspaceAgentStat, 0, len(agentStats))
 			for _, stat := range agentStats {
-				snapshot.WorkspaceAgentStats = append(snapshot.WorkspaceAgentStats, ConvertWorkspaceAgentStat(database.GetWorkspaceAgentStatsRow(stat)))
+				converted, err := ConvertWorkspaceAgentStat(database.GetWorkspaceAgentStatsRow(stat))
+				if err != nil {
+					return xerrors.Errorf("convert workspace agent stat: %w", err)
+				}
+				snapshot.WorkspaceAgentStats = append(snapshot.WorkspaceAgentStats, converted)
 			}
 		} else {
-			agentStats, err := r.options.Database.GetWorkspaceAgentStats(ctx, database.GetWorkspaceAgentStatsParams{
-				CreatedAt:   createdAfter,
-				AppFamilies: codersdk.SessionCountAppFamiliesJSON(),
-			})
+			agentStats, err := r.options.Database.GetWorkspaceAgentStats(ctx, createdAfter)
 			if err != nil {
 				return xerrors.Errorf("get workspace agent stats: %w", err)
 			}
 			snapshot.WorkspaceAgentStats = make([]WorkspaceAgentStat, 0, len(agentStats))
 			for _, stat := range agentStats {
-				snapshot.WorkspaceAgentStats = append(snapshot.WorkspaceAgentStats, ConvertWorkspaceAgentStat(stat))
+				converted, err := ConvertWorkspaceAgentStat(stat)
+				if err != nil {
+					return xerrors.Errorf("convert workspace agent stat: %w", err)
+				}
+				snapshot.WorkspaceAgentStats = append(snapshot.WorkspaceAgentStats, converted)
 			}
 		}
 		return nil
@@ -1285,8 +1287,14 @@ func ConvertWorkspaceAgentVolumeResourceMonitor(monitor database.WorkspaceAgentV
 	}
 }
 
-// ConvertWorkspaceAgentStat anonymizes a workspace agent stat.
-func ConvertWorkspaceAgentStat(stat database.GetWorkspaceAgentStatsRow) WorkspaceAgentStat {
+// ConvertWorkspaceAgentStat anonymizes a workspace agent stat. The query sums
+// sessions per app name, so a session reported under a name this version does
+// not know about is counted here rather than dropped.
+func ConvertWorkspaceAgentStat(stat database.GetWorkspaceAgentStatsRow) (WorkspaceAgentStat, error) {
+	sessionCounts, err := codersdk.SessionCountsByFamilyJSON(stat.SessionCounts)
+	if err != nil {
+		return WorkspaceAgentStat{}, xerrors.Errorf("group session counts by app family: %w", err)
+	}
 	return WorkspaceAgentStat{
 		UserID:                      stat.UserID,
 		TemplateID:                  stat.TemplateID,
@@ -1297,11 +1305,11 @@ func ConvertWorkspaceAgentStat(stat database.GetWorkspaceAgentStatsRow) Workspac
 		ConnectionLatency95:         stat.WorkspaceConnectionLatency95,
 		RxBytes:                     stat.WorkspaceRxBytes,
 		TxBytes:                     stat.WorkspaceTxBytes,
-		SessionCountVSCode:          stat.SessionCountVSCode,
-		SessionCountJetBrains:       stat.SessionCountJetBrains,
-		SessionCountReconnectingPTY: stat.SessionCountReconnectingPTY,
-		SessionCountSSH:             stat.SessionCountSSH,
-	}
+		SessionCountVSCode:          sessionCounts[codersdk.AppFamilyVSCode],
+		SessionCountJetBrains:       sessionCounts[codersdk.AppFamilyJetBrains],
+		SessionCountReconnectingPTY: sessionCounts[codersdk.AppFamilyReconnectingPTY],
+		SessionCountSSH:             sessionCounts[codersdk.AppFamilySSH],
+	}, nil
 }
 
 // ConvertWorkspaceApp anonymizes a workspace app.

--- a/coderd/telemetry/telemetry_test.go
+++ b/coderd/telemetry/telemetry_test.go
@@ -215,6 +215,9 @@ func TestTelemetry(t *testing.T) {
 
 		_ = dbgen.WorkspaceAgentStat(t, db, database.WorkspaceAgentStat{
 			ConnectionMedianLatencyMS: 1,
+			// Names from the same family, one of them an alias, so the fixed
+			// session count fields cover the app name folding.
+			SessionCounts: dbgen.SessionCounts(t, map[string]int64{"vscode": 1, "cursor": 2, "zed": 3}),
 		})
 		_, err = db.InsertLicense(ctx, database.InsertLicenseParams{
 			UploadedAt: dbtime.Now(),
@@ -334,6 +337,8 @@ func TestTelemetry(t *testing.T) {
 		require.Len(t, snapshot.WorkspaceBuilds, 2)
 		require.Len(t, snapshot.WorkspaceResources, 2)
 		require.Len(t, snapshot.WorkspaceAgentStats, 1)
+		require.Equal(t, int64(3), snapshot.WorkspaceAgentStats[0].SessionCountVSCode)
+		require.Equal(t, int64(3), snapshot.WorkspaceAgentStats[0].SessionCountSSH)
 		require.Len(t, snapshot.WorkspaceProxies, 1)
 		require.Len(t, snapshot.WorkspaceModules, 1)
 		require.Len(t, snapshot.Organizations, 1)

--- a/coderd/workspacestats/batcher_internal_test.go
+++ b/coderd/workspacestats/batcher_internal_test.go
@@ -2,6 +2,7 @@ package workspacestats
 
 import (
 	"context"
+	"encoding/json"
 	"testing"
 	"time"
 
@@ -56,11 +57,7 @@ func TestBatchStats(t *testing.T) {
 	t.Log("flush 1 completed")
 
 	// Then: it should report no stats.
-	appFamilies := codersdk.SessionCountAppFamiliesJSON()
-	stats, err := store.GetWorkspaceAgentStats(ctx, database.GetWorkspaceAgentStatsParams{
-		CreatedAt:   t1,
-		AppFamilies: appFamilies,
-	})
+	stats, err := store.GetWorkspaceAgentStats(ctx, t1)
 	require.NoError(t, err, "should not error getting stats")
 	require.Empty(t, stats, "should have no stats for workspace")
 
@@ -83,22 +80,19 @@ func TestBatchStats(t *testing.T) {
 	t.Log("flush 2 completed")
 
 	// Then: counts reach the right agent, normalized, without the zero entry.
-	stats, err = store.GetWorkspaceAgentStats(ctx, database.GetWorkspaceAgentStatsParams{
-		CreatedAt:   t2,
-		AppFamilies: appFamilies,
-	})
+	stats, err = store.GetWorkspaceAgentStats(ctx, t2)
 	require.NoError(t, err, "should not error getting stats")
 	require.Len(t, stats, 2, "should have stats for both workspaces")
 	byAgent := make(map[uuid.UUID]database.GetWorkspaceAgentStatsRow)
 	for _, stat := range stats {
 		byAgent[stat.AgentID] = stat
 	}
-	require.EqualValues(t, 3, byAgent[deps1.Agent.ID].SessionCountVSCode)
-	require.EqualValues(t, 1, byAgent[deps1.Agent.ID].SessionCountSSH)
-	require.EqualValues(t, 0, byAgent[deps1.Agent.ID].SessionCountJetBrains)
-	require.EqualValues(t, 4, byAgent[deps2.Agent.ID].SessionCountJetBrains)
-	require.EqualValues(t, 2, byAgent[deps2.Agent.ID].SessionCountReconnectingPTY)
-	require.EqualValues(t, 0, byAgent[deps2.Agent.ID].SessionCountVSCode)
+	require.EqualValues(t, 3, sessionFamilyCounts(t, byAgent[deps1.Agent.ID].SessionCounts)["vscode"])
+	require.EqualValues(t, 1, sessionFamilyCounts(t, byAgent[deps1.Agent.ID].SessionCounts)["ssh"])
+	require.EqualValues(t, 0, sessionFamilyCounts(t, byAgent[deps1.Agent.ID].SessionCounts)["jetbrains"])
+	require.EqualValues(t, 4, sessionFamilyCounts(t, byAgent[deps2.Agent.ID].SessionCounts)["jetbrains"])
+	require.EqualValues(t, 2, sessionFamilyCounts(t, byAgent[deps2.Agent.ID].SessionCounts)["reconnecting_pty"])
+	require.EqualValues(t, 0, sessionFamilyCounts(t, byAgent[deps2.Agent.ID].SessionCounts)["vscode"])
 
 	// Given: a lot of data points are added for both workspaces
 	// (equal to batch size)
@@ -125,10 +119,7 @@ func TestBatchStats(t *testing.T) {
 	// And we should finish inserting the stats
 	<-done
 
-	stats, err = store.GetWorkspaceAgentStats(ctx, database.GetWorkspaceAgentStatsParams{
-		CreatedAt:   t3,
-		AppFamilies: appFamilies,
-	})
+	stats, err = store.GetWorkspaceAgentStats(ctx, t3)
 	require.NoError(t, err, "should not error getting stats")
 	require.Len(t, stats, 2, "should have stats for both workspaces")
 
@@ -147,10 +138,7 @@ func TestBatchStats(t *testing.T) {
 	require.Zero(t, f, "expected zero stats to have been flushed")
 	t.Log("flush 5 completed")
 
-	stats, err = store.GetWorkspaceAgentStats(ctx, database.GetWorkspaceAgentStatsParams{
-		CreatedAt:   t5,
-		AppFamilies: appFamilies,
-	})
+	stats, err = store.GetWorkspaceAgentStats(ctx, t5)
 	require.NoError(t, err, "should not error getting stats")
 	require.Len(t, stats, 0, "should have no stats for workspace")
 
@@ -254,4 +242,11 @@ func mustRandInt64n(t *testing.T, n int64) int64 {
 	i, err := cryptorand.Intn(int(n))
 	require.NoError(t, err)
 	return int64(i)
+}
+
+func sessionFamilyCounts(t *testing.T, data json.RawMessage) map[codersdk.AppFamilyName]int64 {
+	t.Helper()
+	counts, err := codersdk.SessionCountsByFamilyJSON(data)
+	require.NoError(t, err)
+	return counts
 }

--- a/codersdk/appname.go
+++ b/codersdk/appname.go
@@ -5,6 +5,8 @@ import (
 	"slices"
 	"strings"
 
+	"golang.org/x/xerrors"
+
 	utilstrings "github.com/coder/coder/v2/coderd/util/strings"
 )
 
@@ -116,6 +118,33 @@ func SessionCountAppFamiliesJSON() json.RawMessage {
 		panic("developer error: marshal session count app families: " + err.Error())
 	}
 	return data
+}
+
+// SessionCountsByFamily folds per-app session counts, as the session count
+// queries report them, into per-family totals. Counts are additive: an agent
+// running Cursor and VS Code at once contributes both to the VS Code family.
+// App names with no registry entry total under AppFamilyUnknown rather than
+// being dropped.
+func SessionCountsByFamily(appCounts map[string]int64) map[AppFamilyName]int64 {
+	familyCounts := make(map[AppFamilyName]int64, len(appCounts))
+	for appName, count := range appCounts {
+		familyCounts[AppNameFamily(appName)] += count
+	}
+	return familyCounts
+}
+
+// SessionCountsByFamilyJSON is SessionCountsByFamily over the jsonb object of
+// app name to session count that the session count queries return. An absent
+// or JSON null object means no sessions, not an error, because a query with
+// no matching rows aggregates to SQL NULL.
+func SessionCountsByFamilyJSON(appCounts json.RawMessage) (map[AppFamilyName]int64, error) {
+	var counts map[string]int64
+	if len(appCounts) > 0 {
+		if err := json.Unmarshal(appCounts, &counts); err != nil {
+			return nil, xerrors.Errorf("unmarshal session counts by app name: %w", err)
+		}
+	}
+	return SessionCountsByFamily(counts), nil
 }
 
 // AppNameFamily normalizes an app name and returns its family, or

--- a/codersdk/appname_test.go
+++ b/codersdk/appname_test.go
@@ -156,3 +156,131 @@ func TestSessionCountAppFamiliesJSON(t *testing.T) {
 	require.NoError(t, json.Unmarshal(raw, &decoded), "registry must marshal to a valid jsonb object")
 	require.Equal(t, codersdk.SessionCountAppFamilies(), decoded)
 }
+
+func TestSessionCountsByFamily(t *testing.T) {
+	t.Parallel()
+
+	for _, tc := range []struct {
+		name      string
+		appCounts map[string]int64
+		want      map[codersdk.AppFamilyName]int64
+	}{
+		{
+			name:      "Empty",
+			appCounts: map[string]int64{},
+			want:      map[codersdk.AppFamilyName]int64{},
+		},
+		{
+			name:      "Nil",
+			appCounts: nil,
+			want:      map[codersdk.AppFamilyName]int64{},
+		},
+		{
+			name:      "SingleApp",
+			appCounts: map[string]int64{"jetbrains": 3},
+			want:      map[codersdk.AppFamilyName]int64{codersdk.AppFamilyJetBrains: 3},
+		},
+		{
+			// Simultaneous forks are additive within their family.
+			name:      "OverlappingAppsInOneFamily",
+			appCounts: map[string]int64{"vscode": 1, "cursor": 2, "windsurf": 4},
+			want:      map[codersdk.AppFamilyName]int64{codersdk.AppFamilyVSCode: 7},
+		},
+		{
+			name:      "UnregisteredAppIsUnknown",
+			appCounts: map[string]int64{"some_future_ide": 5, "ssh": 1},
+			want: map[codersdk.AppFamilyName]int64{
+				codersdk.AppFamilyUnknown: 5,
+				codersdk.AppFamilySSH:     1,
+			},
+		},
+		{
+			// Storage normalizes app names, but folding must not depend on it.
+			name:      "DenormalizedNamesFold",
+			appCounts: map[string]int64{"VSCode-Insiders": 2, "vscode_insiders": 1},
+			want:      map[codersdk.AppFamilyName]int64{codersdk.AppFamilyVSCode: 3},
+		},
+		{
+			name:      "AllFamilies",
+			appCounts: map[string]int64{"vscode": 1, "jetbrains": 2, "zed": 3, "reconnecting_pty": 4, "": 5},
+			want: map[codersdk.AppFamilyName]int64{
+				codersdk.AppFamilyVSCode:          1,
+				codersdk.AppFamilyJetBrains:       2,
+				codersdk.AppFamilySSH:             3,
+				codersdk.AppFamilyReconnectingPTY: 4,
+				codersdk.AppFamilyUnknown:         5,
+			},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			require.Equal(t, tc.want, codersdk.SessionCountsByFamily(tc.appCounts))
+		})
+	}
+}
+
+// Every app name the registry attributes must fold back into the family it is
+// registered under, so no attributed family can go uncounted.
+func TestSessionCountsByFamilyCoversEveryAttributedFamily(t *testing.T) {
+	t.Parallel()
+
+	appCounts := map[string]int64{}
+	want := map[codersdk.AppFamilyName]int64{}
+	for family, appNames := range codersdk.SessionCountAppFamilies() {
+		for _, appName := range appNames {
+			appCounts[appName] = 1
+			want[family]++
+		}
+	}
+	require.Equal(t, want, codersdk.SessionCountsByFamily(appCounts))
+}
+
+func TestSessionCountsByFamilyJSON(t *testing.T) {
+	t.Parallel()
+
+	for _, tc := range []struct {
+		name      string
+		appCounts json.RawMessage
+		want      map[codersdk.AppFamilyName]int64
+	}{
+		{"Counts", json.RawMessage(`{"cursor":2,"vscode":1,"ssh":4}`), map[codersdk.AppFamilyName]int64{
+			codersdk.AppFamilyVSCode: 3,
+			codersdk.AppFamilySSH:    4,
+		}},
+		{"UnknownApp", json.RawMessage(`{"some_future_ide":9}`), map[codersdk.AppFamilyName]int64{
+			codersdk.AppFamilyUnknown: 9,
+		}},
+		{"EmptyObject", json.RawMessage(`{}`), map[codersdk.AppFamilyName]int64{}},
+		// A query with no matching rows aggregates to SQL NULL, which is not
+		// an error, just no sessions.
+		{"JSONNull", json.RawMessage(`null`), map[codersdk.AppFamilyName]int64{}},
+		{"Absent", nil, map[codersdk.AppFamilyName]int64{}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			got, err := codersdk.SessionCountsByFamilyJSON(tc.appCounts)
+			require.NoError(t, err)
+			require.Equal(t, tc.want, got)
+		})
+	}
+}
+
+func TestSessionCountsByFamilyJSONMalformed(t *testing.T) {
+	t.Parallel()
+
+	for _, tc := range []struct {
+		name      string
+		appCounts json.RawMessage
+	}{
+		{"Truncated", json.RawMessage(`{"vscode":`)},
+		{"NotAnObject", json.RawMessage(`["vscode"]`)},
+		{"NonNumericCount", json.RawMessage(`{"vscode":"1"}`)},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			got, err := codersdk.SessionCountsByFamilyJSON(tc.appCounts)
+			require.Error(t, err)
+			require.Nil(t, got)
+		})
+	}
+}


### PR DESCRIPTION
Make the six raw session-count queries in `workspaceagentstats.sql` return one `session_counts` JSONB keyed by app name, and fold it into the existing per-family fields in Go with `codersdk.SessionCountsByFamily`.

Previously each query probed one hardcoded name list per family, so a new family needed a probe in six queries and a matching output column. Now the queries know nothing about families: counts are additive per app, the fold happens once in Go, and unknown names are counted under `unknown` rather than dropped. Deployment stats, Prometheus, and telemetry keep their existing fields and values. The registry parameter and its dbauthz validation go away for these six queries; they return to plain forwarding, as on `main`.

The two latest-row queries select session counts directly from the single latest eligible row, without decomposing and reaggregating its JSONB. Byte and latency aggregates stay in their own subqueries so expanding `session_counts` never multiplies them, and an agent whose latest row reports no sessions keeps its row with zero counts; both are pinned by tests.

Stacked on #28337. #29109 follows with the `template_usage_stats` storage change. Prepares #27411.

Description generated by Coder Agents for @EhabY.

<details>
<summary>Stack review decisions</summary>

Preserve the latest-row projection and output layout; remove only the redundant single-row session-map aggregation.

</details>
