### PR TITLE
fix: standardize org use in the mcp server tools

### DIFF
--- a/codersdk/toolsdk/chats.go
+++ b/codersdk/toolsdk/chats.go
@@ -97,11 +97,11 @@ The chat runs asynchronously. Poll coder_get_chat for status and read the transc
 				},
 				"organization_id": map[string]any{
 					"type":        "string",
-					"description": "Optional organization UUID. Defaults to the organization of the authenticated user's most recently updated chat. If the user has never created a chat, defaults only when they belong to one organization.",
+					"description": "Organization UUID.",
 				},
 				"model_config_id": map[string]any{
 					"type":        "string",
-					"description": "Optional chat model config UUID from coder_list_chat_model_configs. Must belong to the chat's organization. Defaults to the organization's default model.",
+					"description": "Optional chat model config UUID from coder_list_chat_model_configs. Must belong to the chat's organization. When omitted, the server uses an applicable personal override or the organization's default model.",
 				},
 				"labels": map[string]any{
 					"type":                 "object",
@@ -117,19 +117,9 @@ The chat runs asynchronously. Poll coder_get_chat for status and read the transc
 		if args.Prompt == "" {
 			return ChatToolStatus{}, xerrors.New("prompt is required")
 		}
-		var orgID uuid.UUID
-		if args.OrganizationID != "" {
-			var err error
-			orgID, err = uuid.Parse(args.OrganizationID)
-			if err != nil {
-				return ChatToolStatus{}, xerrors.New("organization_id must be a valid UUID")
-			}
-		} else {
-			var err error
-			orgID, err = defaultChatOrganization(ctx, deps)
-			if err != nil {
-				return ChatToolStatus{}, err
-			}
+		orgID, err := resolveOrganization(ctx, deps, args.OrganizationID)
+		if err != nil {
+			return ChatToolStatus{}, err
 		}
 		var modelConfigID *uuid.UUID
 		if args.ModelConfigID != "" {
@@ -153,69 +143,6 @@ The chat runs asynchronously. Poll coder_get_chat for status and read the transc
 		}
 		return chatToolStatus(deps, chat), nil
 	},
-}
-
-// defaultChatOrganization resolves the organization used by chat tools when
-// organization_id is omitted, keeping coder_create_chat and
-// coder_list_chat_model_configs consistent for multi-organization users.
-func defaultChatOrganization(ctx context.Context, deps Deps) (uuid.UUID, error) {
-	me, err := deps.coderClient.User(ctx, codersdk.Me)
-	if err != nil {
-		return uuid.Nil, err
-	}
-	// Admins can remove a user's only organization membership.
-	if len(me.OrganizationIDs) == 0 {
-		return uuid.Nil, xerrors.New("authenticated user belongs to no organization; pass organization_id explicitly")
-	}
-	if len(me.OrganizationIDs) == 1 {
-		return me.OrganizationIDs[0], nil
-	}
-
-	expClient := codersdk.NewExperimentalClient(deps.coderClient)
-	chats, err := expClient.ListChats(ctx, &codersdk.ListChatsOptions{
-		Source: codersdk.ChatListSourceCreatedByMe,
-		Pagination: codersdk.Pagination{
-			Limit: 100,
-		},
-	})
-	if err != nil {
-		return uuid.Nil, xerrors.Errorf("list chats to determine organization: %w", err)
-	}
-	// The chat list excludes archived chats by default and archiving bumps
-	// updated_at, so the most recently updated chat can be archived even
-	// when active chats exist. Fetch both states and scan the union.
-	archivedChats, err := expClient.ListChats(ctx, &codersdk.ListChatsOptions{
-		Query:  "archived:true",
-		Source: codersdk.ChatListSourceCreatedByMe,
-		Pagination: codersdk.Pagination{
-			Limit: 100,
-		},
-	})
-	if err != nil {
-		return uuid.Nil, xerrors.Errorf("list archived chats to determine organization: %w", err)
-	}
-	chats = append(chats, archivedChats...)
-	// Pinned chats sort before recently updated chats. If the user has 100
-	// pinned chats, this batch may not contain their latest chat, which is an
-	// acceptable tradeoff for keeping organization selection to one page.
-	var latest *codersdk.Chat
-	consider := func(chat *codersdk.Chat) {
-		if latest == nil || chat.UpdatedAt.After(latest.UpdatedAt) {
-			latest = chat
-		}
-	}
-	for i := range chats {
-		consider(&chats[i])
-		// Subagent activity bumps only the child row's UpdatedAt, so roots
-		// alone can misreport the most recently updated organization.
-		for j := range chats[i].Children {
-			consider(&chats[i].Children[j])
-		}
-	}
-	if latest != nil {
-		return latest.OrganizationID, nil
-	}
-	return uuid.Nil, xerrors.New("organization_id is required because the authenticated user belongs to multiple organizations and has not created a chat yet")
 }
 
 type GetChatArgs struct {
@@ -939,7 +866,7 @@ Per-user provider credentials are validated when creating a chat, so coder_creat
 			Properties: map[string]any{
 				"organization_id": map[string]any{
 					"type":        "string",
-					"description": "Optional organization UUID. Defaults to the organization of the authenticated user's most recently updated chat. If the user has never created a chat, defaults only when they belong to one organization.",
+					"description": "Organization UUID.",
 				},
 			},
 			Required: []string{},
@@ -947,19 +874,9 @@ Per-user provider credentials are validated when creating a chat, so coder_creat
 	},
 	MCPAnnotations: mcpReadOnlyAnnotations,
 	Handler: func(ctx context.Context, deps Deps, args ListChatModelConfigsArgs) (ListChatModelConfigsResponse, error) {
-		var organizationID uuid.UUID
-		if args.OrganizationID != "" {
-			var err error
-			organizationID, err = uuid.Parse(args.OrganizationID)
-			if err != nil {
-				return ListChatModelConfigsResponse{}, xerrors.New("organization_id must be a valid UUID")
-			}
-		} else {
-			var err error
-			organizationID, err = defaultChatOrganization(ctx, deps)
-			if err != nil {
-				return ListChatModelConfigsResponse{}, err
-			}
+		organizationID, err := resolveOrganization(ctx, deps, args.OrganizationID)
+		if err != nil {
+			return ListChatModelConfigsResponse{}, err
 		}
 
 		response, err := codersdk.NewExperimentalClient(deps.coderClient).ChatModels(ctx, organizationID)

--- a/codersdk/toolsdk/chats_test.go
+++ b/codersdk/toolsdk/chats_test.go
@@ -801,206 +801,47 @@ func TestChatTools(t *testing.T) {
 		require.Contains(t, auditorIDs, defaultModelConfig.ID.String())
 	})
 
-	t.Run("CreateChatUsesLastUpdatedOrganization", func(t *testing.T) {
-		ctx := testutil.Context(t, testutil.WaitLong)
-		model := coderdtest.CreateOpenAICompatChatModel(t, expClient, "")
-		organization := dbgen.Organization(t, api.Database, database.Organization{})
-		dbgen.OrganizationMember(t, api.Database, database.OrganizationMember{
-			OrganizationID: organization.ID,
-			UserID:         firstUser.UserID,
-		})
-		defaultOrgChat := dbgen.Chat(t, api.Database, database.Chat{
-			OrganizationID:    firstUser.OrganizationID,
-			OwnerID:           firstUser.UserID,
-			LastModelConfigID: model.ID,
-		})
-		dbgen.Chat(t, api.Database, database.Chat{
-			OrganizationID:    organization.ID,
-			OwnerID:           firstUser.UserID,
-			LastModelConfigID: model.ID,
-		})
-
-		err := expClient.UpdateChat(ctx, defaultOrgChat.ID, codersdk.UpdateChatRequest{
-			Archived: new(true),
-		})
-		require.NoError(t, err)
-		err = expClient.UpdateChat(ctx, defaultOrgChat.ID, codersdk.UpdateChatRequest{
-			Archived: new(false),
-		})
-		require.NoError(t, err)
-
-		created, err := testTool(t, toolsdk.CreateChat, tb, toolsdk.CreateChatArgs{
-			Prompt:        "Reuse the last updated organization.",
-			ModelConfigID: model.ID.String(),
-		})
-		require.NoError(t, err)
-		chat, err := expClient.GetChat(ctx, uuid.MustParse(created.ID))
-		require.NoError(t, err)
-		require.Equal(t, firstUser.OrganizationID, chat.OrganizationID)
-	})
-
-	t.Run("CreateChatRequiresOrganizationForNewMultiOrgUser", func(t *testing.T) {
-		organization := dbgen.Organization(t, api.Database, database.Organization{})
-		memberClient, member := coderdtest.CreateAnotherUser(t, client, firstUser.OrganizationID)
-		dbgen.OrganizationMember(t, api.Database, database.OrganizationMember{
-			OrganizationID: organization.ID,
-			UserID:         member.ID,
-		})
-		memberDeps, err := toolsdk.NewDeps(memberClient)
-		require.NoError(t, err)
-
-		_, err = testTool(t, toolsdk.CreateChat, memberDeps, toolsdk.CreateChatArgs{Prompt: "hi"})
-		require.ErrorContains(t, err, "belongs to multiple organizations")
-		require.ErrorContains(t, err, "organization_id is required")
-	})
-
-	t.Run("ListChatModelConfigsUsesLastUpdatedOrganization", func(t *testing.T) {
-		ctx := testutil.Context(t, testutil.WaitLong)
-		organization := dbgen.Organization(t, api.Database, database.Organization{})
-		memberClient, member := coderdtest.CreateAnotherUser(t, client, firstUser.OrganizationID)
-		dbgen.OrganizationMember(t, api.Database, database.OrganizationMember{
-			OrganizationID: organization.ID,
-			UserID:         member.ID,
-		})
-
-		provider, err := client.CreateAIProvider(ctx, codersdk.CreateAIProviderRequest{
-			Type:    codersdk.AIProviderTypeOpenAICompat,
-			Name:    "recent-org-" + uuid.NewString(),
-			BaseURL: chattest.OpenAI(t),
-			Enabled: true,
-			APIKeys: []string{"test-api-key"},
-		})
-		require.NoError(t, err)
-		contextLimit := int64(4096)
-		model, err := expClient.CreateChatModel(ctx, organization.ID, codersdk.CreateChatModelRequest{
-			AIProviderID: &provider.ID,
-			Model:        "gpt-4o-recent-org",
-			ContextLimit: &contextLimit,
-		})
-		require.NoError(t, err)
-		dbgen.Chat(t, api.Database, database.Chat{
-			OrganizationID:    organization.ID,
-			OwnerID:           member.ID,
-			LastModelConfigID: model.ID,
-		})
-
-		memberDeps, err := toolsdk.NewDeps(memberClient)
-		require.NoError(t, err)
-		result, err := testTool(t, toolsdk.ListChatModelConfigs, memberDeps, toolsdk.ListChatModelConfigsArgs{})
-		require.NoError(t, err)
-		require.Equal(t, organization.ID.String(), result.OrganizationID)
-		require.Len(t, result.ModelConfigs, 1)
-		require.Equal(t, model.ID.String(), result.ModelConfigs[0].ID)
-	})
-
-	t.Run("ListChatModelConfigsRequiresOrganizationForNewMultiOrgUser", func(t *testing.T) {
-		organization := dbgen.Organization(t, api.Database, database.Organization{})
-		memberClient, member := coderdtest.CreateAnotherUser(t, client, firstUser.OrganizationID)
-		dbgen.OrganizationMember(t, api.Database, database.OrganizationMember{
-			OrganizationID: organization.ID,
-			UserID:         member.ID,
-		})
-		memberDeps, err := toolsdk.NewDeps(memberClient)
-		require.NoError(t, err)
-
-		_, err = testTool(t, toolsdk.ListChatModelConfigs, memberDeps, toolsdk.ListChatModelConfigsArgs{})
-		require.ErrorContains(t, err, "belongs to multiple organizations")
-		require.ErrorContains(t, err, "organization_id is required")
-	})
-
-	t.Run("DefaultOrganizationAllChatsArchived", func(t *testing.T) {
-		ctx := testutil.Context(t, testutil.WaitLong)
-		organization := dbgen.Organization(t, api.Database, database.Organization{})
-		memberClient, member := coderdtest.CreateAnotherUser(t, client, firstUser.OrganizationID)
-		dbgen.OrganizationMember(t, api.Database, database.OrganizationMember{
-			OrganizationID: organization.ID,
-			UserID:         member.ID,
-		})
-		chat := dbgen.Chat(t, api.Database, database.Chat{
-			OrganizationID:    organization.ID,
-			OwnerID:           member.ID,
-			LastModelConfigID: defaultModelConfig.ID,
-		})
-		memberExpClient := codersdk.NewExperimentalClient(memberClient)
-		err := memberExpClient.UpdateChat(ctx, chat.ID, codersdk.UpdateChatRequest{
-			Archived: new(true),
-		})
-		require.NoError(t, err)
-
-		memberDeps, err := toolsdk.NewDeps(memberClient)
-		require.NoError(t, err)
-		result, err := testTool(t, toolsdk.ListChatModelConfigs, memberDeps, toolsdk.ListChatModelConfigsArgs{})
-		require.NoError(t, err)
-		require.Equal(t, organization.ID.String(), result.OrganizationID)
-	})
-
-	t.Run("DefaultOrganizationPrefersNewerArchivedChat", func(t *testing.T) {
-		ctx := testutil.Context(t, testutil.WaitLong)
-		organization := dbgen.Organization(t, api.Database, database.Organization{})
-		memberClient, member := coderdtest.CreateAnotherUser(t, client, firstUser.OrganizationID)
-		dbgen.OrganizationMember(t, api.Database, database.OrganizationMember{
-			OrganizationID: organization.ID,
-			UserID:         member.ID,
-		})
-		activeChat := dbgen.Chat(t, api.Database, database.Chat{
-			OrganizationID:    firstUser.OrganizationID,
-			OwnerID:           member.ID,
-			LastModelConfigID: defaultModelConfig.ID,
-		})
-		archivedChat := dbgen.Chat(t, api.Database, database.Chat{
-			OrganizationID:    organization.ID,
-			OwnerID:           member.ID,
-			LastModelConfigID: defaultModelConfig.ID,
-		})
-		require.True(t, archivedChat.UpdatedAt.After(activeChat.UpdatedAt))
-		// Archiving bumps updated_at, so the archived chat stays newest.
-		memberExpClient := codersdk.NewExperimentalClient(memberClient)
-		err := memberExpClient.UpdateChat(ctx, archivedChat.ID, codersdk.UpdateChatRequest{
-			Archived: new(true),
-		})
-		require.NoError(t, err)
-
-		memberDeps, err := toolsdk.NewDeps(memberClient)
-		require.NoError(t, err)
-		result, err := testTool(t, toolsdk.ListChatModelConfigs, memberDeps, toolsdk.ListChatModelConfigsArgs{})
-		require.NoError(t, err)
-		require.Equal(t, organization.ID.String(), result.OrganizationID)
-	})
-
-	t.Run("DefaultOrganizationConsidersChildChats", func(t *testing.T) {
-		organization := dbgen.Organization(t, api.Database, database.Organization{})
-		memberClient, member := coderdtest.CreateAnotherUser(t, client, firstUser.OrganizationID)
-		dbgen.OrganizationMember(t, api.Database, database.OrganizationMember{
-			OrganizationID: organization.ID,
-			UserID:         member.ID,
-		})
-		childOrgRoot := dbgen.Chat(t, api.Database, database.Chat{
-			OrganizationID:    organization.ID,
-			OwnerID:           member.ID,
-			LastModelConfigID: defaultModelConfig.ID,
-		})
-		rootOrgChat := dbgen.Chat(t, api.Database, database.Chat{
-			OrganizationID:    firstUser.OrganizationID,
-			OwnerID:           member.ID,
-			LastModelConfigID: defaultModelConfig.ID,
-		})
-		child := dbgen.Chat(t, api.Database, database.Chat{
-			OrganizationID:    organization.ID,
-			OwnerID:           member.ID,
-			LastModelConfigID: defaultModelConfig.ID,
-			ParentChatID:      uuid.NullUUID{UUID: childOrgRoot.ID, Valid: true},
-			RootChatID:        uuid.NullUUID{UUID: childOrgRoot.ID, Valid: true},
-		})
-		// The child must be the newest chat while its root stays older than
-		// the other organization's root, or the scenario is not exercised.
-		require.True(t, child.UpdatedAt.After(rootOrgChat.UpdatedAt))
-		require.True(t, rootOrgChat.UpdatedAt.After(childOrgRoot.UpdatedAt))
-
-		memberDeps, err := toolsdk.NewDeps(memberClient)
-		require.NoError(t, err)
-		result, err := testTool(t, toolsdk.ListChatModelConfigs, memberDeps, toolsdk.ListChatModelConfigsArgs{})
-		require.NoError(t, err)
-		require.Equal(t, organization.ID.String(), result.OrganizationID)
+	t.Run("RequiresOrganizationWithHistory", func(t *testing.T) {
+		for _, history := range []string{"None", "Active", "Archived", "ActiveAndArchived", "Pinned", "Child"} {
+			t.Run(history, func(t *testing.T) {
+				t.Parallel()
+				organization := dbgen.Organization(t, api.Database, database.Organization{})
+				memberClient, member := coderdtest.CreateAnotherUser(t, client, firstUser.OrganizationID)
+				dbgen.OrganizationMember(t, api.Database, database.OrganizationMember{
+					OrganizationID: organization.ID,
+					UserID:         member.ID,
+				})
+				if history != "None" {
+					chat := dbgen.Chat(t, api.Database, database.Chat{
+						OrganizationID:    organization.ID,
+						OwnerID:           member.ID,
+						LastModelConfigID: defaultModelConfig.ID,
+						Archived:          history == "Archived" || history == "ActiveAndArchived",
+					})
+					if history == "Pinned" {
+						err := codersdk.NewExperimentalClient(memberClient).UpdateChat(t.Context(), chat.ID, codersdk.UpdateChatRequest{PinOrder: new(int32(1))})
+						require.NoError(t, err)
+					}
+					if history == "ActiveAndArchived" {
+						dbgen.Chat(t, api.Database, database.Chat{OrganizationID: firstUser.OrganizationID, OwnerID: member.ID, LastModelConfigID: defaultModelConfig.ID})
+					}
+					if history == "Child" {
+						dbgen.Chat(t, api.Database, database.Chat{
+							OrganizationID: organization.ID, OwnerID: member.ID, LastModelConfigID: defaultModelConfig.ID,
+							ParentChatID: uuid.NullUUID{UUID: chat.ID, Valid: true}, RootChatID: uuid.NullUUID{UUID: chat.ID, Valid: true},
+						})
+					}
+				}
+				deps, err := toolsdk.NewDeps(memberClient)
+				require.NoError(t, err)
+				_, err = testTool(t, toolsdk.CreateChat, deps, toolsdk.CreateChatArgs{Prompt: "hello", ModelConfigID: defaultModelConfig.ID.String()})
+				require.ErrorContains(t, err, "organization_id is required")
+				require.ErrorContains(t, err, toolsdk.ToolNameListOrganizations)
+				_, err = testTool(t, toolsdk.ListChatModelConfigs, deps, toolsdk.ListChatModelConfigsArgs{})
+				require.ErrorContains(t, err, "organization_id is required")
+				require.ErrorContains(t, err, toolsdk.ToolNameListOrganizations)
+			})
+		}
 	})
 
 	t.Run("CreateChatZeroOrgUser", func(t *testing.T) {
@@ -1012,7 +853,7 @@ func TestChatTools(t *testing.T) {
 		orphanDeps, err := toolsdk.NewDeps(orphanClient)
 		require.NoError(t, err)
 		_, err = testTool(t, toolsdk.CreateChat, orphanDeps, toolsdk.CreateChatArgs{Prompt: "hi"})
-		require.ErrorContains(t, err, "belongs to no organization")
+		require.ErrorContains(t, err, "no organizations")
 	})
 
 	t.Run("Validation", func(t *testing.T) {
@@ -1057,4 +898,36 @@ func TestChatTools(t *testing.T) {
 			require.ErrorContains(t, err, "limit must be between 1 and 200")
 		}
 	})
+}
+
+func TestCreateChatOrganizationDefaultModel(t *testing.T) {
+	t.Parallel()
+	providerKeys := coderdtest.FakeOpenAICompatProviderAPIKeys(t)
+	client, _, api := coderdtest.NewWithAPI(t, &coderdtest.Options{ChatProviderAPIKeys: &providerKeys})
+	owner := coderdtest.CreateFirstUser(t, client)
+	expClient := codersdk.NewExperimentalClient(client)
+	firstModel := coderdtest.CreateOpenAICompatChatModel(t, expClient, "")
+	other := dbgen.Organization(t, api.Database, database.Organization{})
+	dbgen.OrganizationMember(t, api.Database, database.OrganizationMember{
+		OrganizationID: other.ID,
+		UserID:         owner.UserID,
+	})
+	model := dbgen.ChatModelConfig(t, api.Database, database.ChatModelConfig{
+		OrganizationID: other.ID,
+		AIProviderID:   uuid.NullUUID{UUID: firstModel.AIProviderID, Valid: true},
+		Model:          firstModel.Model,
+		Enabled:        true,
+		IsDefault:      true,
+	})
+	deps, err := toolsdk.NewDeps(client)
+	require.NoError(t, err)
+	created, err := testTool(t, toolsdk.CreateChat, deps, toolsdk.CreateChatArgs{
+		OrganizationID: other.ID.String(),
+		Prompt:         "hello",
+	})
+	require.NoError(t, err)
+	chat, err := expClient.GetChat(t.Context(), uuid.MustParse(created.ID))
+	require.NoError(t, err)
+	require.Equal(t, other.ID, chat.OrganizationID)
+	require.Equal(t, model.ID, chat.LastModelConfigID)
 }

--- a/codersdk/toolsdk/organizations.go
+++ b/codersdk/toolsdk/organizations.go
@@ -1,0 +1,59 @@
+package toolsdk
+
+import (
+	"context"
+
+	"github.com/google/uuid"
+	"golang.org/x/xerrors"
+
+	"github.com/coder/aisdk-go"
+	"github.com/coder/coder/v2/codersdk"
+)
+
+// ListOrganizations lists the authenticated user's visible memberships.
+var ListOrganizations = Tool[NoArgs, []codersdk.Organization]{
+	Tool: aisdk.Tool{
+		Name:        ToolNameListOrganizations,
+		Description: "List organizations the authenticated user belongs to, including IDs, names, and display names. Membership does not grant permission to perform every organization-scoped action.",
+		Schema: aisdk.Schema{
+			Properties: map[string]any{},
+			Required:   []string{},
+		},
+	},
+	MCPAnnotations: mcpReadOnlyAnnotations,
+	Handler: func(ctx context.Context, deps Deps, _ NoArgs) ([]codersdk.Organization, error) {
+		organizations, err := deps.coderClient.OrganizationsByUser(ctx, codersdk.Me)
+		if err != nil {
+			return nil, xerrors.Errorf("list organizations: %w", err)
+		}
+		if organizations == nil {
+			organizations = []codersdk.Organization{}
+		}
+		return organizations, nil
+	},
+}
+
+func resolveOrganization(ctx context.Context, deps Deps, organizationID string) (uuid.UUID, error) {
+	if organizationID != "" {
+		id, err := uuid.Parse(organizationID)
+		if err != nil {
+			return uuid.Nil, xerrors.New("organization_id must be a valid UUID")
+		}
+		if id == uuid.Nil {
+			return uuid.Nil, xerrors.New("organization_id must be a valid nonzero UUID")
+		}
+		return id, nil
+	}
+	me, err := deps.coderClient.User(ctx, codersdk.Me)
+	if err != nil {
+		return uuid.Nil, xerrors.Errorf("resolve organization: get authenticated user: %w", err)
+	}
+	switch len(me.OrganizationIDs) {
+	case 0:
+		return uuid.Nil, xerrors.Errorf("organization_id is required because you belong to no organizations; use %s to inspect organization membership details", ToolNameListOrganizations)
+	case 1:
+		return me.OrganizationIDs[0], nil
+	default:
+		return uuid.Nil, xerrors.Errorf("organization_id is required because you belong to multiple organizations; use %s to obtain organization IDs and details", ToolNameListOrganizations)
+	}
+}

--- a/codersdk/toolsdk/organizations_internal_test.go
+++ b/codersdk/toolsdk/organizations_internal_test.go
@@ -1,0 +1,62 @@
+package toolsdk
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/coder/coder/v2/codersdk"
+)
+
+func TestResolveOrganization(t *testing.T) {
+	t.Parallel()
+	first, second := uuid.New(), uuid.New()
+	for _, tc := range []struct {
+		name, organizationID string
+		memberships          []uuid.UUID
+		lookupFailure        bool
+		want                 uuid.UUID
+		wantError            string
+	}{
+		{name: "Explicit", organizationID: second.String(), memberships: []uuid.UUID{first}, want: second},
+		{name: "Invalid", organizationID: "invalid", wantError: "organization_id must be a valid UUID"},
+		{name: "ZeroUUID", organizationID: uuid.Nil.String(), wantError: "organization_id must be a valid nonzero UUID"},
+		{name: "NoMemberships", wantError: "no organizations; use " + ToolNameListOrganizations},
+		{name: "SoleMembership", memberships: []uuid.UUID{first}, want: first},
+		{name: "MultipleMemberships", memberships: []uuid.UUID{first, second}, wantError: "multiple organizations; use " + ToolNameListOrganizations},
+		{name: "LookupFailure", lookupFailure: true, wantError: "lookup failed"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				assert.Empty(t, tc.organizationID, "explicit IDs must not trigger a user lookup")
+				assert.Equal(t, "/api/v2/users/me", r.URL.Path)
+				w.Header().Set("Content-Type", "application/json")
+				if tc.lookupFailure {
+					w.WriteHeader(http.StatusInternalServerError)
+					_ = json.NewEncoder(w).Encode(codersdk.Response{Message: "lookup failed"})
+					return
+				}
+				_ = json.NewEncoder(w).Encode(codersdk.User{OrganizationIDs: tc.memberships})
+			}))
+			defer server.Close()
+			serverURL, err := url.Parse(server.URL)
+			require.NoError(t, err)
+			deps, err := NewDeps(codersdk.New(serverURL))
+			require.NoError(t, err)
+			got, err := resolveOrganization(t.Context(), deps, tc.organizationID)
+			if tc.wantError != "" {
+				require.ErrorContains(t, err, tc.wantError)
+			} else {
+				require.NoError(t, err)
+				require.Equal(t, tc.want, got)
+			}
+		})
+	}
+}

