### PR TITLE
test(cli): use WaitLong for interactive create test assertions

### DIFF
--- a/cli/create_test.go
+++ b/cli/create_test.go
@@ -1094,7 +1094,7 @@ cli_param: from file`)
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			logger := testutil.Logger(t)
-			ctx := testutil.Context(t, testutil.WaitMedium)
+			ctx := testutil.Context(t, testutil.WaitLong)
 
 			parameters := params
 			if len(tt.inputParameters) > 0 {
@@ -1249,7 +1249,7 @@ func TestCreateWithPreset(t *testing.T) {
 	// the CLI uses the specified preset instead of the default
 	t.Run("PresetFlag", func(t *testing.T) {
 		t.Parallel()
-		ctx := testutil.Context(t, testutil.WaitMedium)
+		ctx := testutil.Context(t, testutil.WaitLong)
 
 		client := coderdtest.New(t, &coderdtest.Options{IncludeProvisionerDaemon: true})
 		owner := coderdtest.CreateFirstUser(t, client)
@@ -1325,7 +1325,7 @@ func TestCreateWithPreset(t *testing.T) {
 	// the CLI automatically uses the default preset to create the workspace
 	t.Run("DefaultPreset", func(t *testing.T) {
 		t.Parallel()
-		ctx := testutil.Context(t, testutil.WaitMedium)
+		ctx := testutil.Context(t, testutil.WaitLong)
 
 		client := coderdtest.New(t, &coderdtest.Options{IncludeProvisionerDaemon: true})
 		owner := coderdtest.CreateFirstUser(t, client)
@@ -1399,7 +1399,7 @@ func TestCreateWithPreset(t *testing.T) {
 	t.Run("NoDefaultPresetPromptUser", func(t *testing.T) {
 		t.Parallel()
 		logger := testutil.Logger(t)
-		ctx := testutil.Context(t, testutil.WaitMedium)
+		ctx := testutil.Context(t, testutil.WaitLong)
 
 		client := coderdtest.New(t, &coderdtest.Options{IncludeProvisionerDaemon: true})
 		owner := coderdtest.CreateFirstUser(t, client)
@@ -1470,7 +1470,7 @@ func TestCreateWithPreset(t *testing.T) {
 	// with workspace creation without applying any preset.
 	t.Run("TemplateVersionWithoutPresets", func(t *testing.T) {
 		t.Parallel()
-		ctx := testutil.Context(t, testutil.WaitMedium)
+		ctx := testutil.Context(t, testutil.WaitLong)
 
 		client := coderdtest.New(t, &coderdtest.Options{IncludeProvisionerDaemon: true})
 		owner := coderdtest.CreateFirstUser(t, client)
@@ -1515,7 +1515,7 @@ func TestCreateWithPreset(t *testing.T) {
 	// The workspace should be created without using any preset-defined parameters.
 	t.Run("PresetFlagNone", func(t *testing.T) {
 		t.Parallel()
-		ctx := testutil.Context(t, testutil.WaitMedium)
+		ctx := testutil.Context(t, testutil.WaitLong)
 
 		client := coderdtest.New(t, &coderdtest.Options{IncludeProvisionerDaemon: true})
 		owner := coderdtest.CreateFirstUser(t, client)
@@ -1609,7 +1609,7 @@ func TestCreateWithPreset(t *testing.T) {
 	// - and the value of parameter B from the parameter flag.
 	t.Run("PresetOverridesParameterFlagValues", func(t *testing.T) {
 		t.Parallel()
-		ctx := testutil.Context(t, testutil.WaitMedium)
+		ctx := testutil.Context(t, testutil.WaitLong)
 
 		client := coderdtest.New(t, &coderdtest.Options{IncludeProvisionerDaemon: true})
 		owner := coderdtest.CreateFirstUser(t, client)
@@ -1674,7 +1674,7 @@ func TestCreateWithPreset(t *testing.T) {
 	// - and the value of parameter B from the file.
 	t.Run("PresetOverridesParameterFileValues", func(t *testing.T) {
 		t.Parallel()
-		ctx := testutil.Context(t, testutil.WaitMedium)
+		ctx := testutil.Context(t, testutil.WaitLong)
 
 		client := coderdtest.New(t, &coderdtest.Options{IncludeProvisionerDaemon: true})
 		owner := coderdtest.CreateFirstUser(t, client)
@@ -1739,7 +1739,7 @@ func TestCreateWithPreset(t *testing.T) {
 	// the CLI prompts the user for input to fill in the missing parameters.
 	t.Run("PromptsForMissingParametersWhenPresetIsIncomplete", func(t *testing.T) {
 		t.Parallel()
-		ctx := testutil.Context(t, testutil.WaitMedium)
+		ctx := testutil.Context(t, testutil.WaitLong)
 		logger := testutil.Logger(t)
 		client := coderdtest.New(t, &coderdtest.Options{IncludeProvisionerDaemon: true})
 		owner := coderdtest.CreateFirstUser(t, client)
@@ -1848,7 +1848,7 @@ func TestCreateValidateRichParameters(t *testing.T) {
 	t.Run("ValidateString", func(t *testing.T) {
 		t.Parallel()
 		logger := testutil.Logger(t)
-		ctx := testutil.Context(t, testutil.WaitMedium)
+		ctx := testutil.Context(t, testutil.WaitLong)
 		client := coderdtest.New(t, &coderdtest.Options{IncludeProvisionerDaemon: true})
 		owner := coderdtest.CreateFirstUser(t, client)
 		member, _ := coderdtest.CreateAnotherUser(t, client, owner.OrganizationID)
@@ -1888,7 +1888,7 @@ func TestCreateValidateRichParameters(t *testing.T) {
 	t.Run("ValidateNumber", func(t *testing.T) {
 		t.Parallel()
 		logger := testutil.Logger(t)
-		ctx := testutil.Context(t, testutil.WaitMedium)
+		ctx := testutil.Context(t, testutil.WaitLong)
 
 		client := coderdtest.New(t, &coderdtest.Options{IncludeProvisionerDaemon: true})
 		owner := coderdtest.CreateFirstUser(t, client)
@@ -1929,7 +1929,7 @@ func TestCreateValidateRichParameters(t *testing.T) {
 	t.Run("ValidateNumber_CustomError", func(t *testing.T) {
 		t.Parallel()
 		logger := testutil.Logger(t)
-		ctx := testutil.Context(t, testutil.WaitMedium)
+		ctx := testutil.Context(t, testutil.WaitLong)
 
 		client := coderdtest.New(t, &coderdtest.Options{IncludeProvisionerDaemon: true})
 		owner := coderdtest.CreateFirstUser(t, client)
@@ -1970,7 +1970,7 @@ func TestCreateValidateRichParameters(t *testing.T) {
 	t.Run("ValidateBool", func(t *testing.T) {
 		t.Parallel()
 		logger := testutil.Logger(t)
-		ctx := testutil.Context(t, testutil.WaitMedium)
+		ctx := testutil.Context(t, testutil.WaitLong)
 
 		client := coderdtest.New(t, &coderdtest.Options{IncludeProvisionerDaemon: true})
 		owner := coderdtest.CreateFirstUser(t, client)
@@ -2020,7 +2020,7 @@ func TestCreateValidateRichParameters(t *testing.T) {
 
 		t.Run("Prompt", func(t *testing.T) {
 			logger := testutil.Logger(t)
-			ctx := testutil.Context(t, testutil.WaitMedium)
+			ctx := testutil.Context(t, testutil.WaitLong)
 			inv, root := clitest.New(t, "create", "my-workspace-1", "--template", template.Name)
 			clitest.SetupConfig(t, member, root)
 			stdout := expecter.NewAttachedToInvocation(t, inv)
@@ -2054,7 +2054,7 @@ func TestCreateValidateRichParameters(t *testing.T) {
 	t.Run("ValidateListOfStrings_YAMLFile", func(t *testing.T) {
 		t.Parallel()
 		logger := testutil.Logger(t)
-		ctx := testutil.Context(t, testutil.WaitMedium)
+		ctx := testutil.Context(t, testutil.WaitLong)
 
 		client := coderdtest.New(t, &coderdtest.Options{IncludeProvisionerDaemon: true})
 		owner := coderdtest.CreateFirstUser(t, client)


### PR DESCRIPTION
The interactive `create` CLI tests share a single `testutil.WaitMedium` (15s) context across template setup and the CLI output assertions. Under CI runner contention the echo-provisioner dry-run can stall for 15-19s between logging `unpacking source archive` and reading the first tar entry, which exhausts the assertion budget and fails matches such as `Confirm create?` even when the expected output was already produced.

The failure timestamps show setup consumes only ~1s of the budget; the dry-run stall is what overruns the remaining window. Bumping the assertion context to `WaitLong` (25s) gives these full server + template + dry-run workflows enough headroom to absorb the observed stalls. Applied consistently to the three test functions named in the flake reports (`TestCreateWithRichParameters`, `TestCreateWithPreset`, `TestCreateValidateRichParameters`).

Refs: DEVEX-833

<details>
<summary>Diagnosis notes</summary>

Verified against source:

- `testutil.WaitMedium = 15 * time.Second` and `testutil.Context` is a flat `context.WithTimeout` with no race-mode multiplier, so the 15s budget applies in every mode (including `test-go-race-pg`).
- Each affected subtest creates `ctx := testutil.Context(t, testutil.WaitMedium)` before `coderdtest.New` / template creation and reuses the same `ctx` for `stdout.ExpectMatch(ctx, ...)`.
- The cited stall lives in `provisionersdk/tfpath/tfpath.go`: `unpacking source archive` (Info) to the first `read archive entry` (Debug) spans only a `MkdirAll` plus `tar.NewReader`/`reader.Next()` on an in-memory ~7 KiB buffer. A 15-19s gap there is CPU starvation of the goroutine, not an extraction defect, so the fix targets the test timeout rather than that code path.
- Both reported occurrences show setup consuming ~1s before the stall, so a longer assertion timeout (rather than reordering the context after setup) is the targeted, low-risk fix.

Classification: flaky test under transient runner scheduling contention, not a product regression. The triggering commits do not touch `cli/create_test.go`, the echo provisioner, or the timeout infrastructure, and every other matrix leg passed.

</details>

---
This PR was generated by Coder Agents on behalf of @aqandrew.
