### PR TITLE
fix(site): redirect created groups to the groups page

### DIFF
--- a/site/e2e/tests/groups/createGroup.spec.ts
+++ b/site/e2e/tests/groups/createGroup.spec.ts
@@ -33,7 +33,7 @@ test("create group", async ({ page, baseURL }) => {
 	await page.getByLabel("Avatar URL").fill(groupValues.avatarURL);
 	await page.getByRole("button", { name: /save/i }).click();
 
-	await expect(page).toHaveTitle(`${groupValues.displayName} - Coder`);
+	await expect(page).toHaveURL(`${baseURL}/organizations/${orgName}/groups`);
+	await expect(page).toHaveTitle("Groups - Coder");
 	await expect(page.getByText(groupValues.displayName)).toBeVisible();
-	await expect(page.getByText("No members yet")).toBeVisible();
 });

--- a/site/e2e/tests/organizationGroups.spec.ts
+++ b/site/e2e/tests/organizationGroups.spec.ts
@@ -56,12 +56,14 @@ test("create group", async ({ page }) => {
 	await page.getByLabel("Avatar URL").fill("/emojis/1f60d.png");
 	await page.getByRole("button", { name: /save/i }).click();
 
+	await expectUrl(page).toHavePathName(`/organizations/${org.name}/groups`);
+	await expect(page).toHaveTitle("Groups - Coder");
+	await page.getByText(displayName).click();
 	await expectUrl(page).toHavePathName(
 		`/organizations/${org.name}/groups/${name}`,
 	);
 	await expect(page).toHaveTitle(`${displayName} - Coder`);
 	await expect(page.getByText("No members yet")).toBeVisible();
-	await expect(page.getByText(displayName)).toBeVisible();
 
 	// Add a user to the group
 	const personToAdd = await createUser(org.id);

--- a/site/src/pages/GroupsPage/CreateGroupPage.tsx
+++ b/site/src/pages/GroupsPage/CreateGroupPage.tsx
@@ -21,12 +21,8 @@ const CreateGroupPage: FC = () => {
 
 			<CreateGroupPageView
 				onSubmit={async (data) => {
-					const newGroup = await createGroupMutation.mutateAsync(data);
-					navigate(
-						organization
-							? `/organizations/${organization}/groups/${newGroup.name}`
-							: `/deployment/groups/${newGroup.name}`,
-					);
+					await createGroupMutation.mutateAsync(data);
+					navigate("..");
 				}}
 				onCancel={() => {
 					navigate("..");


### PR DESCRIPTION
> 🤖 This PR was written by Coder Agents on behalf of Jake Howell.

Creating a group currently opens the new group's detail page. Redirect back to the groups list after creation and update both create-group end-to-end flows to lock in the list redirect.