--- a/codersdk/toolsdk/organizations_test.go
+++ b/codersdk/toolsdk/organizations_test.go
@@ -1,0 +1,49 @@
+package toolsdk_test
+
+import (
+	"strconv"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+
+	"github.com/coder/coder/v2/coderd/coderdtest"
+	"github.com/coder/coder/v2/coderd/database"
+	"github.com/coder/coder/v2/coderd/database/dbgen"
+	"github.com/coder/coder/v2/codersdk"
+	"github.com/coder/coder/v2/codersdk/toolsdk"
+)
+
+func TestListOrganizations(t *testing.T) {
+	t.Parallel()
+	for _, count := range []int{0, 1, 2} {
+		t.Run(strconv.Itoa(count), func(t *testing.T) {
+			t.Parallel()
+			client, db := coderdtest.NewWithDatabase(t, nil)
+			owner := coderdtest.CreateFirstUser(t, client)
+			memberClient, member := coderdtest.CreateAnotherUser(t, client, owner.OrganizationID)
+			org := dbgen.Organization(t, db, database.Organization{})
+			_ = dbgen.Organization(t, db, database.Organization{})
+			if count == 0 {
+				require.NoError(t, client.DeleteOrganizationMember(t.Context(), owner.OrganizationID, member.ID.String()))
+			}
+			if count == 2 {
+				dbgen.OrganizationMember(t, db, database.OrganizationMember{OrganizationID: org.ID, UserID: member.ID})
+			}
+			deps, err := toolsdk.NewDeps(memberClient)
+			require.NoError(t, err)
+			result, err := testTool(t, toolsdk.ListOrganizations, deps, toolsdk.NoArgs{})
+			require.NoError(t, err)
+			require.NotNil(t, result)
+			require.Len(t, result, count)
+			expected, err := memberClient.OrganizationsByUser(t.Context(), codersdk.Me)
+			require.NoError(t, err)
+			require.ElementsMatch(t, expected, result)
+			for _, org := range result {
+				require.NotEqual(t, uuid.Nil, org.ID)
+				require.NotEmpty(t, org.Name)
+				require.NotEmpty(t, org.DisplayName)
+			}
+		})
+	}
+}

