### PR TITLE
fix(agent): launch stdio MCP servers in the workspace dir

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -489,7 +489,7 @@ func (a *agent) init() {
 		a.logger.Named("desktop"), a.execer, a.scriptRunner.ScriptBinDir(), nil,
 	)
 	a.desktopAPI = agentdesktop.NewAPI(a.logger.Named("desktop"), desktop, a.clock)
-	a.mcpManager = agentmcp.NewManager(a.gracefulCtx, a.logger.Named("mcp"), a.execer, a.updateCommandEnv, workingDirFn)
+	a.mcpManager = agentmcp.NewManager(a.gracefulCtx, a.logger.Named("mcp"), a.execer, a.envInfo, a.updateCommandEnv, workingDirFn)
 	a.contextConfigAPI = agentcontextconfig.NewAPI(workingDirFn, a.contextConfig)
 	a.mcpAPI = agentmcp.NewAPI(a.mcpManager)
 

--- a/agent/agent.go
+++ b/agent/agent.go
@@ -475,25 +475,22 @@ func (a *agent) init() {
 
 	pathStore := agentgit.NewPathStore()
 	a.filesAPI = agentfiles.NewAPI(a.logger.Named("files"), a.filesystem, pathStore, agentfiles.WithEnvInfo(a.envInfo))
-	a.processAPI = agentproc.NewAPI(a.logger.Named("processes"), a.execer, a.filesystem, pathStore, a.envInfo, a.updateCommandEnv, func() string {
+	// workingDirFn reports the workspace directory ("" before the first manifest).
+	workingDirFn := func() string {
 		if m := a.manifest.Load(); m != nil {
 			return m.Directory
 		}
 		return ""
-	})
+	}
+	a.processAPI = agentproc.NewAPI(a.logger.Named("processes"), a.execer, a.filesystem, pathStore, a.envInfo, a.updateCommandEnv, workingDirFn)
 	gitOpts := append([]agentgit.Option{agentgit.WithClock(a.clock)}, a.gitAPIOptions...)
 	a.gitAPI = agentgit.NewAPI(a.logger.Named("git"), pathStore, gitOpts...)
 	desktop := agentdesktop.NewPortableDesktop(
 		a.logger.Named("desktop"), a.execer, a.scriptRunner.ScriptBinDir(), nil,
 	)
 	a.desktopAPI = agentdesktop.NewAPI(a.logger.Named("desktop"), desktop, a.clock)
-	a.mcpManager = agentmcp.NewManager(a.gracefulCtx, a.logger.Named("mcp"), a.execer, a.updateCommandEnv)
-	a.contextConfigAPI = agentcontextconfig.NewAPI(func() string {
-		if m := a.manifest.Load(); m != nil {
-			return m.Directory
-		}
-		return ""
-	}, a.contextConfig)
+	a.mcpManager = agentmcp.NewManager(a.gracefulCtx, a.logger.Named("mcp"), a.execer, a.updateCommandEnv, workingDirFn)
+	a.contextConfigAPI = agentcontextconfig.NewAPI(workingDirFn, a.contextConfig)
 	a.mcpAPI = agentmcp.NewAPI(a.mcpManager)
 
 	// agentcontext.Manager is the new consolidated resolver,
@@ -501,12 +498,6 @@ func (a *agent) init() {
 	// and the MCP manager during rollout. Initial sources are
 	// seeded from the existing CODER_AGENT_EXP_* env vars and
 	// from the agent's working directory at scan time.
-	workingDirFn := func() string {
-		if m := a.manifest.Load(); m != nil {
-			return m.Directory
-		}
-		return ""
-	}
 	a.contextManager = agentcontext.NewManager(agentcontext.ManagerOptions{
 		Logger:         a.logger.Named("agentcontext"),
 		Clock:          a.clock,

--- a/agent/agent.go
+++ b/agent/agent.go
@@ -489,7 +489,7 @@ func (a *agent) init() {
 		a.logger.Named("desktop"), a.execer, a.scriptRunner.ScriptBinDir(), nil,
 	)
 	a.desktopAPI = agentdesktop.NewAPI(a.logger.Named("desktop"), desktop, a.clock)
-	a.mcpManager = agentmcp.NewManager(a.gracefulCtx, a.logger.Named("mcp"), a.execer, a.envInfo, a.updateCommandEnv, workingDirFn)
+	a.mcpManager = agentmcp.NewManager(a.gracefulCtx, a.logger.Named("mcp"), a.execer, a.filesystem, a.envInfo, a.updateCommandEnv, workingDirFn)
 	a.contextConfigAPI = agentcontextconfig.NewAPI(workingDirFn, a.contextConfig)
 	a.mcpAPI = agentmcp.NewAPI(a.mcpManager)
 

--- a/agent/x/agentmcp/api_internal_test.go
+++ b/agent/x/agentmcp/api_internal_test.go
@@ -24,7 +24,7 @@ func TestHandleCallTool_ErrorMapping(t *testing.T) {
 
 	ctx := testutil.Context(t, testutil.WaitShort)
 	logger := slogtest.Make(t, nil)
-	m := NewManager(ctx, logger, agentexec.DefaultExecer, nil, nil, nil)
+	m := NewManager(ctx, logger, agentexec.DefaultExecer, nil, nil, nil, nil)
 	t.Cleanup(func() { _ = m.Close() })
 
 	api := NewAPI(m)

--- a/agent/x/agentmcp/api_internal_test.go
+++ b/agent/x/agentmcp/api_internal_test.go
@@ -24,7 +24,7 @@ func TestHandleCallTool_ErrorMapping(t *testing.T) {
 
 	ctx := testutil.Context(t, testutil.WaitShort)
 	logger := slogtest.Make(t, nil)
-	m := NewManager(ctx, logger, agentexec.DefaultExecer, nil, nil)
+	m := NewManager(ctx, logger, agentexec.DefaultExecer, nil, nil, nil)
 	t.Cleanup(func() { _ = m.Close() })
 
 	api := NewAPI(m)

--- a/agent/x/agentmcp/api_internal_test.go
+++ b/agent/x/agentmcp/api_internal_test.go
@@ -24,7 +24,7 @@ func TestHandleCallTool_ErrorMapping(t *testing.T) {
 
 	ctx := testutil.Context(t, testutil.WaitShort)
 	logger := slogtest.Make(t, nil)
-	m := NewManager(ctx, logger, agentexec.DefaultExecer, nil)
+	m := NewManager(ctx, logger, agentexec.DefaultExecer, nil, nil)
 	t.Cleanup(func() { _ = m.Close() })
 
 	api := NewAPI(m)

--- a/agent/x/agentmcp/configwatcher_internal_test.go
+++ b/agent/x/agentmcp/configwatcher_internal_test.go
@@ -64,7 +64,7 @@ func TestWatcher_LateFileTriggersReload(t *testing.T) {
 	dir := t.TempDir()
 	configPath := filepath.Join(dir, ".mcp.json")
 
-	m := NewManager(ctx, logger, agentexec.DefaultExecer, nil)
+	m := NewManager(ctx, logger, agentexec.DefaultExecer, nil, nil)
 	useFastDebounce(t, m)
 	t.Cleanup(func() { _ = m.Close() })
 
@@ -104,7 +104,7 @@ func TestWatcher_RewriteTriggersReload(t *testing.T) {
 	_, entry := fakeMCPServerConfig(t, "srv")
 	configPath := writeMCPConfig(t, dir, map[string]mcpServerEntry{"srv": entry})
 
-	m := NewManager(ctx, logger, agentexec.DefaultExecer, nil)
+	m := NewManager(ctx, logger, agentexec.DefaultExecer, nil, nil)
 	useFastDebounce(t, m)
 	t.Cleanup(func() { _ = m.Close() })
 
@@ -141,7 +141,7 @@ func TestWatcher_RemovalTransitionsToEmpty(t *testing.T) {
 	_, entry := fakeMCPServerConfig(t, "srv")
 	configPath := writeMCPConfig(t, dir, map[string]mcpServerEntry{"srv": entry})
 
-	m := NewManager(ctx, logger, agentexec.DefaultExecer, nil)
+	m := NewManager(ctx, logger, agentexec.DefaultExecer, nil, nil)
 	useFastDebounce(t, m)
 	t.Cleanup(func() { _ = m.Close() })
 
@@ -240,7 +240,7 @@ func TestWatcher_CloseStopsGoroutine(t *testing.T) {
 	configPath := filepath.Join(dir, ".mcp.json")
 
 	for range 5 {
-		m := NewManager(ctx, logger, agentexec.DefaultExecer, nil)
+		m := NewManager(ctx, logger, agentexec.DefaultExecer, nil, nil)
 		useFastDebounce(t, m)
 		require.NoError(t, m.Reload(ctx, []string{configPath}))
 		require.NoError(t, m.Close())
@@ -274,7 +274,7 @@ func TestWatcher_DualAgentLateConfigWarmsCatalog(t *testing.T) {
 	dir := t.TempDir()
 	configPath := filepath.Join(dir, ".mcp.json")
 
-	m := NewManager(ctx, logger, agentexec.DefaultExecer, nil)
+	m := NewManager(ctx, logger, agentexec.DefaultExecer, nil, nil)
 	useFastDebounce(t, m)
 	t.Cleanup(func() { _ = m.Close() })
 
@@ -322,7 +322,7 @@ func TestWatcher_LateParentDirTriggersReload(t *testing.T) {
 	missing := filepath.Join(root, "config")
 	configPath := filepath.Join(missing, ".mcp.json")
 
-	m := NewManager(ctx, logger, agentexec.DefaultExecer, nil)
+	m := NewManager(ctx, logger, agentexec.DefaultExecer, nil, nil)
 	useFastDebounce(t, m)
 	t.Cleanup(func() { _ = m.Close() })
 
@@ -367,7 +367,7 @@ func TestWatcher_SharedParentRefcount(t *testing.T) {
 	pathA := filepath.Join(dir, "a.mcp.json")
 	pathB := filepath.Join(dir, "b.mcp.json")
 
-	m := NewManager(ctx, logger, agentexec.DefaultExecer, nil)
+	m := NewManager(ctx, logger, agentexec.DefaultExecer, nil, nil)
 	useFastDebounce(t, m)
 	t.Cleanup(func() { _ = m.Close() })
 
@@ -441,7 +441,7 @@ func TestWatcher_CloseDoesNotStallOnInFlightReload(t *testing.T) {
 	dir := t.TempDir()
 	configPath := filepath.Join(dir, ".mcp.json")
 
-	m := NewManager(ctx, logger, agentexec.DefaultExecer, nil)
+	m := NewManager(ctx, logger, agentexec.DefaultExecer, nil, nil)
 	useFastDebounce(t, m)
 
 	// Arm the watcher with an initial empty Reload. We install the

--- a/agent/x/agentmcp/configwatcher_internal_test.go
+++ b/agent/x/agentmcp/configwatcher_internal_test.go
@@ -64,7 +64,7 @@ func TestWatcher_LateFileTriggersReload(t *testing.T) {
 	dir := t.TempDir()
 	configPath := filepath.Join(dir, ".mcp.json")
 
-	m := NewManager(ctx, logger, agentexec.DefaultExecer, nil, nil, nil)
+	m := NewManager(ctx, logger, agentexec.DefaultExecer, nil, nil, nil, nil)
 	useFastDebounce(t, m)
 	t.Cleanup(func() { _ = m.Close() })
 
@@ -104,7 +104,7 @@ func TestWatcher_RewriteTriggersReload(t *testing.T) {
 	_, entry := fakeMCPServerConfig(t, "srv")
 	configPath := writeMCPConfig(t, dir, map[string]mcpServerEntry{"srv": entry})
 
-	m := NewManager(ctx, logger, agentexec.DefaultExecer, nil, nil, nil)
+	m := NewManager(ctx, logger, agentexec.DefaultExecer, nil, nil, nil, nil)
 	useFastDebounce(t, m)
 	t.Cleanup(func() { _ = m.Close() })
 
@@ -141,7 +141,7 @@ func TestWatcher_RemovalTransitionsToEmpty(t *testing.T) {
 	_, entry := fakeMCPServerConfig(t, "srv")
 	configPath := writeMCPConfig(t, dir, map[string]mcpServerEntry{"srv": entry})
 
-	m := NewManager(ctx, logger, agentexec.DefaultExecer, nil, nil, nil)
+	m := NewManager(ctx, logger, agentexec.DefaultExecer, nil, nil, nil, nil)
 	useFastDebounce(t, m)
 	t.Cleanup(func() { _ = m.Close() })
 
@@ -240,7 +240,7 @@ func TestWatcher_CloseStopsGoroutine(t *testing.T) {
 	configPath := filepath.Join(dir, ".mcp.json")
 
 	for range 5 {
-		m := NewManager(ctx, logger, agentexec.DefaultExecer, nil, nil, nil)
+		m := NewManager(ctx, logger, agentexec.DefaultExecer, nil, nil, nil, nil)
 		useFastDebounce(t, m)
 		require.NoError(t, m.Reload(ctx, []string{configPath}))
 		require.NoError(t, m.Close())
@@ -274,7 +274,7 @@ func TestWatcher_DualAgentLateConfigWarmsCatalog(t *testing.T) {
 	dir := t.TempDir()
 	configPath := filepath.Join(dir, ".mcp.json")
 
-	m := NewManager(ctx, logger, agentexec.DefaultExecer, nil, nil, nil)
+	m := NewManager(ctx, logger, agentexec.DefaultExecer, nil, nil, nil, nil)
 	useFastDebounce(t, m)
 	t.Cleanup(func() { _ = m.Close() })
 
@@ -322,7 +322,7 @@ func TestWatcher_LateParentDirTriggersReload(t *testing.T) {
 	missing := filepath.Join(root, "config")
 	configPath := filepath.Join(missing, ".mcp.json")
 
-	m := NewManager(ctx, logger, agentexec.DefaultExecer, nil, nil, nil)
+	m := NewManager(ctx, logger, agentexec.DefaultExecer, nil, nil, nil, nil)
 	useFastDebounce(t, m)
 	t.Cleanup(func() { _ = m.Close() })
 
@@ -367,7 +367,7 @@ func TestWatcher_SharedParentRefcount(t *testing.T) {
 	pathA := filepath.Join(dir, "a.mcp.json")
 	pathB := filepath.Join(dir, "b.mcp.json")
 
-	m := NewManager(ctx, logger, agentexec.DefaultExecer, nil, nil, nil)
+	m := NewManager(ctx, logger, agentexec.DefaultExecer, nil, nil, nil, nil)
 	useFastDebounce(t, m)
 	t.Cleanup(func() { _ = m.Close() })
 
@@ -441,7 +441,7 @@ func TestWatcher_CloseDoesNotStallOnInFlightReload(t *testing.T) {
 	dir := t.TempDir()
 	configPath := filepath.Join(dir, ".mcp.json")
 
-	m := NewManager(ctx, logger, agentexec.DefaultExecer, nil, nil, nil)
+	m := NewManager(ctx, logger, agentexec.DefaultExecer, nil, nil, nil, nil)
 	useFastDebounce(t, m)
 
 	// Arm the watcher with an initial empty Reload. We install the

--- a/agent/x/agentmcp/configwatcher_internal_test.go
+++ b/agent/x/agentmcp/configwatcher_internal_test.go
@@ -64,7 +64,7 @@ func TestWatcher_LateFileTriggersReload(t *testing.T) {
 	dir := t.TempDir()
 	configPath := filepath.Join(dir, ".mcp.json")
 
-	m := NewManager(ctx, logger, agentexec.DefaultExecer, nil, nil)
+	m := NewManager(ctx, logger, agentexec.DefaultExecer, nil, nil, nil)
 	useFastDebounce(t, m)
 	t.Cleanup(func() { _ = m.Close() })
 
@@ -104,7 +104,7 @@ func TestWatcher_RewriteTriggersReload(t *testing.T) {
 	_, entry := fakeMCPServerConfig(t, "srv")
 	configPath := writeMCPConfig(t, dir, map[string]mcpServerEntry{"srv": entry})
 
-	m := NewManager(ctx, logger, agentexec.DefaultExecer, nil, nil)
+	m := NewManager(ctx, logger, agentexec.DefaultExecer, nil, nil, nil)
 	useFastDebounce(t, m)
 	t.Cleanup(func() { _ = m.Close() })
 
@@ -141,7 +141,7 @@ func TestWatcher_RemovalTransitionsToEmpty(t *testing.T) {
 	_, entry := fakeMCPServerConfig(t, "srv")
 	configPath := writeMCPConfig(t, dir, map[string]mcpServerEntry{"srv": entry})
 
-	m := NewManager(ctx, logger, agentexec.DefaultExecer, nil, nil)
+	m := NewManager(ctx, logger, agentexec.DefaultExecer, nil, nil, nil)
 	useFastDebounce(t, m)
 	t.Cleanup(func() { _ = m.Close() })
 
@@ -240,7 +240,7 @@ func TestWatcher_CloseStopsGoroutine(t *testing.T) {
 	configPath := filepath.Join(dir, ".mcp.json")
 
 	for range 5 {
-		m := NewManager(ctx, logger, agentexec.DefaultExecer, nil, nil)
+		m := NewManager(ctx, logger, agentexec.DefaultExecer, nil, nil, nil)
 		useFastDebounce(t, m)
 		require.NoError(t, m.Reload(ctx, []string{configPath}))
 		require.NoError(t, m.Close())
@@ -274,7 +274,7 @@ func TestWatcher_DualAgentLateConfigWarmsCatalog(t *testing.T) {
 	dir := t.TempDir()
 	configPath := filepath.Join(dir, ".mcp.json")
 
-	m := NewManager(ctx, logger, agentexec.DefaultExecer, nil, nil)
+	m := NewManager(ctx, logger, agentexec.DefaultExecer, nil, nil, nil)
 	useFastDebounce(t, m)
 	t.Cleanup(func() { _ = m.Close() })
 
@@ -322,7 +322,7 @@ func TestWatcher_LateParentDirTriggersReload(t *testing.T) {
 	missing := filepath.Join(root, "config")
 	configPath := filepath.Join(missing, ".mcp.json")
 
-	m := NewManager(ctx, logger, agentexec.DefaultExecer, nil, nil)
+	m := NewManager(ctx, logger, agentexec.DefaultExecer, nil, nil, nil)
 	useFastDebounce(t, m)
 	t.Cleanup(func() { _ = m.Close() })
 
@@ -367,7 +367,7 @@ func TestWatcher_SharedParentRefcount(t *testing.T) {
 	pathA := filepath.Join(dir, "a.mcp.json")
 	pathB := filepath.Join(dir, "b.mcp.json")
 
-	m := NewManager(ctx, logger, agentexec.DefaultExecer, nil, nil)
+	m := NewManager(ctx, logger, agentexec.DefaultExecer, nil, nil, nil)
 	useFastDebounce(t, m)
 	t.Cleanup(func() { _ = m.Close() })
 
@@ -441,7 +441,7 @@ func TestWatcher_CloseDoesNotStallOnInFlightReload(t *testing.T) {
 	dir := t.TempDir()
 	configPath := filepath.Join(dir, ".mcp.json")
 
-	m := NewManager(ctx, logger, agentexec.DefaultExecer, nil, nil)
+	m := NewManager(ctx, logger, agentexec.DefaultExecer, nil, nil, nil)
 	useFastDebounce(t, m)
 
 	// Arm the watcher with an initial empty Reload. We install the

--- a/agent/x/agentmcp/manager.go
+++ b/agent/x/agentmcp/manager.go
@@ -16,6 +16,7 @@ import (
 	"time"
 
 	"github.com/modelcontextprotocol/go-sdk/mcp"
+	"github.com/spf13/afero"
 	"golang.org/x/sync/errgroup"
 	"golang.org/x/xerrors"
 	tailscalesingleflight "tailscale.com/util/singleflight"
@@ -75,6 +76,10 @@ type Manager struct {
 	execer    agentexec.Execer
 	updateEnv func(current []string) ([]string, error)
 
+	// workingDir reports the workspace working directory for stdio
+	// servers, read at connect time. See resolveWorkingDir.
+	workingDir func() string
+
 	mu        sync.RWMutex
 	logger    slog.Logger
 	clock     quartz.Clock
@@ -133,12 +138,15 @@ type serverEntry struct {
 // NewManager creates a new MCP client manager. The ctx bounds
 // subprocess lifetime. The execer applies resource limits to
 // MCP server subprocesses. The updateEnv callback enriches the
-// subprocess environment to match interactive sessions.
+// subprocess environment to match interactive sessions. The
+// workingDir callback reports the workspace working directory for
+// stdio servers.
 func NewManager(
 	ctx context.Context,
 	logger slog.Logger,
 	execer agentexec.Execer,
 	updateEnv func([]string) ([]string, error),
+	workingDir func() string,
 ) *Manager {
 	managerCtx, cancel := context.WithCancel(ctx)
 	return &Manager{
@@ -148,6 +156,7 @@ func NewManager(
 		clock:         quartz.NewReal(),
 		execer:        execer,
 		updateEnv:     updateEnv,
+		workingDir:    workingDir,
 		servers:       make(map[string]*serverEntry),
 		snapshot:      make(map[string]fileSnapshot),
 		closedCh:      make(chan struct{}),
@@ -886,6 +895,8 @@ func (m *Manager) createTransport(ctx context.Context, cfg ServerConfig) (mcp.Tr
 		env := m.buildEnv(ctx, cfg.Env)
 		cmd := m.execer.CommandContext(ctx, cfg.Command, cfg.Args...)
 		cmd.Env = env
+		// Relative paths in Args resolve against the workspace dir.
+		cmd.Dir = m.resolveWorkingDir(ctx)
 		return &mcp.CommandTransport{Command: cmd}, nil
 	case "http", "":
 		return &mcp.StreamableClientTransport{
@@ -900,6 +911,33 @@ func (m *Manager) createTransport(ctx context.Context, cfg ServerConfig) (mcp.Tr
 	default:
 		return nil, xerrors.Errorf("unsupported transport %q", cfg.Transport)
 	}
+}
+
+// resolveWorkingDir returns the directory for stdio MCP servers so
+// relative Args resolve against the workspace, not the agent's temp cwd.
+// It uses usershell.ResolveWorkingDirectory (shared with SSH and the
+// process API to avoid drift): the configured dir if it exists, else the
+// home directory. Returns "" (inherit the agent cwd) when workingDir is
+// nil or empty.
+func (m *Manager) resolveWorkingDir(ctx context.Context) string {
+	if m.workingDir == nil {
+		return ""
+	}
+	dir := m.workingDir()
+	if dir == "" {
+		return ""
+	}
+	resolved, err := usershell.ResolveWorkingDirectory(afero.NewOsFs(), usershell.SystemEnvInfo{}, dir)
+	if err != nil {
+		m.logger.Warn(ctx, "could not resolve MCP server working directory; inheriting the agent working directory",
+			slog.F("dir", dir), slog.Error(err))
+		return ""
+	}
+	if resolved != dir {
+		m.logger.Warn(ctx, "workspace working directory unavailable; launching MCP server in home directory",
+			slog.F("requested", dir), slog.F("resolved", resolved))
+	}
+	return resolved
 }
 
 // buildEnv enriches the process environment via the agent's

--- a/agent/x/agentmcp/manager.go
+++ b/agent/x/agentmcp/manager.go
@@ -139,19 +139,24 @@ type serverEntry struct {
 
 // NewManager creates a new MCP client manager. The ctx bounds
 // subprocess lifetime. The execer applies resource limits to
-// MCP server subprocesses. The envInfo reports the user's environment,
-// home, and shell; a nil value defaults to the current process. The
-// updateEnv callback enriches the subprocess environment to match
-// interactive sessions. The workingDir callback reports the workspace
-// working directory for stdio servers.
+// MCP server subprocesses. The fs and envInfo report the filesystem and
+// the user's environment, home, and shell; nil values default to the OS
+// filesystem and the current process. The updateEnv callback enriches
+// the subprocess environment to match interactive sessions. The
+// workingDir callback reports the workspace working directory for stdio
+// servers.
 func NewManager(
 	ctx context.Context,
 	logger slog.Logger,
 	execer agentexec.Execer,
+	filesystem afero.Fs,
 	envInfo usershell.EnvInfoer,
 	updateEnv func([]string) ([]string, error),
 	workingDir func() string,
 ) *Manager {
+	if filesystem == nil {
+		filesystem = afero.NewOsFs()
+	}
 	if envInfo == nil {
 		envInfo = &usershell.SystemEnvInfo{}
 	}
@@ -162,7 +167,7 @@ func NewManager(
 		logger:        logger,
 		clock:         quartz.NewReal(),
 		execer:        execer,
-		fs:            afero.NewOsFs(),
+		fs:            filesystem,
 		envInfo:       envInfo,
 		updateEnv:     updateEnv,
 		workingDir:    workingDir,
@@ -904,7 +909,6 @@ func (m *Manager) createTransport(ctx context.Context, cfg ServerConfig) (mcp.Tr
 		env := m.buildEnv(ctx, cfg.Env)
 		cmd := m.execer.CommandContext(ctx, cfg.Command, cfg.Args...)
 		cmd.Env = env
-		// Relative paths in Args resolve against the workspace dir.
 		cmd.Dir = m.resolveWorkingDir()
 		return &mcp.CommandTransport{Command: cmd}, nil
 	case "http", "":

--- a/agent/x/agentmcp/manager.go
+++ b/agent/x/agentmcp/manager.go
@@ -74,6 +74,8 @@ type Manager struct {
 	ctx       context.Context
 	cancel    context.CancelFunc
 	execer    agentexec.Execer
+	fs        afero.Fs
+	envInfo   usershell.EnvInfoer
 	updateEnv func(current []string) ([]string, error)
 
 	// workingDir reports the workspace working directory for stdio
@@ -137,17 +139,22 @@ type serverEntry struct {
 
 // NewManager creates a new MCP client manager. The ctx bounds
 // subprocess lifetime. The execer applies resource limits to
-// MCP server subprocesses. The updateEnv callback enriches the
-// subprocess environment to match interactive sessions. The
-// workingDir callback reports the workspace working directory for
-// stdio servers.
+// MCP server subprocesses. The envInfo reports the user's environment,
+// home, and shell; a nil value defaults to the current process. The
+// updateEnv callback enriches the subprocess environment to match
+// interactive sessions. The workingDir callback reports the workspace
+// working directory for stdio servers.
 func NewManager(
 	ctx context.Context,
 	logger slog.Logger,
 	execer agentexec.Execer,
+	envInfo usershell.EnvInfoer,
 	updateEnv func([]string) ([]string, error),
 	workingDir func() string,
 ) *Manager {
+	if envInfo == nil {
+		envInfo = &usershell.SystemEnvInfo{}
+	}
 	managerCtx, cancel := context.WithCancel(ctx)
 	return &Manager{
 		ctx:           managerCtx,
@@ -155,6 +162,8 @@ func NewManager(
 		logger:        logger,
 		clock:         quartz.NewReal(),
 		execer:        execer,
+		fs:            afero.NewOsFs(),
+		envInfo:       envInfo,
 		updateEnv:     updateEnv,
 		workingDir:    workingDir,
 		servers:       make(map[string]*serverEntry),
@@ -896,7 +905,7 @@ func (m *Manager) createTransport(ctx context.Context, cfg ServerConfig) (mcp.Tr
 		cmd := m.execer.CommandContext(ctx, cfg.Command, cfg.Args...)
 		cmd.Env = env
 		// Relative paths in Args resolve against the workspace dir.
-		cmd.Dir = m.resolveWorkingDir(ctx)
+		cmd.Dir = m.resolveWorkingDir()
 		return &mcp.CommandTransport{Command: cmd}, nil
 	case "http", "":
 		return &mcp.StreamableClientTransport{
@@ -913,31 +922,21 @@ func (m *Manager) createTransport(ctx context.Context, cfg ServerConfig) (mcp.Tr
 	}
 }
 
-// resolveWorkingDir returns the directory for stdio MCP servers so
-// relative Args resolve against the workspace, not the agent's temp cwd.
-// It uses usershell.ResolveWorkingDirectory (shared with SSH and the
-// process API to avoid drift): the configured dir if it exists, else the
-// home directory. Returns "" (inherit the agent cwd) when workingDir is
-// nil or empty.
-func (m *Manager) resolveWorkingDir(ctx context.Context) string {
-	if m.workingDir == nil {
-		return ""
+// resolveWorkingDir returns the directory to launch stdio MCP servers in
+// so relative Args resolve against the workspace, not the agent's temp
+// cwd: the configured workspace dir if it exists, otherwise the user's
+// home dir. It mirrors SSH and the process API via
+// usershell.ResolveWorkingDirectory so the three cannot drift.
+func (m *Manager) resolveWorkingDir() string {
+	var configured string
+	if m.workingDir != nil {
+		configured = m.workingDir()
 	}
-	dir := m.workingDir()
-	if dir == "" {
-		return ""
-	}
-	resolved, err := usershell.ResolveWorkingDirectory(afero.NewOsFs(), usershell.SystemEnvInfo{}, dir)
+	dir, err := usershell.ResolveWorkingDirectory(m.fs, m.envInfo, configured)
 	if err != nil {
-		m.logger.Warn(ctx, "could not resolve MCP server working directory; inheriting the agent working directory",
-			slog.F("dir", dir), slog.Error(err))
 		return ""
 	}
-	if resolved != dir {
-		m.logger.Warn(ctx, "workspace working directory unavailable; launching MCP server in home directory",
-			slog.F("requested", dir), slog.F("resolved", resolved))
-	}
-	return resolved
+	return dir
 }
 
 // buildEnv enriches the process environment via the agent's
@@ -946,7 +945,7 @@ func (m *Manager) resolveWorkingDir(ctx context.Context) string {
 func (m *Manager) buildEnv(ctx context.Context, explicit map[string]string) []string {
 	logger := m.logger.With(agentchat.Fields(ctx)...)
 
-	env := usershell.SystemEnvInfo{}.Environ()
+	env := m.envInfo.Environ()
 	if m.updateEnv != nil {
 		var err error
 		env, err = m.updateEnv(env)
@@ -954,7 +953,7 @@ func (m *Manager) buildEnv(ctx context.Context, explicit map[string]string) []st
 			logger.Warn(ctx, "failed to enrich MCP server environment",
 				slog.Error(err),
 			)
-			env = usershell.SystemEnvInfo{}.Environ()
+			env = m.envInfo.Environ()
 		}
 	}
 	if len(explicit) == 0 {

--- a/agent/x/agentmcp/manager_internal_test.go
+++ b/agent/x/agentmcp/manager_internal_test.go
@@ -7,6 +7,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
+	"path/filepath"
 	"testing"
 	"time"
 
@@ -17,6 +18,7 @@ import (
 	"cdr.dev/slog/v3"
 	"cdr.dev/slog/v3/sloggers/slogtest"
 	"github.com/coder/coder/v2/agent/agentexec"
+	"github.com/coder/coder/v2/agent/usershell"
 	"github.com/coder/coder/v2/codersdk/workspacesdk"
 	"github.com/coder/coder/v2/testutil"
 	"github.com/coder/quartz"
@@ -278,7 +280,7 @@ func TestManager_WaitReloadTimeout(t *testing.T) {
 	timerTrap := clock.Trap().NewTimer("agentmcp", "tools_reload")
 	defer timerTrap.Close()
 
-	m := NewManager(ctx, logger, agentexec.DefaultExecer, nil)
+	m := NewManager(ctx, logger, agentexec.DefaultExecer, nil, nil)
 	m.clock = clock
 	t.Cleanup(func() { _ = m.Close() })
 
@@ -296,6 +298,65 @@ func TestManager_WaitReloadTimeout(t *testing.T) {
 	require.Error(t, err)
 	assert.ErrorIs(t, err, context.DeadlineExceeded)
 	assert.Contains(t, err.Error(), "tools reload timed out after 1m0s")
+}
+
+// TestCreateTransport_StdioSetsWorkingDir verifies a stdio server's command
+// is launched in the workspace dir, so relative Args resolve there rather
+// than the agent's cwd.
+func TestCreateTransport_StdioSetsWorkingDir(t *testing.T) {
+	t.Parallel()
+
+	ctx := testutil.Context(t, testutil.WaitShort)
+	workDir := t.TempDir()
+	m := NewManager(ctx, slogtest.Make(t, nil), agentexec.DefaultExecer, nil,
+		func() string { return workDir })
+	t.Cleanup(func() { _ = m.Close() })
+
+	transport, err := m.createTransport(ctx, ServerConfig{
+		Name:      "fake",
+		Transport: "stdio",
+		Command:   "true",
+	})
+	require.NoError(t, err)
+
+	cmdTransport, ok := transport.(*mcp.CommandTransport)
+	require.True(t, ok)
+	assert.Equal(t, workDir, cmdTransport.Command.Dir)
+}
+
+// TestResolveWorkingDir covers resolveWorkingDir's fallback: nil/empty
+// inherits (""), an existing dir is used, missing/file falls back to home.
+func TestResolveWorkingDir(t *testing.T) {
+	t.Parallel()
+
+	home, err := usershell.SystemEnvInfo{}.HomeDir()
+	require.NoError(t, err)
+
+	existing := t.TempDir()
+	file := filepath.Join(existing, "a-file")
+	require.NoError(t, os.WriteFile(file, []byte("x"), 0o600))
+	missing := filepath.Join(existing, "does-not-exist")
+
+	tests := []struct {
+		name       string
+		workingDir func() string
+		want       string
+	}{
+		{name: "NilCallback", workingDir: nil, want: ""},
+		{name: "EmptyResult", workingDir: func() string { return "" }, want: ""},
+		{name: "ExistingDir", workingDir: func() string { return existing }, want: existing},
+		{name: "MissingDir", workingDir: func() string { return missing }, want: home},
+		{name: "PathIsFile", workingDir: func() string { return file }, want: home},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			ctx := testutil.Context(t, testutil.WaitShort)
+			m := &Manager{workingDir: tt.workingDir}
+			assert.Equal(t, tt.want, m.resolveWorkingDir(ctx))
+		})
+	}
 }
 
 // runFakeMCPServer implements a minimal JSON-RPC / MCP server over

--- a/agent/x/agentmcp/manager_internal_test.go
+++ b/agent/x/agentmcp/manager_internal_test.go
@@ -281,7 +281,7 @@ func TestManager_WaitReloadTimeout(t *testing.T) {
 	timerTrap := clock.Trap().NewTimer("agentmcp", "tools_reload")
 	defer timerTrap.Close()
 
-	m := NewManager(ctx, logger, agentexec.DefaultExecer, nil, nil, nil)
+	m := NewManager(ctx, logger, agentexec.DefaultExecer, nil, nil, nil, nil)
 	m.clock = clock
 	t.Cleanup(func() { _ = m.Close() })
 
@@ -309,7 +309,7 @@ func TestCreateTransport_StdioSetsWorkingDir(t *testing.T) {
 
 	ctx := testutil.Context(t, testutil.WaitShort)
 	workDir := t.TempDir()
-	m := NewManager(ctx, slogtest.Make(t, nil), agentexec.DefaultExecer, nil, nil,
+	m := NewManager(ctx, slogtest.Make(t, nil), agentexec.DefaultExecer, nil, nil, nil,
 		func() string { return workDir })
 	t.Cleanup(func() { _ = m.Close() })
 

--- a/agent/x/agentmcp/manager_internal_test.go
+++ b/agent/x/agentmcp/manager_internal_test.go
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	"github.com/modelcontextprotocol/go-sdk/mcp"
+	"github.com/spf13/afero"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -255,7 +256,7 @@ func TestConnectServer_StdioProcessSurvivesConnect(t *testing.T) {
 	}
 
 	ctx := testutil.Context(t, testutil.WaitLong)
-	m := &Manager{execer: agentexec.DefaultExecer}
+	m := &Manager{execer: agentexec.DefaultExecer, fs: afero.NewOsFs(), envInfo: &usershell.SystemEnvInfo{}}
 	client, err := m.connectServer(ctx, cfg)
 	require.NoError(t, err, "connectServer should succeed")
 	t.Cleanup(func() { _ = client.Close() })
@@ -280,7 +281,7 @@ func TestManager_WaitReloadTimeout(t *testing.T) {
 	timerTrap := clock.Trap().NewTimer("agentmcp", "tools_reload")
 	defer timerTrap.Close()
 
-	m := NewManager(ctx, logger, agentexec.DefaultExecer, nil, nil)
+	m := NewManager(ctx, logger, agentexec.DefaultExecer, nil, nil, nil)
 	m.clock = clock
 	t.Cleanup(func() { _ = m.Close() })
 
@@ -308,7 +309,7 @@ func TestCreateTransport_StdioSetsWorkingDir(t *testing.T) {
 
 	ctx := testutil.Context(t, testutil.WaitShort)
 	workDir := t.TempDir()
-	m := NewManager(ctx, slogtest.Make(t, nil), agentexec.DefaultExecer, nil,
+	m := NewManager(ctx, slogtest.Make(t, nil), agentexec.DefaultExecer, nil, nil,
 		func() string { return workDir })
 	t.Cleanup(func() { _ = m.Close() })
 
@@ -324,12 +325,13 @@ func TestCreateTransport_StdioSetsWorkingDir(t *testing.T) {
 	assert.Equal(t, workDir, cmdTransport.Command.Dir)
 }
 
-// TestResolveWorkingDir covers resolveWorkingDir's fallback: nil/empty
-// inherits (""), an existing dir is used, missing/file falls back to home.
+// TestResolveWorkingDir covers resolveWorkingDir's fallback: nil/empty,
+// a missing path, or a file all fall back to home; an existing dir is used.
 func TestResolveWorkingDir(t *testing.T) {
 	t.Parallel()
 
-	home, err := usershell.SystemEnvInfo{}.HomeDir()
+	envInfo := &usershell.SystemEnvInfo{}
+	home, err := envInfo.HomeDir()
 	require.NoError(t, err)
 
 	existing := t.TempDir()
@@ -342,8 +344,8 @@ func TestResolveWorkingDir(t *testing.T) {
 		workingDir func() string
 		want       string
 	}{
-		{name: "NilCallback", workingDir: nil, want: ""},
-		{name: "EmptyResult", workingDir: func() string { return "" }, want: ""},
+		{name: "NilCallback", workingDir: nil, want: home},
+		{name: "EmptyResult", workingDir: func() string { return "" }, want: home},
 		{name: "ExistingDir", workingDir: func() string { return existing }, want: existing},
 		{name: "MissingDir", workingDir: func() string { return missing }, want: home},
 		{name: "PathIsFile", workingDir: func() string { return file }, want: home},
@@ -352,9 +354,8 @@ func TestResolveWorkingDir(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
-			ctx := testutil.Context(t, testutil.WaitShort)
-			m := &Manager{workingDir: tt.workingDir}
-			assert.Equal(t, tt.want, m.resolveWorkingDir(ctx))
+			m := &Manager{fs: afero.NewOsFs(), envInfo: envInfo, workingDir: tt.workingDir}
+			assert.Equal(t, tt.want, m.resolveWorkingDir())
 		})
 	}
 }

--- a/agent/x/agentmcp/reload_internal_test.go
+++ b/agent/x/agentmcp/reload_internal_test.go
@@ -189,7 +189,7 @@ func TestSnapshotChanged(t *testing.T) {
 
 			paths := tc.setup(t, dir)
 
-			m := NewManager(ctx, logger, agentexec.DefaultExecer, nil, nil, nil)
+			m := NewManager(ctx, logger, agentexec.DefaultExecer, nil, nil, nil, nil)
 			t.Cleanup(func() { _ = m.Close() })
 
 			err := m.Reload(ctx, paths)
@@ -230,7 +230,7 @@ func TestSnapshotChanged_MultipleConfigFiles(t *testing.T) {
 	path2 := writeMCPConfig(t, dir2, map[string]mcpServerEntry{"srv2": entry2})
 	paths := []string{path1, path2}
 
-	m := NewManager(ctx, logger, agentexec.DefaultExecer, nil, nil, nil)
+	m := NewManager(ctx, logger, agentexec.DefaultExecer, nil, nil, nil, nil)
 	t.Cleanup(func() { _ = m.Close() })
 
 	// Initial reload with both config files.
@@ -273,7 +273,7 @@ func TestReload(t *testing.T) {
 		_, entry := fakeMCPServerConfig(t, "srv")
 		configPath := writeMCPConfig(t, dir, map[string]mcpServerEntry{"srv": entry})
 
-		m := NewManager(ctx, logger, agentexec.DefaultExecer, nil, nil, nil)
+		m := NewManager(ctx, logger, agentexec.DefaultExecer, nil, nil, nil, nil)
 		t.Cleanup(func() { _ = m.Close() })
 
 		err := m.Reload(ctx, []string{configPath})
@@ -292,7 +292,7 @@ func TestReload(t *testing.T) {
 		ctx := testutil.Context(t, testutil.WaitLong)
 		logger := slogtest.Make(t, nil).Leveled(slog.LevelDebug)
 
-		m := NewManager(ctx, logger, agentexec.DefaultExecer, nil, nil, nil)
+		m := NewManager(ctx, logger, agentexec.DefaultExecer, nil, nil, nil, nil)
 		require.NoError(t, m.Close())
 
 		err := m.Reload(ctx, []string{"/nonexistent"})
@@ -308,7 +308,7 @@ func TestReload(t *testing.T) {
 		_, entry := fakeMCPServerConfig(t, "srv")
 		configPath := writeMCPConfig(t, dir, map[string]mcpServerEntry{"srv": entry})
 
-		m := NewManager(ctx, logger, agentexec.DefaultExecer, nil, nil, nil)
+		m := NewManager(ctx, logger, agentexec.DefaultExecer, nil, nil, nil, nil)
 		t.Cleanup(func() { _ = m.Close() })
 
 		// Launch multiple concurrent reloads.
@@ -337,7 +337,7 @@ func TestReload(t *testing.T) {
 		dir := t.TempDir()
 		paths := []string{filepath.Join(dir, ".mcp.json")}
 
-		m := NewManager(mgrCtx, logger, agentexec.DefaultExecer, nil, nil, nil)
+		m := NewManager(mgrCtx, logger, agentexec.DefaultExecer, nil, nil, nil, nil)
 		t.Cleanup(func() { _ = m.Close() })
 
 		// Use an already-canceled caller context.
@@ -367,7 +367,7 @@ func TestReload(t *testing.T) {
 		_, entry1 := fakeMCPServerConfig(t, "srv1")
 		configPath := writeMCPConfig(t, dir, map[string]mcpServerEntry{"srv1": entry1})
 
-		m := NewManager(ctx, logger, agentexec.DefaultExecer, nil, nil, nil)
+		m := NewManager(ctx, logger, agentexec.DefaultExecer, nil, nil, nil, nil)
 		t.Cleanup(func() { _ = m.Close() })
 
 		// First reload.
@@ -401,7 +401,7 @@ func TestReload(t *testing.T) {
 		data := `{"mcpServers":{"bad":{"command":"/nonexistent/binary","args":[]}}}`
 		require.NoError(t, os.WriteFile(path, []byte(data), 0o600))
 
-		m := NewManager(ctx, logger, agentexec.DefaultExecer, nil, nil, nil)
+		m := NewManager(ctx, logger, agentexec.DefaultExecer, nil, nil, nil, nil)
 		t.Cleanup(func() { _ = m.Close() })
 
 		// Reload should succeed (per-server failures are logged and
@@ -421,7 +421,7 @@ func TestReload(t *testing.T) {
 		_, entry := fakeMCPServerConfig(t, "srv")
 		configPath := writeMCPConfig(t, dir, map[string]mcpServerEntry{"srv": entry})
 
-		m := NewManager(ctx, logger, agentexec.DefaultExecer, nil, nil, nil)
+		m := NewManager(ctx, logger, agentexec.DefaultExecer, nil, nil, nil, nil)
 		t.Cleanup(func() { _ = m.Close() })
 
 		err := m.Reload(ctx, []string{configPath})
@@ -456,7 +456,7 @@ func TestDifferentialReload(t *testing.T) {
 		_, entry := fakeMCPServerConfig(t, "srv")
 		configPath := writeMCPConfig(t, dir, map[string]mcpServerEntry{"srv": entry})
 
-		m := NewManager(ctx, logger, agentexec.DefaultExecer, nil, nil, nil)
+		m := NewManager(ctx, logger, agentexec.DefaultExecer, nil, nil, nil, nil)
 		t.Cleanup(func() { _ = m.Close() })
 
 		err := m.Reload(ctx, []string{configPath})
@@ -497,7 +497,7 @@ func TestDifferentialReload(t *testing.T) {
 		_, entry := fakeMCPServerConfig(t, "srv")
 		configPath := writeMCPConfig(t, dir, map[string]mcpServerEntry{"srv": entry})
 
-		m := NewManager(ctx, logger, agentexec.DefaultExecer, nil, nil, nil)
+		m := NewManager(ctx, logger, agentexec.DefaultExecer, nil, nil, nil, nil)
 		t.Cleanup(func() { _ = m.Close() })
 
 		err := m.Reload(ctx, []string{configPath})
@@ -534,7 +534,7 @@ func TestDifferentialReload(t *testing.T) {
 			"srvA": entryA, "srvB": entryB,
 		})
 
-		m := NewManager(ctx, logger, agentexec.DefaultExecer, nil, nil, nil)
+		m := NewManager(ctx, logger, agentexec.DefaultExecer, nil, nil, nil, nil)
 		t.Cleanup(func() { _ = m.Close() })
 
 		err := m.Reload(ctx, []string{configPath})
@@ -574,7 +574,7 @@ func TestDifferentialReload(t *testing.T) {
 		_, entry := fakeMCPServerConfig(t, "srv")
 		configPath := writeMCPConfig(t, dir, map[string]mcpServerEntry{"srv": entry})
 
-		m := NewManager(ctx, logger, agentexec.DefaultExecer, nil, nil, nil)
+		m := NewManager(ctx, logger, agentexec.DefaultExecer, nil, nil, nil, nil)
 		t.Cleanup(func() { _ = m.Close() })
 
 		err := m.Reload(ctx, []string{configPath})
@@ -615,7 +615,7 @@ func TestDifferentialReload(t *testing.T) {
 		_, entry := fakeMCPServerConfig(t, "srv")
 		configPath := writeMCPConfig(t, dir, map[string]mcpServerEntry{"srv": entry})
 
-		m := NewManager(ctx, logger, agentexec.DefaultExecer, nil, nil, nil)
+		m := NewManager(ctx, logger, agentexec.DefaultExecer, nil, nil, nil, nil)
 		t.Cleanup(func() { _ = m.Close() })
 
 		err := m.Reload(ctx, []string{configPath})
@@ -664,7 +664,7 @@ func TestReload_FirstBootPath(t *testing.T) {
 	_, entry := fakeMCPServerConfig(t, "srv")
 	configPath := writeMCPConfig(t, dir, map[string]mcpServerEntry{"srv": entry})
 
-	m := NewManager(ctx, logger, agentexec.DefaultExecer, nil, nil, nil)
+	m := NewManager(ctx, logger, agentexec.DefaultExecer, nil, nil, nil, nil)
 	t.Cleanup(func() { _ = m.Close() })
 
 	// Simulate first-boot: Reload with the initial config.
@@ -693,7 +693,7 @@ func TestReload_NoopWhenUnchanged(t *testing.T) {
 	_, entry := fakeMCPServerConfig(t, "srv")
 	configPath := writeMCPConfig(t, dir, map[string]mcpServerEntry{"srv": entry})
 
-	m := NewManager(ctx, logger, agentexec.DefaultExecer, nil, nil, nil)
+	m := NewManager(ctx, logger, agentexec.DefaultExecer, nil, nil, nil, nil)
 	t.Cleanup(func() { _ = m.Close() })
 
 	err := m.Reload(ctx, []string{configPath})
@@ -738,7 +738,7 @@ func TestClose_SuppressesSubprocessExitError(t *testing.T) {
 	_, entry := fakeMCPServerConfig(t, "srv")
 	configPath := writeMCPConfig(t, dir, map[string]mcpServerEntry{"srv": entry})
 
-	m := NewManager(ctx, logger, agentexec.DefaultExecer, nil, nil, nil)
+	m := NewManager(ctx, logger, agentexec.DefaultExecer, nil, nil, nil, nil)
 	t.Cleanup(func() { _ = m.Close() })
 
 	err := m.Reload(ctx, []string{configPath})

--- a/agent/x/agentmcp/reload_internal_test.go
+++ b/agent/x/agentmcp/reload_internal_test.go
@@ -189,7 +189,7 @@ func TestSnapshotChanged(t *testing.T) {
 
 			paths := tc.setup(t, dir)
 
-			m := NewManager(ctx, logger, agentexec.DefaultExecer, nil, nil)
+			m := NewManager(ctx, logger, agentexec.DefaultExecer, nil, nil, nil)
 			t.Cleanup(func() { _ = m.Close() })
 
 			err := m.Reload(ctx, paths)
@@ -230,7 +230,7 @@ func TestSnapshotChanged_MultipleConfigFiles(t *testing.T) {
 	path2 := writeMCPConfig(t, dir2, map[string]mcpServerEntry{"srv2": entry2})
 	paths := []string{path1, path2}
 
-	m := NewManager(ctx, logger, agentexec.DefaultExecer, nil, nil)
+	m := NewManager(ctx, logger, agentexec.DefaultExecer, nil, nil, nil)
 	t.Cleanup(func() { _ = m.Close() })
 
 	// Initial reload with both config files.
@@ -273,7 +273,7 @@ func TestReload(t *testing.T) {
 		_, entry := fakeMCPServerConfig(t, "srv")
 		configPath := writeMCPConfig(t, dir, map[string]mcpServerEntry{"srv": entry})
 
-		m := NewManager(ctx, logger, agentexec.DefaultExecer, nil, nil)
+		m := NewManager(ctx, logger, agentexec.DefaultExecer, nil, nil, nil)
 		t.Cleanup(func() { _ = m.Close() })
 
 		err := m.Reload(ctx, []string{configPath})
@@ -292,7 +292,7 @@ func TestReload(t *testing.T) {
 		ctx := testutil.Context(t, testutil.WaitLong)
 		logger := slogtest.Make(t, nil).Leveled(slog.LevelDebug)
 
-		m := NewManager(ctx, logger, agentexec.DefaultExecer, nil, nil)
+		m := NewManager(ctx, logger, agentexec.DefaultExecer, nil, nil, nil)
 		require.NoError(t, m.Close())
 
 		err := m.Reload(ctx, []string{"/nonexistent"})
@@ -308,7 +308,7 @@ func TestReload(t *testing.T) {
 		_, entry := fakeMCPServerConfig(t, "srv")
 		configPath := writeMCPConfig(t, dir, map[string]mcpServerEntry{"srv": entry})
 
-		m := NewManager(ctx, logger, agentexec.DefaultExecer, nil, nil)
+		m := NewManager(ctx, logger, agentexec.DefaultExecer, nil, nil, nil)
 		t.Cleanup(func() { _ = m.Close() })
 
 		// Launch multiple concurrent reloads.
@@ -337,7 +337,7 @@ func TestReload(t *testing.T) {
 		dir := t.TempDir()
 		paths := []string{filepath.Join(dir, ".mcp.json")}
 
-		m := NewManager(mgrCtx, logger, agentexec.DefaultExecer, nil, nil)
+		m := NewManager(mgrCtx, logger, agentexec.DefaultExecer, nil, nil, nil)
 		t.Cleanup(func() { _ = m.Close() })
 
 		// Use an already-canceled caller context.
@@ -367,7 +367,7 @@ func TestReload(t *testing.T) {
 		_, entry1 := fakeMCPServerConfig(t, "srv1")
 		configPath := writeMCPConfig(t, dir, map[string]mcpServerEntry{"srv1": entry1})
 
-		m := NewManager(ctx, logger, agentexec.DefaultExecer, nil, nil)
+		m := NewManager(ctx, logger, agentexec.DefaultExecer, nil, nil, nil)
 		t.Cleanup(func() { _ = m.Close() })
 
 		// First reload.
@@ -401,7 +401,7 @@ func TestReload(t *testing.T) {
 		data := `{"mcpServers":{"bad":{"command":"/nonexistent/binary","args":[]}}}`
 		require.NoError(t, os.WriteFile(path, []byte(data), 0o600))
 
-		m := NewManager(ctx, logger, agentexec.DefaultExecer, nil, nil)
+		m := NewManager(ctx, logger, agentexec.DefaultExecer, nil, nil, nil)
 		t.Cleanup(func() { _ = m.Close() })
 
 		// Reload should succeed (per-server failures are logged and
@@ -421,7 +421,7 @@ func TestReload(t *testing.T) {
 		_, entry := fakeMCPServerConfig(t, "srv")
 		configPath := writeMCPConfig(t, dir, map[string]mcpServerEntry{"srv": entry})
 
-		m := NewManager(ctx, logger, agentexec.DefaultExecer, nil, nil)
+		m := NewManager(ctx, logger, agentexec.DefaultExecer, nil, nil, nil)
 		t.Cleanup(func() { _ = m.Close() })
 
 		err := m.Reload(ctx, []string{configPath})
@@ -456,7 +456,7 @@ func TestDifferentialReload(t *testing.T) {
 		_, entry := fakeMCPServerConfig(t, "srv")
 		configPath := writeMCPConfig(t, dir, map[string]mcpServerEntry{"srv": entry})
 
-		m := NewManager(ctx, logger, agentexec.DefaultExecer, nil, nil)
+		m := NewManager(ctx, logger, agentexec.DefaultExecer, nil, nil, nil)
 		t.Cleanup(func() { _ = m.Close() })
 
 		err := m.Reload(ctx, []string{configPath})
@@ -497,7 +497,7 @@ func TestDifferentialReload(t *testing.T) {
 		_, entry := fakeMCPServerConfig(t, "srv")
 		configPath := writeMCPConfig(t, dir, map[string]mcpServerEntry{"srv": entry})
 
-		m := NewManager(ctx, logger, agentexec.DefaultExecer, nil, nil)
+		m := NewManager(ctx, logger, agentexec.DefaultExecer, nil, nil, nil)
 		t.Cleanup(func() { _ = m.Close() })
 
 		err := m.Reload(ctx, []string{configPath})
@@ -534,7 +534,7 @@ func TestDifferentialReload(t *testing.T) {
 			"srvA": entryA, "srvB": entryB,
 		})
 
-		m := NewManager(ctx, logger, agentexec.DefaultExecer, nil, nil)
+		m := NewManager(ctx, logger, agentexec.DefaultExecer, nil, nil, nil)
 		t.Cleanup(func() { _ = m.Close() })
 
 		err := m.Reload(ctx, []string{configPath})
@@ -574,7 +574,7 @@ func TestDifferentialReload(t *testing.T) {
 		_, entry := fakeMCPServerConfig(t, "srv")
 		configPath := writeMCPConfig(t, dir, map[string]mcpServerEntry{"srv": entry})
 
-		m := NewManager(ctx, logger, agentexec.DefaultExecer, nil, nil)
+		m := NewManager(ctx, logger, agentexec.DefaultExecer, nil, nil, nil)
 		t.Cleanup(func() { _ = m.Close() })
 
 		err := m.Reload(ctx, []string{configPath})
@@ -615,7 +615,7 @@ func TestDifferentialReload(t *testing.T) {
 		_, entry := fakeMCPServerConfig(t, "srv")
 		configPath := writeMCPConfig(t, dir, map[string]mcpServerEntry{"srv": entry})
 
-		m := NewManager(ctx, logger, agentexec.DefaultExecer, nil, nil)
+		m := NewManager(ctx, logger, agentexec.DefaultExecer, nil, nil, nil)
 		t.Cleanup(func() { _ = m.Close() })
 
 		err := m.Reload(ctx, []string{configPath})
@@ -664,7 +664,7 @@ func TestReload_FirstBootPath(t *testing.T) {
 	_, entry := fakeMCPServerConfig(t, "srv")
 	configPath := writeMCPConfig(t, dir, map[string]mcpServerEntry{"srv": entry})
 
-	m := NewManager(ctx, logger, agentexec.DefaultExecer, nil, nil)
+	m := NewManager(ctx, logger, agentexec.DefaultExecer, nil, nil, nil)
 	t.Cleanup(func() { _ = m.Close() })
 
 	// Simulate first-boot: Reload with the initial config.
@@ -693,7 +693,7 @@ func TestReload_NoopWhenUnchanged(t *testing.T) {
 	_, entry := fakeMCPServerConfig(t, "srv")
 	configPath := writeMCPConfig(t, dir, map[string]mcpServerEntry{"srv": entry})
 
-	m := NewManager(ctx, logger, agentexec.DefaultExecer, nil, nil)
+	m := NewManager(ctx, logger, agentexec.DefaultExecer, nil, nil, nil)
 	t.Cleanup(func() { _ = m.Close() })
 
 	err := m.Reload(ctx, []string{configPath})
@@ -738,7 +738,7 @@ func TestClose_SuppressesSubprocessExitError(t *testing.T) {
 	_, entry := fakeMCPServerConfig(t, "srv")
 	configPath := writeMCPConfig(t, dir, map[string]mcpServerEntry{"srv": entry})
 
-	m := NewManager(ctx, logger, agentexec.DefaultExecer, nil, nil)
+	m := NewManager(ctx, logger, agentexec.DefaultExecer, nil, nil, nil)
 	t.Cleanup(func() { _ = m.Close() })
 
 	err := m.Reload(ctx, []string{configPath})

--- a/agent/x/agentmcp/reload_internal_test.go
+++ b/agent/x/agentmcp/reload_internal_test.go
@@ -189,7 +189,7 @@ func TestSnapshotChanged(t *testing.T) {
 
 			paths := tc.setup(t, dir)
 
-			m := NewManager(ctx, logger, agentexec.DefaultExecer, nil)
+			m := NewManager(ctx, logger, agentexec.DefaultExecer, nil, nil)
 			t.Cleanup(func() { _ = m.Close() })
 
 			err := m.Reload(ctx, paths)
@@ -230,7 +230,7 @@ func TestSnapshotChanged_MultipleConfigFiles(t *testing.T) {
 	path2 := writeMCPConfig(t, dir2, map[string]mcpServerEntry{"srv2": entry2})
 	paths := []string{path1, path2}
 
-	m := NewManager(ctx, logger, agentexec.DefaultExecer, nil)
+	m := NewManager(ctx, logger, agentexec.DefaultExecer, nil, nil)
 	t.Cleanup(func() { _ = m.Close() })
 
 	// Initial reload with both config files.
@@ -273,7 +273,7 @@ func TestReload(t *testing.T) {
 		_, entry := fakeMCPServerConfig(t, "srv")
 		configPath := writeMCPConfig(t, dir, map[string]mcpServerEntry{"srv": entry})
 
-		m := NewManager(ctx, logger, agentexec.DefaultExecer, nil)
+		m := NewManager(ctx, logger, agentexec.DefaultExecer, nil, nil)
 		t.Cleanup(func() { _ = m.Close() })
 
 		err := m.Reload(ctx, []string{configPath})
@@ -292,7 +292,7 @@ func TestReload(t *testing.T) {
 		ctx := testutil.Context(t, testutil.WaitLong)
 		logger := slogtest.Make(t, nil).Leveled(slog.LevelDebug)
 
-		m := NewManager(ctx, logger, agentexec.DefaultExecer, nil)
+		m := NewManager(ctx, logger, agentexec.DefaultExecer, nil, nil)
 		require.NoError(t, m.Close())
 
 		err := m.Reload(ctx, []string{"/nonexistent"})
@@ -308,7 +308,7 @@ func TestReload(t *testing.T) {
 		_, entry := fakeMCPServerConfig(t, "srv")
 		configPath := writeMCPConfig(t, dir, map[string]mcpServerEntry{"srv": entry})
 
-		m := NewManager(ctx, logger, agentexec.DefaultExecer, nil)
+		m := NewManager(ctx, logger, agentexec.DefaultExecer, nil, nil)
 		t.Cleanup(func() { _ = m.Close() })
 
 		// Launch multiple concurrent reloads.
@@ -337,7 +337,7 @@ func TestReload(t *testing.T) {
 		dir := t.TempDir()
 		paths := []string{filepath.Join(dir, ".mcp.json")}
 
-		m := NewManager(mgrCtx, logger, agentexec.DefaultExecer, nil)
+		m := NewManager(mgrCtx, logger, agentexec.DefaultExecer, nil, nil)
 		t.Cleanup(func() { _ = m.Close() })
 
 		// Use an already-canceled caller context.
@@ -367,7 +367,7 @@ func TestReload(t *testing.T) {
 		_, entry1 := fakeMCPServerConfig(t, "srv1")
 		configPath := writeMCPConfig(t, dir, map[string]mcpServerEntry{"srv1": entry1})
 
-		m := NewManager(ctx, logger, agentexec.DefaultExecer, nil)
+		m := NewManager(ctx, logger, agentexec.DefaultExecer, nil, nil)
 		t.Cleanup(func() { _ = m.Close() })
 
 		// First reload.
@@ -401,7 +401,7 @@ func TestReload(t *testing.T) {
 		data := `{"mcpServers":{"bad":{"command":"/nonexistent/binary","args":[]}}}`
 		require.NoError(t, os.WriteFile(path, []byte(data), 0o600))
 
-		m := NewManager(ctx, logger, agentexec.DefaultExecer, nil)
+		m := NewManager(ctx, logger, agentexec.DefaultExecer, nil, nil)
 		t.Cleanup(func() { _ = m.Close() })
 
 		// Reload should succeed (per-server failures are logged and
@@ -421,7 +421,7 @@ func TestReload(t *testing.T) {
 		_, entry := fakeMCPServerConfig(t, "srv")
 		configPath := writeMCPConfig(t, dir, map[string]mcpServerEntry{"srv": entry})
 
-		m := NewManager(ctx, logger, agentexec.DefaultExecer, nil)
+		m := NewManager(ctx, logger, agentexec.DefaultExecer, nil, nil)
 		t.Cleanup(func() { _ = m.Close() })
 
 		err := m.Reload(ctx, []string{configPath})
@@ -456,7 +456,7 @@ func TestDifferentialReload(t *testing.T) {
 		_, entry := fakeMCPServerConfig(t, "srv")
 		configPath := writeMCPConfig(t, dir, map[string]mcpServerEntry{"srv": entry})
 
-		m := NewManager(ctx, logger, agentexec.DefaultExecer, nil)
+		m := NewManager(ctx, logger, agentexec.DefaultExecer, nil, nil)
 		t.Cleanup(func() { _ = m.Close() })
 
 		err := m.Reload(ctx, []string{configPath})
@@ -497,7 +497,7 @@ func TestDifferentialReload(t *testing.T) {
 		_, entry := fakeMCPServerConfig(t, "srv")
 		configPath := writeMCPConfig(t, dir, map[string]mcpServerEntry{"srv": entry})
 
-		m := NewManager(ctx, logger, agentexec.DefaultExecer, nil)
+		m := NewManager(ctx, logger, agentexec.DefaultExecer, nil, nil)
 		t.Cleanup(func() { _ = m.Close() })
 
 		err := m.Reload(ctx, []string{configPath})
@@ -534,7 +534,7 @@ func TestDifferentialReload(t *testing.T) {
 			"srvA": entryA, "srvB": entryB,
 		})
 
-		m := NewManager(ctx, logger, agentexec.DefaultExecer, nil)
+		m := NewManager(ctx, logger, agentexec.DefaultExecer, nil, nil)
 		t.Cleanup(func() { _ = m.Close() })
 
 		err := m.Reload(ctx, []string{configPath})
@@ -574,7 +574,7 @@ func TestDifferentialReload(t *testing.T) {
 		_, entry := fakeMCPServerConfig(t, "srv")
 		configPath := writeMCPConfig(t, dir, map[string]mcpServerEntry{"srv": entry})
 
-		m := NewManager(ctx, logger, agentexec.DefaultExecer, nil)
+		m := NewManager(ctx, logger, agentexec.DefaultExecer, nil, nil)
 		t.Cleanup(func() { _ = m.Close() })
 
 		err := m.Reload(ctx, []string{configPath})
@@ -615,7 +615,7 @@ func TestDifferentialReload(t *testing.T) {
 		_, entry := fakeMCPServerConfig(t, "srv")
 		configPath := writeMCPConfig(t, dir, map[string]mcpServerEntry{"srv": entry})
 
-		m := NewManager(ctx, logger, agentexec.DefaultExecer, nil)
+		m := NewManager(ctx, logger, agentexec.DefaultExecer, nil, nil)
 		t.Cleanup(func() { _ = m.Close() })
 
 		err := m.Reload(ctx, []string{configPath})
@@ -664,7 +664,7 @@ func TestReload_FirstBootPath(t *testing.T) {
 	_, entry := fakeMCPServerConfig(t, "srv")
 	configPath := writeMCPConfig(t, dir, map[string]mcpServerEntry{"srv": entry})
 
-	m := NewManager(ctx, logger, agentexec.DefaultExecer, nil)
+	m := NewManager(ctx, logger, agentexec.DefaultExecer, nil, nil)
 	t.Cleanup(func() { _ = m.Close() })
 
 	// Simulate first-boot: Reload with the initial config.
@@ -693,7 +693,7 @@ func TestReload_NoopWhenUnchanged(t *testing.T) {
 	_, entry := fakeMCPServerConfig(t, "srv")
 	configPath := writeMCPConfig(t, dir, map[string]mcpServerEntry{"srv": entry})
 
-	m := NewManager(ctx, logger, agentexec.DefaultExecer, nil)
+	m := NewManager(ctx, logger, agentexec.DefaultExecer, nil, nil)
 	t.Cleanup(func() { _ = m.Close() })
 
 	err := m.Reload(ctx, []string{configPath})
@@ -738,7 +738,7 @@ func TestClose_SuppressesSubprocessExitError(t *testing.T) {
 	_, entry := fakeMCPServerConfig(t, "srv")
 	configPath := writeMCPConfig(t, dir, map[string]mcpServerEntry{"srv": entry})
 
-	m := NewManager(ctx, logger, agentexec.DefaultExecer, nil)
+	m := NewManager(ctx, logger, agentexec.DefaultExecer, nil, nil)
 	t.Cleanup(func() { _ = m.Close() })
 
 	err := m.Reload(ctx, []string{configPath})


### PR DESCRIPTION
## Problem

stdio MCP servers declared in `.mcp.json` were launched from the agent's own working directory, which is unspecified and often a temp dir (observed `/tmp/coder.*`). Relative paths in a server's `Args` (for example a language server `-workspace ./site/`) resolved against that temp dir instead of the workspace, so:

- `typescript-language-server` failed immediately: the resolved `./site/` did not exist under the temp cwd.
- `go-language-server` connected but gopls rooted at the temp dir, so workspace symbol lookups failed while per-file hover still worked.

The agent log showed `connection closed: calling "initialize": client is closing: EOF`.

<img width="682" height="606" alt="Screenshot 2026-09-09 at 5 33 58 PM" src="https://github.com/user-attachments/assets/650f1305-d807-406e-864e-e347e9a4c52d" />

## Fix

Launch stdio MCP servers in the workspace working directory instead of inheriting the agent's cwd.

- `agent/agent.go`: hoist a single `workingDirFn` closure (reads `a.manifest.Load().Directory`, `""` before the first manifest) and reuse it for the process API, MCP manager, and context config/manager wiring.
- `agent/x/agentmcp/manager.go`: `Manager` gains a `workingDir func() string`; `createTransport` sets `cmd.Dir = m.resolveWorkingDir(ctx)` for the stdio path. `resolveWorkingDir` routes through `usershell.ResolveWorkingDirectory`, the same helper SSH sessions and the process API use, so the three cannot drift: an existing configured dir is used, otherwise the user's home dir. Returns `""` (inherit) only when the callback is nil or empty.

`.mcp.json` is unchanged. Storybook is untouched.

## Tests

- `TestCreateTransport_StdioSetsWorkingDir`: constructs the manager via `NewManager` and asserts the stdio transport's `Command.Dir` is the workspace dir.
- `TestResolveWorkingDir`: table cases for nil/empty callback (inherit), existing dir, missing dir, and a path that is a file (both fall back to home).

## Checks

`make fmt`, `make lint`, and `go test ./agent/x/agentmcp/` all pass.

<details>
<summary>Design notes and alternatives considered</summary>

First-principles contract: MCP servers should launch in the workspace working directory, matching existing docs and agent subsystem behavior, not the config directory that declares them.

An earlier iteration set `cmd.Dir` from the config file's directory; review found that fragile (global config locations, `$HOME` semantics). It was replaced with the workspace-dir callback that reuses `usershell.ResolveWorkingDirectory` for consistency with SSH and the process API.

A tooling-only alternative also exists (resolve the language-server workspace via a `WORKSPACE` env value in `.mcp.json`). The agent-side fix was preferred because it corrects the root cause for every stdio MCP server, not just the two language servers, and keeps `.mcp.json` portable.

Deferred (not in this PR): converting `NewManager` to an options struct to avoid positional `nil` churn, and setting `PWD` alongside `cmd.Dir`.

</details>

---

Generated by Coder Agents on behalf of @jeremyruppel.
