### PR TITLE
fix(site): redirect after creating organization

### DIFF
--- a/site/src/pages/OrganizationSettingsPage/CreateOrganizationPageView.tsx
+++ b/site/src/pages/OrganizationSettingsPage/CreateOrganizationPageView.tsx
@@ -67,13 +67,10 @@ export const CreateOrganizationPageView: FC<
 			icon: "",
 		},
 		validationSchema,
-		onSubmit: (values) => {
-			createOrganizationMutation.mutate(values, {
-				onSuccess: () => {
-					toast.success(`Organization "${values.name}" created successfully.`);
-					void navigate(`/organizations/${values.name}`);
-				},
-			});
+		onSubmit: async (values) => {
+			await createOrganizationMutation.mutateAsync(values);
+			toast.success(`Organization "${values.name}" created successfully.`);
+			void navigate(`/organizations/${values.name}`);
 		},
 	});
 	const getFieldHelpers = getFormHelpers(form, error);


### PR DESCRIPTION
> 🤖 This PR was written by Coder Agents on behalf of Jake Howell.

The create organization page regressed the redirect fix from #26890 when its mutation moved into the page view. The per-call success callback can be dropped when organization cache invalidation temporarily unmounts the form.

Await the mutation and navigate inline so successful creation reliably opens the new organization. If creation fails, `mutateAsync` rejects before the success toast and navigation, while the mutation error continues to be displayed by the existing error alert.
