### PR TITLE
fix(site/src/pages/AgentsPage/components/ChatConversation): tighten attachment chips and render them after assistant text

### DIFF
--- a/site/src/pages/AgentsPage/components/ChatConversation/AttachmentBlocks.tsx
+++ b/site/src/pages/AgentsPage/components/ChatConversation/AttachmentBlocks.tsx
@@ -287,7 +287,7 @@ const InlineTextAttachmentButton: FC<{
 					? `View ${fileName}`
 					: "View text attachment"
 			}
-			className="inline-flex h-16 max-w-sm items-center gap-2 rounded-md border-0 bg-surface-tertiary px-3 py-2 text-left transition-colors hover:bg-surface-quaternary focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-content-link"
+			className="inline-flex max-w-sm items-center gap-2 rounded-md border-0 bg-surface-tertiary p-3 text-left transition-colors hover:bg-surface-quaternary focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-content-link"
 			onClick={(event) => {
 				event.stopPropagation();
 				void onPreview?.({ content, fileName });

--- a/site/src/pages/AgentsPage/components/ChatConversation/ConversationTimeline.stories.tsx
+++ b/site/src/pages/AgentsPage/components/ChatConversation/ConversationTimeline.stories.tsx
@@ -1378,6 +1378,45 @@ export const AssistantMessageWithImage: Story = {
 	},
 };
 
+/**
+ * A tool emits its file part before the model writes about it. The chip
+ * still renders after the text.
+ */
+export const AssistantAttachmentRendersAfterText: Story = {
+	args: {
+		...defaultArgs,
+		parsedMessages: buildMessages([
+			{
+				...baseMessage,
+				id: 1,
+				role: "assistant",
+				content: [
+					{
+						type: "file",
+						media_type: "image/png",
+						data: TEST_PNG_B64,
+						name: "analysis.png",
+					},
+					{ type: "text", text: "# Rogue colors analysis\n\nSummary below." },
+				],
+			},
+		]),
+	},
+	play: async ({ canvasElement }) => {
+		const canvas = within(canvasElement);
+		const heading = canvas.getByRole("heading", {
+			name: "Rogue colors analysis",
+		});
+		const chip = canvas.getByRole("button", { name: "View analysis.png" });
+		expect(
+			heading.compareDocumentPosition(chip) & Node.DOCUMENT_POSITION_FOLLOWING,
+		).toBeTruthy();
+		expect(chip.getBoundingClientRect().top).toBeGreaterThan(
+			heading.getBoundingClientRect().bottom,
+		);
+	},
+};
+
 export const AssistantMessageWithUnnamedDownloadableFile: Story = {
 	args: {
 		...defaultArgs,

--- a/site/src/pages/AgentsPage/components/ChatConversation/MessageBlocks.tsx
+++ b/site/src/pages/AgentsPage/components/ChatConversation/MessageBlocks.tsx
@@ -243,7 +243,14 @@ export const BlockList: FC<BlockListProps> = ({
 		prefQuery.data?.code_diff_display_mode || "auto";
 
 	const toolByID = new Map(tools.map((tool) => [tool.id, tool]));
-	const displayBlocks = groupSequentialReadFileBlocks(blocks, tools);
+	// Attachments render after everything else, as in user messages: a tool
+	// emits its file part before the model writes about it, so in part order
+	// the chip would sit above its own explanation.
+	const fileBlocks = blocks.filter((block) => block.type === "file");
+	const displayBlocks = groupSequentialReadFileBlocks(
+		blocks.filter((block) => block.type !== "file"),
+		tools,
+	);
 
 	// Pre-compute which tool IDs have a corresponding block so
 	// we can render "remaining" (block-less) tools afterwards.
@@ -390,16 +397,7 @@ export const BlockList: FC<BlockListProps> = ({
 						);
 					}
 					case "file":
-						return (
-							<AttachmentBlock
-								key={`${keyPrefix}-file-${block.file_id ?? index}`}
-								block={block}
-								onImageClick={onImageClick}
-								onTextFileClick={onTextFileClick}
-								framePreview
-								showTextStatus
-							/>
-						);
+						return null;
 					case "sources":
 						return (
 							<WebSearchSources
@@ -450,6 +448,20 @@ export const BlockList: FC<BlockListProps> = ({
 					hookRewritten={tool.hookRewritten}
 				/>
 			))}
+			{fileBlocks.length > 0 && (
+				<div className="flex flex-wrap gap-2">
+					{fileBlocks.map((block, index) => (
+						<AttachmentBlock
+							key={`${keyPrefix}-file-${block.file_id ?? index}`}
+							block={block}
+							onImageClick={onImageClick}
+							onTextFileClick={onTextFileClick}
+							framePreview
+							showTextStatus
+						/>
+					))}
+				</div>
+			)}
 		</>
 	);
 };


### PR DESCRIPTION
Two small fixes to attachments in the chat transcript.

- **Chip padding.** The text/file attachment chip had a fixed `h-16` with `px-3 py-2`, so it stretched to 64px around a single line. It now uses `p-3` with no fixed height and hugs its content, like a badge. Image thumbnails and the download card are unchanged.
- **Order in assistant messages.** A tool emits its file part before the model writes about it, so in part order the chip sat above its own explanation (often above the heading). Assistant attachments now render after the message's other blocks in a wrapping row, matching user messages where files follow the text.

Story `AssistantAttachmentRendersAfterText` covers the ordering.

> This PR was prepared by Coder Agents on behalf of @tracyjohnsonux.