### PR TITLE
feat(site/src): replace the running tool spinner with a flip loader in the icon slot

### DIFF
--- a/site/src/index.css
+++ b/site/src/index.css
@@ -184,6 +184,21 @@
 		}
 	}
 
+	@keyframes flip-card {
+		0%,
+		15% {
+			transform: rotateY(0deg);
+		}
+		50%,
+		65% {
+			transform: rotateY(180deg);
+		}
+		100% {
+			transform: rotateY(360deg);
+		}
+	}
+
+	--animate-flip-card: flip-card 1.8s ease-in-out infinite;
 	--animate-loading: loading 2s ease-in-out infinite alternate;
 	--animate-caret-scan: caret-scan 3s ease-in-out infinite;
 	--animate-spin-once: spin 1s cubic-bezier(0.4, 0, 0.2, 1);

--- a/site/src/index.css
+++ b/site/src/index.css
@@ -186,19 +186,19 @@
 
 	@keyframes flip-card {
 		0%,
-		12% {
+		17% {
 			transform: rotateY(0deg);
 		}
 		25%,
-		37% {
+		42% {
 			transform: rotateY(-90deg);
 		}
 		50%,
-		62% {
+		67% {
 			transform: rotateY(-180deg);
 		}
 		75%,
-		87% {
+		92% {
 			transform: rotateY(-270deg);
 		}
 		100% {

--- a/site/src/index.css
+++ b/site/src/index.css
@@ -186,19 +186,27 @@
 
 	@keyframes flip-card {
 		0%,
-		15% {
+		12% {
 			transform: rotateY(0deg);
 		}
+		25%,
+		37% {
+			transform: rotateY(-90deg);
+		}
 		50%,
-		65% {
-			transform: rotateY(180deg);
+		62% {
+			transform: rotateY(-180deg);
+		}
+		75%,
+		87% {
+			transform: rotateY(-270deg);
 		}
 		100% {
-			transform: rotateY(360deg);
+			transform: rotateY(-360deg);
 		}
 	}
 
-	--animate-flip-card: flip-card 1.8s ease-in-out infinite;
+	--animate-flip-card: flip-card 3.2s cubic-bezier(0.3, 0, 0.1, 1) infinite;
 	--animate-loading: loading 2s ease-in-out infinite alternate;
 	--animate-caret-scan: caret-scan 3s ease-in-out infinite;
 	--animate-spin-once: spin 1s cubic-bezier(0.4, 0, 0.2, 1);

--- a/site/src/pages/AgentsPage/components/ChatElements/FlipLoader.stories.tsx
+++ b/site/src/pages/AgentsPage/components/ChatElements/FlipLoader.stories.tsx
@@ -1,0 +1,41 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { expect, within } from "storybook/test";
+import { FlipLoader } from "./FlipLoader";
+
+const meta: Meta<typeof FlipLoader> = {
+	title: "pages/AgentsPage/ChatElements/FlipLoader",
+	component: FlipLoader,
+	args: { label: "Tool call running" },
+};
+export default meta;
+type Story = StoryObj<typeof FlipLoader>;
+
+export const IconSlot: Story = {
+	play: async ({ canvasElement }) => {
+		await expect(
+			within(canvasElement).getByRole("img", { name: "Tool call running" }),
+		).toBeInTheDocument();
+	},
+};
+
+export const Sizes: Story = {
+	render: (args) => (
+		<div className="flex items-end gap-8 p-6">
+			{[16, 32, 64, 128].map((size) => (
+				<div key={size} className="flex flex-col items-center gap-2">
+					<FlipLoader {...args} size={size} />
+					<span className="text-xs text-content-secondary">{size}px</span>
+				</div>
+			))}
+		</div>
+	),
+};
+
+export const InToolRow: Story = {
+	render: (args) => (
+		<div className="flex items-center gap-2 text-[13px] leading-6 text-content-secondary">
+			<FlipLoader {...args} />
+			<span>Adding the streaming behavior to the working block</span>
+		</div>
+	),
+};

--- a/site/src/pages/AgentsPage/components/ChatElements/FlipLoader.tsx
+++ b/site/src/pages/AgentsPage/components/ChatElements/FlipLoader.tsx
@@ -1,0 +1,37 @@
+import { cn } from "cn";
+import type { CSSProperties, FC } from "react";
+
+type FlipLoaderProps = {
+	className?: string;
+	label: string;
+	/** Slot size in px; the card scales with it. Defaults to a 16px icon slot. */
+	size?: number;
+};
+
+/** A card flipping between a primary and a tertiary face. */
+export const FlipLoader: FC<FlipLoaderProps> = ({
+	className,
+	label,
+	size = 16,
+}) => (
+	<span
+		role="img"
+		aria-label={label}
+		className={cn("flex shrink-0 items-center justify-center", className)}
+		style={
+			{
+				width: size,
+				height: size,
+				perspective: size * 3,
+			} satisfies CSSProperties
+		}
+	>
+		<span
+			className="relative block animate-flip-card motion-reduce:animate-none [transform-style:preserve-3d]"
+			style={{ width: size * 0.625, height: size * 0.75 }}
+		>
+			<span className="absolute inset-0 rounded-[1px] bg-content-primary [backface-visibility:hidden]" />
+			<span className="absolute inset-0 rounded-[1px] bg-surface-tertiary [backface-visibility:hidden] [transform:rotateY(180deg)]" />
+		</span>
+	</span>
+);

--- a/site/src/pages/AgentsPage/components/ChatElements/FlipLoader.tsx
+++ b/site/src/pages/AgentsPage/components/ChatElements/FlipLoader.tsx
@@ -11,7 +11,7 @@ type FlipLoaderProps = {
 const SLICES = 4;
 // Phase lead per slice from the top down. Slices realign during the hold on
 // each face, so the box appears to twist through the turn and snap straight.
-const SLICE_LEAD_MS = 90;
+const SLICE_LEAD_MS = 60;
 
 /**
  * A box turning a quarter at a time, alternating a primary face and a
@@ -44,31 +44,46 @@ export const FlipLoader: FC<FlipLoaderProps> = ({
 			}
 		>
 			{Array.from({ length: SLICES }, (_, index) => (
+				// Bands overlap by a pixel so anti-aliasing never opens a seam. The
+				// pivot sits half the depth back so a resting face lands at z=0 and
+				// rasterises 1:1 instead of at a perspective-scaled fraction.
 				<span
 					key={index}
-					className="relative block animate-flip-card motion-reduce:animate-none [transform-style:preserve-3d]"
+					className="relative block [transform-style:preserve-3d]"
 					style={{
 						width,
-						height: sliceHeight,
-						animationDelay: `-${(SLICES - 1 - index) * SLICE_LEAD_MS}ms`,
+						height: sliceHeight + (index > 0 ? 1 : 0),
+						marginTop: index > 0 ? -1 : 0,
+						transform: `translateZ(${-depth / 2}px)`,
 					}}
 				>
 					<span
-						className={cn(face, "bg-content-primary")}
-						style={{ transform: `translateZ(${depth / 2}px)` }}
-					/>
-					<span
-						className={cn(face, "bg-surface-quaternary")}
-						style={{ transform: `rotateY(90deg) translateZ(${width / 2}px)` }}
-					/>
-					<span
-						className={cn(face, "bg-content-primary")}
-						style={{ transform: `rotateY(180deg) translateZ(${depth / 2}px)` }}
-					/>
-					<span
-						className={cn(face, "bg-surface-quaternary")}
-						style={{ transform: `rotateY(-90deg) translateZ(${width / 2}px)` }}
-					/>
+						className="absolute inset-0 animate-flip-card motion-reduce:animate-none [transform-style:preserve-3d]"
+						style={{
+							animationDelay: `-${(SLICES - 1 - index) * SLICE_LEAD_MS}ms`,
+						}}
+					>
+						<span
+							className={cn(face, "bg-content-primary")}
+							style={{ transform: `translateZ(${depth / 2}px)` }}
+						/>
+						<span
+							className={cn(face, "bg-surface-quaternary")}
+							style={{ transform: `rotateY(90deg) translateZ(${width / 2}px)` }}
+						/>
+						<span
+							className={cn(face, "bg-content-primary")}
+							style={{
+								transform: `rotateY(180deg) translateZ(${depth / 2}px)`,
+							}}
+						/>
+						<span
+							className={cn(face, "bg-surface-quaternary")}
+							style={{
+								transform: `rotateY(-90deg) translateZ(${width / 2}px)`,
+							}}
+						/>
+					</span>
 				</span>
 			))}
 		</span>

--- a/site/src/pages/AgentsPage/components/ChatElements/FlipLoader.tsx
+++ b/site/src/pages/AgentsPage/components/ChatElements/FlipLoader.tsx
@@ -4,34 +4,73 @@ import type { CSSProperties, FC } from "react";
 type FlipLoaderProps = {
 	className?: string;
 	label: string;
-	/** Slot size in px; the card scales with it. Defaults to a 16px icon slot. */
+	/** Slot size in px; the box scales with it. Defaults to a 16px icon slot. */
 	size?: number;
 };
 
-/** A card flipping between a primary and a tertiary face. */
+const SLICES = 4;
+// Phase lead per slice from the top down. Slices realign during the hold on
+// each face, so the box appears to twist through the turn and snap straight.
+const SLICE_LEAD_MS = 90;
+
+/**
+ * A box turning a quarter at a time, alternating a primary face and a
+ * quaternary face. The faces are laid out in 3D so both are visible mid-turn.
+ */
 export const FlipLoader: FC<FlipLoaderProps> = ({
 	className,
 	label,
 	size = 16,
-}) => (
-	<span
-		role="img"
-		aria-label={label}
-		className={cn("flex shrink-0 items-center justify-center", className)}
-		style={
-			{
-				width: size,
-				height: size,
-				perspective: size * 3,
-			} satisfies CSSProperties
-		}
-	>
+}) => {
+	const width = size * 0.625;
+	const height = size * 0.75;
+	const depth = width;
+	const sliceHeight = height / SLICES;
+	const face = "absolute inset-0 [backface-visibility:hidden]";
+	return (
 		<span
-			className="relative block animate-flip-card motion-reduce:animate-none [transform-style:preserve-3d]"
-			style={{ width: size * 0.625, height: size * 0.75 }}
+			role="img"
+			aria-label={label}
+			className={cn(
+				"flex shrink-0 flex-col items-center justify-center [transform-style:preserve-3d]",
+				className,
+			)}
+			style={
+				{
+					width: size,
+					height: size,
+					perspective: size * 2.5,
+				} satisfies CSSProperties
+			}
 		>
-			<span className="absolute inset-0 rounded-[1px] bg-content-primary [backface-visibility:hidden]" />
-			<span className="absolute inset-0 rounded-[1px] bg-surface-tertiary [backface-visibility:hidden] [transform:rotateY(180deg)]" />
+			{Array.from({ length: SLICES }, (_, index) => (
+				<span
+					key={index}
+					className="relative block animate-flip-card motion-reduce:animate-none [transform-style:preserve-3d]"
+					style={{
+						width,
+						height: sliceHeight,
+						animationDelay: `-${(SLICES - 1 - index) * SLICE_LEAD_MS}ms`,
+					}}
+				>
+					<span
+						className={cn(face, "bg-content-primary")}
+						style={{ transform: `translateZ(${depth / 2}px)` }}
+					/>
+					<span
+						className={cn(face, "bg-surface-quaternary")}
+						style={{ transform: `rotateY(90deg) translateZ(${width / 2}px)` }}
+					/>
+					<span
+						className={cn(face, "bg-content-primary")}
+						style={{ transform: `rotateY(180deg) translateZ(${depth / 2}px)` }}
+					/>
+					<span
+						className={cn(face, "bg-surface-quaternary")}
+						style={{ transform: `rotateY(-90deg) translateZ(${width / 2}px)` }}
+					/>
+				</span>
+			))}
 		</span>
-	</span>
-);
+	);
+};

--- a/site/src/pages/AgentsPage/components/ChatElements/tools/Tool.stories.tsx
+++ b/site/src/pages/AgentsPage/components/ChatElements/tools/Tool.stories.tsx
@@ -1448,6 +1448,12 @@ export const MCPToolRunning: Story = {
 		mcpServerConfigId: "mcp-server-1",
 		mcpServers: sampleMCPServers,
 	},
+	play: async ({ canvasElement }) => {
+		expect(
+			within(canvasElement).getByRole("img", { name: "Tool call running" }),
+		).toBeInTheDocument();
+		expect(canvasElement.querySelector(".brightness-0")).toBeNull();
+	},
 };
 
 export const MCPToolCompleted: Story = {
@@ -1595,6 +1601,16 @@ export const MCPToolModelIntentRunning: Story = {
 		modelIntent: "Fetching backend issues from Linear",
 		mcpServerConfigId: "mcp-server-1",
 		mcpServers: sampleMCPServers,
+	},
+	play: async ({ canvasElement }) => {
+		const canvas = within(canvasElement);
+		// Should show the model intent label instead of the raw tool name.
+		expect(
+			canvas.getByText("Fetching backend issues from Linear"),
+		).toBeInTheDocument();
+		expect(
+			canvas.getByRole("img", { name: "Tool call running" }),
+		).toBeInTheDocument();
 	},
 };
 
@@ -2014,6 +2030,13 @@ export const ComputerRunning: Story = {
 	args: {
 		name: "computer",
 		status: "running",
+	},
+	play: async ({ canvasElement }) => {
+		const canvas = within(canvasElement);
+		expect(canvas.getByText("Taking screenshot…")).toBeInTheDocument();
+		expect(
+			canvas.getByRole("img", { name: "Tool call running" }),
+		).toBeInTheDocument();
 	},
 };
 

--- a/site/src/pages/AgentsPage/components/ChatElements/tools/ToolCall.tsx
+++ b/site/src/pages/AgentsPage/components/ChatElements/tools/ToolCall.tsx
@@ -1,10 +1,5 @@
 import { cn } from "cn";
-import {
-	ChevronDownIcon,
-	LoaderIcon,
-	ShieldIcon,
-	TriangleAlertIcon,
-} from "lucide-react";
+import { ChevronDownIcon, ShieldIcon, TriangleAlertIcon } from "lucide-react";
 import {
 	type ComponentPropsWithoutRef,
 	createContext,
@@ -19,6 +14,7 @@ import {
 	TooltipContent,
 	TooltipTrigger,
 } from "#/components/Tooltip/Tooltip";
+import { FlipLoader } from "../FlipLoader";
 import { Shimmer } from "../Shimmer";
 import { TranscriptRow } from "../TranscriptRow";
 import { ToolIcon } from "./ToolIcon";
@@ -264,6 +260,9 @@ const LeadingIcon: FC<ToolCallLeadingIconProps> = ({
 	if (!name) {
 		return null;
 	}
+	if (active) {
+		return <FlipLoader label="Tool call running" />;
+	}
 
 	return (
 		<ToolIcon
@@ -307,20 +306,10 @@ type ToolCallStatusProps = {
 };
 
 const Status: FC<ToolCallStatusProps> = ({ className }) => {
-	const { active, errorMessage, failed } = useToolCallContext();
+	const { errorMessage, failed } = useToolCallContext();
 	const message = errorMessage || "Tool call failed";
 	return (
 		<>
-			{active && (
-				<LoaderIcon
-					aria-label="Tool call running"
-					role="img"
-					className={cn(
-						"size-3.5 shrink-0 animate-spin motion-reduce:animate-none text-current",
-						className,
-					)}
-				/>
-			)}
 			{failed && (
 				<Tooltip>
 					<TooltipTrigger asChild>


### PR DESCRIPTION
Running tool rows read `[icon] [label] [spinner]`. This changes them to `[loader] [label]`: while a call runs, a small 3D box takes the icon's slot, and the trailing spinner is gone. The failure triangle in the trailing slot is unchanged.

- `FlipLoader`: a box with `content-primary` front/back and `surface-quaternary` sides, laid out in 3D so both colours show mid-turn. It turns a quarter every 0.8s with a hold on each face. The box is four horizontal bands with a staggered phase, so it twists through the turn and snaps square during the hold. Back faces are hidden to avoid edge halos. Sized for the 16px icon slot with a `size` prop for larger uses; only `transform` animates.
- Keeps the spinner's `role="img"` / "Tool call running" label.
- `ToolCall.LeadingIcon` renders the loader while active; `ToolCall.Status` only reports failure now.

Stories at `ChatElements/FlipLoader` show it at 16 to 128px and in a tool row.

> This PR was prepared by Coder Agents on behalf of @tracyjohnsonux.