### PR TITLE
test(cli): stabilize TestSSH_OneShotCommandMode flake

### DIFF
--- a/cli/ssh_test.go
+++ b/cli/ssh_test.go
@@ -2395,7 +2395,7 @@ func TestSSH_OneShotCommandMode(t *testing.T) {
 		inv.Stdout = output
 		inv.Stderr = io.Discard
 
-		ctx := testutil.Context(t, testutil.WaitShort)
+		ctx := testutil.Context(t, testutil.WaitLong)
 		err := inv.WithContext(ctx).Run()
 		require.NoError(t, err)
 		require.Equal(t, "not-tty", strings.TrimSpace(output.String()))
@@ -2410,7 +2410,7 @@ func TestSSH_OneShotCommandMode(t *testing.T) {
 		inv.Stdout = output
 		inv.Stderr = io.Discard
 
-		ctx := testutil.Context(t, testutil.WaitShort)
+		ctx := testutil.Context(t, testutil.WaitLong)
 		err := inv.WithContext(ctx).Run()
 		require.NoError(t, err)
 		require.Equal(t, "tty", strings.TrimSpace(output.String()))
@@ -2426,7 +2426,7 @@ func TestSSH_OneShotCommandMode(t *testing.T) {
 		inv.Stdout = output
 		inv.Stderr = io.Discard
 
-		ctx := testutil.Context(t, testutil.WaitShort)
+		ctx := testutil.Context(t, testutil.WaitLong)
 		err := inv.WithContext(ctx).Run()
 		require.NoError(t, err)
 		require.Equal(t, "3", strings.TrimSpace(output.String()))
@@ -2441,7 +2441,7 @@ func TestSSH_OneShotCommandMode(t *testing.T) {
 		clitest.SetupConfig(t, client, root)
 		inv.Stderr = io.Discard
 
-		ctx := testutil.Context(t, testutil.WaitShort)
+		ctx := testutil.Context(t, testutil.WaitLong)
 		err := inv.WithContext(ctx).Run()
 		require.Error(t, err)
 


### PR DESCRIPTION
## Summary

Fixes the flake [PLAT-608](https://linear.app/codercom/issue/PLAT-608): `TestSSH_OneShotCommandMode/ClosesStdinOnEOF`.

Each `TestSSH_OneShotCommandMode` subtest starts a fresh `coder ssh <workspace> <cmd>` invocation, which dials the workspace agent over tailnet from scratch. Under heavy PostgreSQL-17 / package-parallel CI load, that connection setup can exceed the 10s `WaitShort` deadline. When the deadline fires, cleanup converts the missing SSH exit status into exit code 255 (`SSH connection ended unexpectedly`), producing the observed failure.

The behavior under test (EOF propagation to the remote command so `wc -l` prints `3` and exits) is correct: `inv.Stdin` is a `strings.Reader`, so no PTY is requested, and gossh `CloseWrite`s the channel on stdin EOF. Only the deadline was too tight for slow CI setup.

## Change

Raise the four one-shot subtest contexts from `WaitShort` (10s) to `WaitLong` (25s), matching the other connection-establishing SSH tests in `cli/ssh_test.go`. All four share the same tailnet-dial setup cost, so this prevents the same flake from surfacing in the sibling subtests.

## Testing

- `go test ./cli -run 'TestSSH_OneShotCommandMode' -count=3` passes.

<details>
<summary>Root cause and decision log</summary>

- CI occurrence: `test-go-pg-17`, run `33896841005`, 2026-09-04. The tailnet control path established, but the one-shot session did not complete before the 10s deadline; cleanup then reported exit 255.
- No data race, panic, OOM, or resource-exhaustion evidence; classification is a timing-dependent flake.
- Considered adding explicit readiness synchronization before relying on EOF, but there is no logic bug in the EOF/exit path. The connection setup latency under load is the sole cause, so aligning the deadline with the rest of the file's connection tests is the smallest correct change.
- Applied to all four subtests (`DoesNotRequestPTY`, `RequestsPTYWithFlag`, `ClosesStdinOnEOF`, `PropagatesExitCode`) because they share the identical setup cost and timing risk.

</details>

---
This PR was created by Coder Agents on behalf of @ThomasK33.