--- a/codersdk/toolsdk/prompts.go
+++ b/codersdk/toolsdk/prompts.go
@@ -55,8 +55,12 @@ var AgentsDelegate = Prompt{
 			Required:    true,
 		},
 		{
+			Name:        "organization_id",
+			Description: "Organization UUID.",
+		},
+		{
 			Name:        "model_config_id",
-			Description: "Optional model config UUID for the chat. When omitted, a model is picked from " + ToolNameListChatModelConfigs + ".",
+			Description: "Optional model config UUID for the chat. When omitted, the server uses an applicable personal override or the organization's default model.",
 		},
 	},
 	Render: func(args map[string]string) (string, error) {
@@ -64,12 +68,20 @@ var AgentsDelegate = Prompt{
 		if err != nil {
 			return "", err
 		}
-		var createStep string
-		if modelConfigID := strings.TrimSpace(args["model_config_id"]); modelConfigID != "" {
-			createStep = fmt.Sprintf("1. Call %s with the task above as the prompt and model_config_id %q.", ToolNameCreateChat, modelConfigID)
-		} else {
-			createStep = fmt.Sprintf("1. Call %s with the task above as the prompt. To pick a specific model, call %s first and pass its ID as model_config_id.", ToolNameCreateChat, ToolNameListChatModelConfigs)
+		createStep := fmt.Sprintf("1. Call %s with the task above as the prompt", ToolNameCreateChat)
+		organizationID := strings.TrimSpace(args["organization_id"])
+		if organizationID != "" {
+			createStep += fmt.Sprintf(" and organization_id %q", organizationID)
 		}
+		if modelConfigID := strings.TrimSpace(args["model_config_id"]); modelConfigID != "" {
+			createStep += fmt.Sprintf(" and model_config_id %q.", modelConfigID)
+		} else {
+			createStep += fmt.Sprintf(". Omit model_config_id to let the server use an applicable personal override or the organization's default model. Only call %s if you want to select a specific model; pass the selected organization's ID to that tool.", ToolNameListChatModelConfigs)
+		}
+		if organizationID == "" {
+			createStep += fmt.Sprintf(" Organization selection defaults only when you belong to exactly one organization. Otherwise, use %s to obtain organization IDs and details, select the intended organization with the user, and pass organization_id to chat creation and any model discovery call. A model config ID does not select an organization. If discovery is unavailable, ask the user for the organization ID.", ToolNameListOrganizations)
+		}
+
 		return fmt.Sprintf(`Delegate the following task to a Coder Agent and see it through to completion.
 
 <task>

--- a/codersdk/toolsdk/prompts_test.go
+++ b/codersdk/toolsdk/prompts_test.go
@@ -80,3 +80,41 @@ func TestChatPrompts(t *testing.T) {
 		}
 	})
 }
+
+func TestDelegateOrganizationAndModel(t *testing.T) {
+	t.Parallel()
+	for _, tc := range []struct{ name, organization, model string }{
+		{name: "Default"},
+		{name: "Organization", organization: "6f225c30-08f9-475c-a64c-611da5db5a40"},
+		{name: "Model", model: "a2913789-b213-45e3-9d18-561fbb1ec97c"},
+		{name: "Both", organization: "6f225c30-08f9-475c-a64c-611da5db5a40", model: "a2913789-b213-45e3-9d18-561fbb1ec97c"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			text, err := toolsdk.AgentsDelegate.Render(map[string]string{"task": "Fix tests", "organization_id": tc.organization, "model_config_id": tc.model})
+			require.NoError(t, err)
+			if tc.organization != "" {
+				require.Contains(t, text, `organization_id "`+tc.organization+`"`)
+			} else {
+				require.Contains(t, text, "coder_list_organizations")
+				require.Contains(t, text, "exactly one organization")
+			}
+			if tc.model != "" {
+				require.Contains(t, text, `model_config_id "`+tc.model+`"`)
+			} else {
+				require.Contains(t, text, "Omit model_config_id")
+				require.Contains(t, text, "personal override")
+			}
+		})
+	}
+	for _, name := range []string{"organization_id", "model_config_id"} {
+		found := false
+		for _, arg := range toolsdk.AgentsDelegate.Arguments {
+			if arg.Name == name {
+				found = true
+				require.False(t, arg.Required)
+			}
+		}
+		require.True(t, found, name)
+	}
+}

--- a/codersdk/toolsdk/toolsdk.go
+++ b/codersdk/toolsdk/toolsdk.go
@@ -33,6 +33,7 @@ const (
 	ToolNameGetWorkspace                = "coder_get_workspace"
 	ToolNameCreateWorkspace             = "coder_create_workspace"
 	ToolNameListWorkspaces              = "coder_list_workspaces"
+	ToolNameListOrganizations           = "coder_list_organizations"
 	ToolNameListTemplates               = "coder_list_templates"
 	ToolNameListTemplateVersionParams   = "coder_template_version_parameters"
 	ToolNameGetTemplate                 = "coder_get_template"
@@ -401,6 +402,7 @@ var All = []GenericTool{
 	CreateWorkspace.Generic(),
 	CreateWorkspaceBuild.Generic(),
 	DeleteTemplate.Generic(),
+	ListOrganizations.Generic(),
 	ListTemplates.Generic(),
 	ListTemplateVersionParameters.Generic(),
 	GetTemplate.Generic(),
@@ -700,6 +702,7 @@ var ListWorkspaces = Tool[ListWorkspacesArgs, []MinimalWorkspace]{
 		minimalWorkspaces := make([]MinimalWorkspace, len(workspaces.Workspaces))
 		for i, workspace := range workspaces.Workspaces {
 			minimalWorkspaces[i] = MinimalWorkspace{
+				OrganizationID:          workspace.OrganizationID.String(),
 				ID:                      workspace.ID.String(),
 				Name:                    workspace.Name,
 				TemplateID:              workspace.TemplateID.String(),
@@ -716,6 +719,7 @@ var ListWorkspaces = Tool[ListWorkspacesArgs, []MinimalWorkspace]{
 
 func minimalTemplate(template codersdk.Template) MinimalTemplate {
 	return MinimalTemplate{
+		OrganizationID:  template.OrganizationID.String(),
 		DisplayName:     template.DisplayName,
 		ID:              template.ID.String(),
 		Name:            template.Name,
@@ -991,8 +995,9 @@ connect to the workspace.
 }
 
 type CreateTemplateVersionArgs struct {
-	FileID     string `json:"file_id"`
-	TemplateID string `json:"template_id"`
+	OrganizationID string `json:"organization_id"`
+	FileID         string `json:"file_id"`
+	TemplateID     string `json:"template_id"`
 }
 
 var CreateTemplateVersion = Tool[CreateTemplateVersionArgs, codersdk.TemplateVersion]{
@@ -1450,6 +1455,10 @@ The file_id provided is a reference to a tar file you have uploaded containing t
 `,
 		Schema: aisdk.Schema{
 			Properties: map[string]any{
+				"organization_id": map[string]any{
+					"type":        "string",
+					"description": "Organization UUID.",
+				},
 				"template_id": map[string]any{
 					"type": "string",
 				},
@@ -1462,7 +1471,7 @@ The file_id provided is a reference to a tar file you have uploaded containing t
 	},
 	MCPAnnotations: mcpMutationAnnotations,
 	Handler: func(ctx context.Context, deps Deps, args CreateTemplateVersionArgs) (codersdk.TemplateVersion, error) {
-		me, err := deps.coderClient.User(ctx, "me")
+		organizationID, err := resolveOrganization(ctx, deps, args.OrganizationID)
 		if err != nil {
 			return codersdk.TemplateVersion{}, err
 		}
@@ -1478,7 +1487,7 @@ The file_id provided is a reference to a tar file you have uploaded containing t
 			}
 			templateID = tid
 		}
-		templateVersion, err := deps.coderClient.CreateTemplateVersion(ctx, me.OrganizationIDs[0], codersdk.CreateTemplateVersionRequest{
+		templateVersion, err := deps.coderClient.CreateTemplateVersion(ctx, organizationID, codersdk.CreateTemplateVersionRequest{
 			Message:       "Created by AI",
 			StorageMethod: codersdk.ProvisionerStorageMethodFile,
 			FileID:        fileID,
@@ -1709,11 +1718,12 @@ var UploadTarFile = Tool[UploadTarFileArgs, codersdk.UploadResponse]{
 }
 
 type CreateTemplateArgs struct {
-	Description string `json:"description"`
-	DisplayName string `json:"display_name"`
-	Icon        string `json:"icon"`
-	Name        string `json:"name"`
-	VersionID   string `json:"version_id"`
+	OrganizationID string `json:"organization_id"`
+	Description    string `json:"description"`
+	DisplayName    string `json:"display_name"`
+	Icon           string `json:"icon"`
+	Name           string `json:"name"`
+	VersionID      string `json:"version_id"`
 }
 
 var CreateTemplate = Tool[CreateTemplateArgs, codersdk.Template]{
@@ -1722,6 +1732,10 @@ var CreateTemplate = Tool[CreateTemplateArgs, codersdk.Template]{
 		Description: "Create a new template in Coder. First, you must create a template version.",
 		Schema: aisdk.Schema{
 			Properties: map[string]any{
+				"organization_id": map[string]any{
+					"type":        "string",
+					"description": "Organization UUID.",
+				},
 				"name": map[string]any{
 					"type": "string",
 				},
@@ -1745,7 +1759,7 @@ var CreateTemplate = Tool[CreateTemplateArgs, codersdk.Template]{
 	},
 	MCPAnnotations: mcpMutationAnnotations,
 	Handler: func(ctx context.Context, deps Deps, args CreateTemplateArgs) (codersdk.Template, error) {
-		me, err := deps.coderClient.User(ctx, "me")
+		organizationID, err := resolveOrganization(ctx, deps, args.OrganizationID)
 		if err != nil {
 			return codersdk.Template{}, err
 		}
@@ -1753,7 +1767,7 @@ var CreateTemplate = Tool[CreateTemplateArgs, codersdk.Template]{
 		if err != nil {
 			return codersdk.Template{}, xerrors.Errorf("version_id must be a valid UUID: %w", err)
 		}
-		template, err := deps.coderClient.CreateTemplate(ctx, me.OrganizationIDs[0], codersdk.CreateTemplateRequest{
+		template, err := deps.coderClient.CreateTemplate(ctx, organizationID, codersdk.CreateTemplateRequest{
 			Name:        args.Name,
 			DisplayName: args.DisplayName,
 			Description: args.Description,
@@ -1800,6 +1814,7 @@ var DeleteTemplate = Tool[DeleteTemplateArgs, codersdk.Response]{
 }
 
 type MinimalWorkspace struct {
+	OrganizationID          string    `json:"organization_id"`
 	ID                      string    `json:"id"`
 	Name                    string    `json:"name"`
 	TemplateID              string    `json:"template_id"`
@@ -1811,6 +1826,7 @@ type MinimalWorkspace struct {
 }
 
 type MinimalTemplate struct {
+	OrganizationID  string    `json:"organization_id"`
 	DisplayName     string    `json:"display_name"`
 	ID              string    `json:"id"`
 	Name            string    `json:"name"`

--- a/codersdk/toolsdk/toolsdk_test.go
+++ b/codersdk/toolsdk/toolsdk_test.go
@@ -534,6 +534,7 @@ func TestTools(t *testing.T) {
 		})
 		for i, template := range result {
 			require.Equal(t, expected[i].ID.String(), template.ID)
+			require.Equal(t, expected[i].OrganizationID.String(), template.OrganizationID)
 			require.Equal(t, expected[i].AgentsAllowed, template.AgentsAllowed)
 		}
 	})
@@ -556,6 +557,7 @@ func TestTools(t *testing.T) {
 		require.NoError(t, err)
 		require.Len(t, result, 1, "expected 1 workspace")
 		workspace := result[0]
+		require.Equal(t, r.Workspace.OrganizationID.String(), workspace.OrganizationID)
 		require.Equal(t, r.Workspace.ID.String(), workspace.ID, "expected the workspace to match the one we created")
 	})
 
@@ -900,6 +902,7 @@ func TestTools(t *testing.T) {
 
 			// MinimalTemplate fields populated.
 			require.Equal(t, gtBuild.Template.ID.String(), result.ID)
+			require.Equal(t, gtBuild.Template.OrganizationID.String(), result.OrganizationID)
 			require.Equal(t, gtBuild.Template.Name, result.Name)
 			require.Equal(t, gtBuild.Template.ActiveVersionID, result.ActiveVersionID)
 
@@ -943,6 +946,7 @@ func TestTools(t *testing.T) {
 			b, err := json.Marshal(result)
 			require.NoError(t, err)
 			require.NotContains(t, string(b), `"presets"`)
+			require.Contains(t, string(b), `"organization_id":"`+gtNoPresetBuild.Template.OrganizationID.String()+`"`)
 		})
 
 		t.Run("InvalidID", func(t *testing.T) {
@@ -1059,26 +1063,38 @@ func TestTools(t *testing.T) {
 			require.NoError(t, err)
 			require.NotEmpty(t, tv)
 		})
+		t.Run("ExplicitOrganization", func(t *testing.T) {
+			organization := dbgen.Organization(t, store, database.Organization{})
+			tv, err := testTool(t, toolsdk.CreateTemplateVersion, tb, toolsdk.CreateTemplateVersionArgs{
+				OrganizationID: organization.ID.String(),
+				FileID:         file.ID.String(),
+			})
+			require.NoError(t, err)
+			require.Equal(t, organization.ID, tv.OrganizationID)
+		})
 	})
 
 	t.Run("CreateTemplate", func(t *testing.T) {
 		tb, err := toolsdk.NewDeps(client)
 		require.NoError(t, err)
+		organization := dbgen.Organization(t, store, database.Organization{})
 		// Create a new template version for use here.
 		tv := dbfake.TemplateVersion(t, store).
 			// nolint:gocritic // This is in a test package and does not end up in the build
-			Seed(database.TemplateVersion{OrganizationID: owner.OrganizationID, CreatedBy: owner.UserID}).
+			Seed(database.TemplateVersion{OrganizationID: organization.ID, CreatedBy: owner.UserID}).
 			SkipCreateTemplate().Do()
 
 		// We're going to re-use the pre-existing template version
-		_, err = testTool(t, toolsdk.CreateTemplate, tb, toolsdk.CreateTemplateArgs{
-			Name:        testutil.GetRandomNameHyphenated(t),
-			DisplayName: "Test Template",
-			Description: "This is a test template",
-			VersionID:   tv.TemplateVersion.ID.String(),
+		created, err := testTool(t, toolsdk.CreateTemplate, tb, toolsdk.CreateTemplateArgs{
+			OrganizationID: organization.ID.String(),
+			Name:           testutil.GetRandomNameHyphenated(t),
+			DisplayName:    "Test Template",
+			Description:    "This is a test template",
+			VersionID:      tv.TemplateVersion.ID.String(),
 		})
 
 		require.NoError(t, err)
+		require.Equal(t, organization.ID, created.OrganizationID)
 	})
 
 	t.Run("CreateWorkspace", func(t *testing.T) {

--- a/docs/ai-coder/mcp-server.md
+++ b/docs/ai-coder/mcp-server.md
@@ -200,7 +200,7 @@ The MCP server exposes tools across several areas:
 - **File operations**: read, write, and edit files in a workspace
 - **Workspace interaction**: run commands, forward ports, list apps, and read logs
 - **Coder Agents chats**: create chats, send messages, read transcripts and status, interrupt, archive, and list available models
-- **User and system**: authenticated user details, tar uploads, and task reporting
+- **User and system**: authenticated user details, organization memberships, tar uploads, and task reporting
 
 The full, authoritative set of tools, including their names, descriptions, and
 arguments, is defined in Coder's


### PR DESCRIPTION
Addresses https://linear.app/codercom/issue/CODAGT-970/expose-mcp-tools-for-organization-selection.

Currently our MCP server does not handle organizations consistently. Some tools, like `create_template`, use a random organization if the user is in multiple orgs. Others, like `create_chat`, pick the organization which contains the latest chat the user spawned.

This PR standardizes organization use in the MCP server tools. Organization ID is now in the argument schema of all tools that depend on it. It's always optional. If the user is only a member of one organization, tools default to that organization. If the user is a member of multiple organizations, tools return an error asking to supply an organization id.

This PR also adds a new `list_organizations` tool to allow MCP clients to view the organizations that the user has membership in.