### PR TITLE
refactor(site/src/pages/AgentsPage): extract chat send pipeline from AgentChatPage

### DIFF
--- a/site/src/pages/AgentsPage/AgentChatPage.tsx
+++ b/site/src/pages/AgentsPage/AgentChatPage.tsx
@@ -13,13 +13,8 @@ import {
 import { useOutletContext, useParams } from "react-router";
 import { toast } from "sonner";
 import type { UrlTransform } from "streamdown";
-import type {
-	ChatPlanModeOrClear,
-	CreateChatMessageRequestWithClearablePlanMode,
-} from "#/api/api";
 import { getErrorMessage, getErrorStatus, isApiError } from "#/api/errors";
 import { chatProviderConfigs } from "#/api/queries/aiProviders";
-import { buildOptimisticEditedMessage } from "#/api/queries/chatMessageEdits";
 import {
 	chatMessagesForInfiniteScroll,
 	chatModels,
@@ -69,20 +64,13 @@ import {
 	isChatHookDispatchFailedResponse,
 } from "./components/ChatConversation/chatError";
 import { getWorkspaceAgent } from "./components/ChatConversation/chatHelpers";
-import {
-	buildInactiveChatQueueReconciliation,
-	reconcilePromotedQueueHead,
-	restoreOptimisticRequestSnapshot,
-	runPromoteQueuedMessage,
-	settlePromotedQueueHead,
-	submitEdit,
-	waitForPendingChatSettingsSyncs,
-} from "./components/ChatConversation/chatQueueReconciliation";
+import { runPromoteQueuedMessage } from "./components/ChatConversation/chatQueueReconciliation";
 import {
 	selectChatStatus,
 	useChatSelector,
 	useChatStore,
 } from "./components/ChatConversation/chatStore";
+import { submitChatTurn } from "./components/ChatConversation/submitChatTurn";
 import { useChatToolInvalidations } from "./components/ChatConversation/useChatToolInvalidations";
 import { useWorkspaceWatch } from "./components/ChatConversation/useWorkspaceWatch";
 import { isChatAgentBindingUnresolved } from "./components/ChatConversation/watchedWorkspace";
@@ -95,10 +83,7 @@ import {
 } from "./components/MCPServerPicker";
 import { getModelSelectorHelp } from "./components/ModelSelectorHelp";
 import { useAgentChatPanelPreference } from "./components/RightPanel/useAgentChatPanelPreference";
-import {
-	BuiltInCommandPendingError,
-	useConversationEditingState,
-} from "./hooks/useConversationEditingState";
+import { useConversationEditingState } from "./hooks/useConversationEditingState";
 import { useGitWatcher } from "./hooks/useGitWatcher";
 import {
 	draftInputStorageKeyPrefix,
@@ -115,33 +100,8 @@ import {
 	resolveModelSelector,
 } from "./utils/modelOptions";
 import { pickReasoningEffort } from "./utils/reasoningEffort";
-import {
-	CHAT_SLASH_COMMANDS,
-	CLEAR_SLASH_COMMAND,
-	COMPACT_SLASH_COMMAND,
-	chatSlashCommandTriggerText,
-	resolveChatSlashCommandAvailability,
-} from "./utils/slashCommands";
-
-const lastModelConfigIDStorageKey = "agents.last-model-config-id";
 
 const AGENT_BINDING_REPAIR_POLL_MS = 30_000;
-
-const clearChatPlanMode = "" satisfies ChatPlanModeOrClear;
-
-type PlanModeSwitch = TypesGen.ChatPlanMode | "clear";
-
-const buildAttachmentMediaTypes = (
-	attachments?: readonly PendingAttachment[],
-): ReadonlyMap<string, string> | undefined => {
-	if (!attachments?.length) {
-		return undefined;
-	}
-
-	return new Map(
-		attachments.map(({ fileId, mediaType }) => [fileId, mediaType]),
-	);
-};
 
 const AgentChatPage: FC = () => {
 	const { agentId } = useParams() as { agentId: string };
@@ -423,7 +383,6 @@ const AgentChatPage: FC = () => {
 		store,
 		isHydratingMessages,
 		acceptServerChatStatus,
-		clearStreamError,
 		setCacheQueuedMessages,
 		getCacheQueuedMessages,
 		upsertCacheMessages,
@@ -692,325 +651,41 @@ const AgentChatPage: FC = () => {
 		return rewriteLocalhostURL(url, proxyHost, agentName, wsName, wsOwner);
 	};
 
-	function buildChatInputContent({
-		message,
-		attachments,
-		useComposerContent = true,
-	}: {
-		message: string;
-		attachments?: readonly PendingAttachment[];
-		useComposerContent?: boolean;
-	}): { content: TypesGen.ChatInputPart[]; hasContent: boolean } {
-		const content: TypesGen.ChatInputPart[] = [];
-
-		if (useComposerContent) {
-			const chatInputHandle = (
-				editing.chatInputRef as React.RefObject<ChatMessageInputRef | null>
-			)?.current;
-			const editorParts = chatInputHandle?.getContentParts() ?? [];
-
-			// Walk the Lexical tree in document order so file-reference
-			// parts appear at the correct position relative to the
-			// surrounding text the user typed.
-			for (const part of editorParts) {
-				if (part.type === "text") {
-					if (part.text.trim()) {
-						content.push({ type: "text", text: part.text });
-					}
-				} else {
-					const reference = part.reference;
-					content.push({
-						type: "file-reference",
-						file_name: reference.fileName,
-						start_line: reference.startLine,
-						end_line: reference.endLine,
-						content: reference.content,
-					});
-				}
-			}
-
-			if (content.length === 0 && message.trim()) {
-				content.push({ type: "text", text: message });
-			}
-		} else if (message.trim()) {
-			content.push({ type: "text", text: message });
-		}
-
-		if (attachments && attachments.length > 0) {
-			for (const { fileId } of attachments) {
-				content.push({ type: "file", file_id: fileId });
-			}
-		}
-
-		return { content, hasContent: content.length > 0 };
-	}
-
-	async function submitChatTurn({
-		message,
-		attachments,
-		editedMessageID,
-		useComposerContent = true,
-		planModeSwitch,
-	}: {
-		message: string;
-		attachments?: readonly PendingAttachment[];
-		editedMessageID?: number;
-		useComposerContent?: boolean;
-		planModeSwitch?: PlanModeSwitch;
-	}) {
-		const { content, hasContent } = buildChatInputContent({
-			message,
-			attachments,
-			useComposerContent,
-		});
-		if (!hasContent || isSubmissionPending || !hasModelOptions) {
-			return;
-		}
-		// Wait for chat-setting mutations to settle before sending so the
-		// message observes the workspace and plan-mode choices the user just made.
-		await waitForPendingChatSettingsSyncs([
-			pendingPlanModeSyncRef.current,
-			pendingWorkspaceSyncRef.current,
-		]);
-
-		// Built-ins only intercept new, text-only sends. A personal or workspace
-		// skill with the same name takes precedence.
-		const builtInCommand =
-			editedMessageID === undefined &&
-			content.length === 1 &&
-			content[0].type === "text"
-				? CHAT_SLASH_COMMANDS.find(
-						(command) =>
-							content[0].text?.trim() === chatSlashCommandTriggerText(command),
-					)
-				: undefined;
-		const builtInCommandResolution = builtInCommand
-			? resolveChatSlashCommandAvailability(
-					builtInCommand,
-					personalSkillsQuery.isSuccess ? personalSkillsQuery.data : undefined,
-					chatWorkspaceSkills,
-				)
-			: undefined;
-		if (builtInCommandResolution === "pending" && builtInCommand) {
-			const triggerText = chatSlashCommandTriggerText(builtInCommand);
-			toast.info(
-				`Checking whether ${triggerText} is available. Try again in a moment.`,
-			);
-			throw new BuiltInCommandPendingError();
-		}
-		if (builtInCommandResolution === "available" && builtInCommand) {
-			switch (builtInCommand.name) {
-				case COMPACT_SLASH_COMMAND.name: {
-					// Set running before awaiting so the worker's streamed waiting status cannot
-					// be overwritten if it arrives before the POST resolves.
-					const previousSnapshot = store.getSnapshot();
-					clearChatErrorReason(agentId);
-					clearStreamError();
-					store.clearStreamState();
-					store.setChatStatus("running");
-					try {
-						await compact();
-					} catch (error) {
-						restoreOptimisticRequestSnapshot(store, previousSnapshot);
-						toast.error(getErrorMessage(error, "Failed to compact chat."));
-						throw error;
-					}
-					return;
-				}
-				case CLEAR_SLASH_COMMAND.name:
-					try {
-						await clearChatContext();
-					} catch (error) {
-						toast.error(getErrorMessage(error, "Failed to clear chat."));
-						throw error;
-					}
-					return;
-			}
-		}
-
-		if (editedMessageID !== undefined) {
-			const originalEditedMessage = chatMessagesList?.find(
-				(existingMessage) => existingMessage.id === editedMessageID,
-			);
-			const originalModelConfigID = originalEditedMessage?.model_config_id;
-			const pickerModelConfigID = effectiveSelectedModel || undefined;
-			const originalIsSelectable =
-				originalModelConfigID !== undefined &&
-				modelOptions.some((option) => option.id === originalModelConfigID);
-			const originalIsUnavailable = isUnavailableHistoricalModelID(
-				originalModelConfigID,
-				modelOptions,
-			);
-			// Use the picker fallback for an unavailable historical model.
-			// Override a selectable model only after the user changes it.
-			// Omit blank and nil references so the backend preserves the original.
-			const editSelectedModelConfigID =
-				pickerModelConfigID &&
-				(originalIsUnavailable ||
-					(originalIsSelectable &&
-						pickerModelConfigID !== originalModelConfigID))
-					? pickerModelConfigID
-					: undefined;
-			// Omit so the backend preserves the original effort.
-			const request: TypesGen.EditChatMessageRequest = {
-				content,
-				model_config_id: editSelectedModelConfigID,
-				reasoning_effort: isEditReasoningEffortDirtyRef.current
-					? effectiveReasoningEffort
-					: undefined,
-				mcp_server_ids: [...effectiveMCPServerIds],
-			};
-			const optimisticMessage = originalEditedMessage
-				? buildOptimisticEditedMessage({
-						requestContent: request.content,
-						originalMessage: originalEditedMessage,
-						attachmentMediaTypes: buildAttachmentMediaTypes(attachments),
-					})
-				: undefined;
-			const previousSnapshot = store.getSnapshot();
-			clearChatErrorReason(agentId);
-			clearStreamError();
-			store.batch(() => {
-				store.setQueuedMessages([]);
-				store.setChatStatus("running");
-				store.clearStreamState();
-			});
-			await submitEdit({
-				editMessage,
-				editArgs: {
-					messageId: editedMessageID,
-					optimisticMessage,
-					req: request,
-				},
-				onError: (error) => {
-					restoreOptimisticRequestSnapshot(store, previousSnapshot);
-					handleRequestError(error);
-					// Hook dispatch failures can park an idle chat in error before returning the request error.
-					acceptServerChatStatus();
-					void invalidateChatEntity(queryClient, agentId);
-				},
-			});
-			scrollToEnd({ behavior: "smooth" });
-			if (editSelectedModelConfigID) {
-				localStorage.setItem(
-					lastModelConfigIDStorageKey,
-					editSelectedModelConfigID,
-				);
-			}
-			return;
-		}
-
-		const selectedModelConfigID = effectiveSelectedModel || undefined;
-		const request: CreateChatMessageRequestWithClearablePlanMode = {
-			content,
-			model_config_id: selectedModelConfigID,
-			reasoning_effort: effectiveReasoningEffort,
-			mcp_server_ids: [...effectiveMCPServerIds],
-			...(planModeSwitch !== undefined
-				? {
-						plan_mode:
-							planModeSwitch === "clear" ? clearChatPlanMode : planModeSwitch,
-					}
-				: {}),
-		};
-		clearChatErrorReason(agentId);
-		clearStreamError();
-
-		// An errored-chat send may promote the queue head that existed when the request began.
-		const queuedMessagesBeforeSend = store.getSnapshot().queuedMessages;
-		const queueHeadIDBeforeSend = queuedMessagesBeforeSend[0]?.id;
-		const statusVersionBeforeSend = store.getServerChatStatusVersion();
-
-		// Don't clear stream state before the POST completes.
-		// For queued sends the WebSocket status events handle
-		// clearing; for non-queued sends we clear explicitly
-		// below. Clearing eagerly causes a visible cutoff.
-		let response: Awaited<ReturnType<typeof sendMessage>>;
-		try {
-			response = await sendMessage(request);
-		} catch (error) {
-			handleRequestError(error);
-			// Hook dispatch failures can park an idle chat in error before returning the request error.
-			acceptServerChatStatus();
-			void invalidateChatEntity(queryClient, agentId);
-			throw error;
-		}
-		const isActiveChat = store.getActiveChatID() === agentId;
-		// Waiting for the WebSocket on non-queued sends leaves stale stream state visible.
-		if (!response.queued && isActiveChat) {
-			store.clearStreamState();
-			// Optimistically set status to "running" so the
-			// Thinking indicator appears immediately.
-			// The server accepted the message (not queued),
-			// so it will start processing. The WebSocket
-			// status:running event no-ops via the
-			// setChatStatus guard. If the server transitions
-			// to error/pending instead, the WebSocket event
-			// overrides this optimistic value.
-			store.setChatStatus("running");
-		}
-		// Upsert the full batch because a queued send can insert a promoted head below
-		// the highest cached ID, which a reconnect would skip.
-		const insertedMessages =
-			response.messages ?? (response.message ? [response.message] : []);
-		if (insertedMessages.length > 0) {
-			upsertCacheMessages(insertedMessages);
-			if (isActiveChat) {
-				store.upsertDurableMessages(insertedMessages);
-			}
-			if (response.queued) {
-				const reconciledQueue = isActiveChat
-					? reconcilePromotedQueueHead(
-							store,
-							insertedMessages,
-							queueHeadIDBeforeSend,
-							response.queued_message,
-						)
-					: buildInactiveChatQueueReconciliation(
-							getCacheQueuedMessages(),
-							queuedMessagesBeforeSend,
-							insertedMessages,
-							queueHeadIDBeforeSend,
-							response.queued_message,
-						);
-				if (reconciledQueue) {
-					setCacheQueuedMessages(reconciledQueue);
-					// A promoted head starts a turn, but any server status received during the
-					// request is newer and must win.
-					if (
-						isActiveChat &&
-						store.getServerChatStatusVersion() === statusVersionBeforeSend
-					) {
-						store.clearStreamState();
-						store.setChatStatus("running");
-					}
-					if (isActiveChat && queueHeadIDBeforeSend !== undefined) {
-						void settlePromotedQueueHead(
-							store,
-							agentId,
-							queueHeadIDBeforeSend,
-							(chatID) => queryClient.fetchQuery(chatQueueConvergence(chatID)),
-						).then((settled) => {
-							if (settled) {
-								setCacheQueuedMessages(settled);
-							}
-						});
-					}
-				}
-			}
-		}
-		if (selectedModelConfigID) {
-			localStorage.setItem(lastModelConfigIDStorageKey, selectedModelConfigID);
-		} else {
-			localStorage.removeItem(lastModelConfigIDStorageKey);
-		}
-		if (planModeSwitch !== undefined) {
-			setCachedChatPlanMode(
-				agentId,
-				planModeSwitch === "clear" ? undefined : planModeSwitch,
-			);
-		}
-	}
+	const chatTurnDeps = {
+		isSubmissionPending,
+		hasModelOptions,
+		pendingPlanModeSyncRef,
+		pendingWorkspaceSyncRef,
+		isEditReasoningEffortDirtyRef,
+		personalSkills: personalSkillsQuery.isSuccess
+			? personalSkillsQuery.data
+			: undefined,
+		workspaceSkills: chatWorkspaceSkills,
+		compact,
+		clearChatContext,
+		store,
+		agentId,
+		clearChatErrorReason,
+		acceptServerChatStatus,
+		chatMessages: chatMessagesList,
+		effectiveSelectedModel,
+		modelOptions,
+		effectiveReasoningEffort,
+		mcpServerIds: effectiveMCPServerIds,
+		editMessage,
+		sendMessage,
+		onRequestError: handleRequestError,
+		invalidateChat: (chatId: string) => {
+			void invalidateChatEntity(queryClient, chatId);
+		},
+		scrollToEnd,
+		upsertCacheMessages,
+		getCacheQueuedMessages,
+		setCacheQueuedMessages,
+		fetchQueueConvergence: (chatId: string) =>
+			queryClient.fetchQuery(chatQueueConvergence(chatId)),
+		setCachedChatPlanMode,
+	};
 
 	async function handleSend(
 		message: string,
@@ -1018,24 +693,26 @@ const AgentChatPage: FC = () => {
 		editedMessageID?: number,
 	) {
 		await submitChatTurn({
+			...chatTurnDeps,
 			message,
 			attachments,
 			editedMessageID,
+			composerParts: editing.chatInputRef.current?.getContentParts() ?? [],
 		});
 	}
 
 	const handleSendAskUserQuestionResponse = async (message: string) => {
 		await submitChatTurn({
+			...chatTurnDeps,
 			message,
-			useComposerContent: false,
 		});
 	};
 
 	const handleImplementPlan = async () => {
 		await submitChatTurn({
+			...chatTurnDeps,
 			message: "Implement the plan.",
 			planModeSwitch: "clear",
-			useComposerContent: false,
 		});
 	};
 

--- a/site/src/pages/AgentsPage/components/ChatConversation/submitChatTurn.test.ts
+++ b/site/src/pages/AgentsPage/components/ChatConversation/submitChatTurn.test.ts
@@ -1,0 +1,382 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("sonner", () => ({
+	toast: {
+		info: vi.fn(),
+		error: vi.fn(),
+	},
+}));
+
+import { toast } from "sonner";
+import type { ModelSelectorOption } from "#/modules/aiModels/ModelSelector";
+import {
+	MockChatMessage,
+	MockChatQueuedMessage,
+} from "#/testHelpers/chatEntities";
+import { createDeferred } from "#/testHelpers/deferred";
+import { BuiltInCommandPendingError } from "../../hooks/useConversationEditingState";
+import { NIL_UUID } from "../../utils/modelOptions";
+import { createChatStore } from "./chatStore";
+import {
+	lastModelConfigIDStorageKey,
+	resolveEditModelConfigID,
+	type SubmitChatTurnParams,
+	submitChatTurn,
+} from "./submitChatTurn";
+
+const buildOption = (id: string): ModelSelectorOption => ({
+	id,
+	provider: "openai",
+	model: id,
+	displayName: id,
+});
+
+const pickerModel = buildOption("picker-model");
+const originalModel = buildOption("original-model");
+
+const buildParams = (
+	overrides: Partial<SubmitChatTurnParams> = {},
+): SubmitChatTurnParams => {
+	const store = overrides.store ?? createChatStore();
+	if (!overrides.store) {
+		store.setActiveChatID("chat-1");
+	}
+	return {
+		message: "hello",
+		isSubmissionPending: false,
+		hasModelOptions: true,
+		pendingPlanModeSyncRef: { current: null },
+		pendingWorkspaceSyncRef: { current: null },
+		isEditReasoningEffortDirtyRef: { current: false },
+		personalSkills: [],
+		workspaceSkills: [],
+		compact: vi.fn().mockResolvedValue(undefined),
+		clearChatContext: vi.fn().mockResolvedValue(undefined),
+		store,
+		agentId: "chat-1",
+		clearChatErrorReason: vi.fn(),
+		acceptServerChatStatus: vi.fn(),
+		chatMessages: undefined,
+		effectiveSelectedModel: pickerModel.id,
+		modelOptions: [pickerModel],
+		effectiveReasoningEffort: undefined,
+		mcpServerIds: ["mcp-1"],
+		editMessage: vi.fn().mockResolvedValue(undefined),
+		sendMessage: vi.fn().mockResolvedValue({ queued: false }),
+		onRequestError: vi.fn(),
+		invalidateChat: vi.fn(),
+		scrollToEnd: vi.fn(),
+		upsertCacheMessages: vi.fn(),
+		getCacheQueuedMessages: vi.fn(),
+		setCacheQueuedMessages: vi.fn(),
+		fetchQueueConvergence: vi.fn().mockResolvedValue({
+			messages: [],
+			queued_messages: [],
+			has_more: false,
+		}),
+		setCachedChatPlanMode: vi.fn(),
+		...overrides,
+	};
+};
+
+describe("resolveEditModelConfigID", () => {
+	it("uses the picker when the original model is no longer available", () => {
+		expect(
+			resolveEditModelConfigID({
+				pickerModelConfigID: pickerModel.id,
+				originalModelConfigID: "stale-model",
+				modelOptions: [pickerModel],
+			}),
+		).toBe(pickerModel.id);
+	});
+
+	it("uses the picker when the user changed a still-selectable model", () => {
+		expect(
+			resolveEditModelConfigID({
+				pickerModelConfigID: pickerModel.id,
+				originalModelConfigID: originalModel.id,
+				modelOptions: [pickerModel, originalModel],
+			}),
+		).toBe(pickerModel.id);
+	});
+
+	it("omits the model so the backend keeps a selectable original", () => {
+		expect(
+			resolveEditModelConfigID({
+				pickerModelConfigID: originalModel.id,
+				originalModelConfigID: originalModel.id,
+				modelOptions: [originalModel],
+			}),
+		).toBeUndefined();
+	});
+
+	it("omits blank and unset picker or original references", () => {
+		expect(
+			resolveEditModelConfigID({
+				pickerModelConfigID: undefined,
+				originalModelConfigID: originalModel.id,
+				modelOptions: [originalModel],
+			}),
+		).toBeUndefined();
+		expect(
+			resolveEditModelConfigID({
+				pickerModelConfigID: pickerModel.id,
+				originalModelConfigID: undefined,
+				modelOptions: [pickerModel],
+			}),
+		).toBeUndefined();
+		expect(
+			resolveEditModelConfigID({
+				pickerModelConfigID: pickerModel.id,
+				originalModelConfigID: NIL_UUID,
+				modelOptions: [pickerModel],
+			}),
+		).toBeUndefined();
+	});
+});
+
+describe("submitChatTurn", () => {
+	beforeEach(() => {
+		localStorage.clear();
+		vi.clearAllMocks();
+	});
+
+	it("returns without sending when content, models, or a pending submit block it", async () => {
+		const sendMessage = vi.fn();
+		await submitChatTurn(buildParams({ message: "   ", sendMessage }));
+		await submitChatTurn(buildParams({ hasModelOptions: false, sendMessage }));
+		await submitChatTurn(
+			buildParams({ isSubmissionPending: true, sendMessage }),
+		);
+		expect(sendMessage).not.toHaveBeenCalled();
+	});
+
+	it("waits for pending chat-setting syncs before sending", async () => {
+		const planModeUpdate = createDeferred<void>();
+		const sendMessage = vi.fn().mockResolvedValue({ queued: false });
+		const turn = submitChatTurn(
+			buildParams({
+				pendingPlanModeSyncRef: { current: planModeUpdate.promise },
+				sendMessage,
+			}),
+		);
+		await Promise.resolve();
+		expect(sendMessage).not.toHaveBeenCalled();
+		planModeUpdate.resolve(undefined);
+		await turn;
+		expect(sendMessage).toHaveBeenCalledTimes(1);
+	});
+
+	it("throws BuiltInCommandPendingError while slash-command skills are unresolved", async () => {
+		const compact = vi.fn();
+		const sendMessage = vi.fn();
+		await expect(
+			submitChatTurn(
+				buildParams({
+					message: "/compact",
+					personalSkills: undefined,
+					workspaceSkills: [],
+					compact,
+					sendMessage,
+				}),
+			),
+		).rejects.toBeInstanceOf(BuiltInCommandPendingError);
+		expect(toast.info).toHaveBeenCalledWith(
+			"Checking whether /compact is available. Try again in a moment.",
+		);
+		expect(compact).not.toHaveBeenCalled();
+		expect(sendMessage).not.toHaveBeenCalled();
+	});
+
+	it("compacts instead of sending and restores state if compact fails", async () => {
+		const store = createChatStore();
+		store.setActiveChatID("chat-1");
+		store.setChatStatus("waiting");
+		const compact = vi.fn().mockRejectedValue(new Error("compact failed"));
+		const sendMessage = vi.fn();
+
+		await expect(
+			submitChatTurn(
+				buildParams({
+					message: "/compact",
+					store,
+					compact,
+					sendMessage,
+				}),
+			),
+		).rejects.toThrow("compact failed");
+
+		expect(compact).toHaveBeenCalledTimes(1);
+		expect(sendMessage).not.toHaveBeenCalled();
+		expect(store.getSnapshot().chatStatus).toBe("waiting");
+		expect(toast.error).toHaveBeenCalled();
+	});
+
+	it("edits with a recovered model and scrolls to the end", async () => {
+		const originalMessage = {
+			...MockChatMessage,
+			id: 5,
+			model_config_id: "stale-model",
+			content: [{ type: "text" as const, text: "old" }],
+		};
+		const editMessage = vi.fn().mockResolvedValue(undefined);
+		const scrollToEnd = vi.fn();
+		const sendMessage = vi.fn();
+
+		await submitChatTurn(
+			buildParams({
+				message: "new text",
+				editedMessageID: 5,
+				chatMessages: [originalMessage],
+				editMessage,
+				scrollToEnd,
+				sendMessage,
+			}),
+		);
+
+		expect(editMessage).toHaveBeenCalledWith({
+			messageId: 5,
+			optimisticMessage: expect.objectContaining({
+				id: 5,
+				content: [{ type: "text", text: "new text" }],
+			}),
+			req: expect.objectContaining({
+				model_config_id: pickerModel.id,
+				mcp_server_ids: ["mcp-1"],
+			}),
+		});
+		expect(scrollToEnd).toHaveBeenCalledWith({ behavior: "smooth" });
+		expect(sendMessage).not.toHaveBeenCalled();
+		expect(localStorage.getItem(lastModelConfigIDStorageKey)).toBe(
+			pickerModel.id,
+		);
+	});
+
+	it("omits reasoning effort on edit until the picker is dirty", async () => {
+		const originalMessage = {
+			...MockChatMessage,
+			id: 5,
+			model_config_id: pickerModel.id,
+		};
+		const editMessage = vi.fn().mockResolvedValue(undefined);
+		await submitChatTurn(
+			buildParams({
+				message: "new text",
+				editedMessageID: 5,
+				chatMessages: [originalMessage],
+				effectiveReasoningEffort: "high",
+				isEditReasoningEffortDirtyRef: { current: false },
+				editMessage,
+			}),
+		);
+		expect(editMessage).toHaveBeenCalledWith(
+			expect.objectContaining({
+				req: expect.objectContaining({
+					reasoning_effort: undefined,
+					model_config_id: undefined,
+				}),
+			}),
+		);
+	});
+
+	it("reports send failures and invalidates the chat", async () => {
+		const error = new Error("send failed");
+		const sendMessage = vi.fn().mockRejectedValue(error);
+		const onRequestError = vi.fn();
+		const acceptServerChatStatus = vi.fn();
+		const invalidateChat = vi.fn();
+
+		await expect(
+			submitChatTurn(
+				buildParams({
+					sendMessage,
+					onRequestError,
+					acceptServerChatStatus,
+					invalidateChat,
+				}),
+			),
+		).rejects.toThrow("send failed");
+
+		expect(onRequestError).toHaveBeenCalledWith(error);
+		expect(acceptServerChatStatus).toHaveBeenCalledTimes(1);
+		expect(invalidateChat).toHaveBeenCalledWith("chat-1");
+	});
+
+	it("upserts a non-queued send, persists the model, and sets running", async () => {
+		const store = createChatStore();
+		store.setActiveChatID("chat-1");
+		const inserted = { ...MockChatMessage, id: 9 };
+		const sendMessage = vi.fn().mockResolvedValue({
+			queued: false,
+			message: inserted,
+		});
+		const upsertCacheMessages = vi.fn();
+
+		await submitChatTurn(
+			buildParams({
+				store,
+				sendMessage,
+				upsertCacheMessages,
+			}),
+		);
+
+		expect(sendMessage).toHaveBeenCalledWith(
+			expect.objectContaining({
+				model_config_id: pickerModel.id,
+				mcp_server_ids: ["mcp-1"],
+			}),
+		);
+		expect(upsertCacheMessages).toHaveBeenCalledWith([inserted]);
+		expect(store.getSnapshot().chatStatus).toBe("running");
+		expect(localStorage.getItem(lastModelConfigIDStorageKey)).toBe(
+			pickerModel.id,
+		);
+	});
+
+	it("reconciles a queued send and clears plan mode on implement", async () => {
+		const store = createChatStore();
+		store.setActiveChatID("chat-1");
+		const queuedHead = { ...MockChatQueuedMessage, id: 3 };
+		store.setQueuedMessages([queuedHead]);
+		const promotedUser = {
+			...MockChatMessage,
+			id: 10,
+			role: "user" as const,
+		};
+		const sendMessage = vi.fn().mockResolvedValue({
+			queued: true,
+			messages: [promotedUser],
+			queued_message: { ...MockChatQueuedMessage, id: 4 },
+		});
+		const fetchQueueConvergence = vi.fn().mockResolvedValue({
+			messages: [],
+			has_more: false,
+			queued_messages: [],
+		});
+		const setCacheQueuedMessages = vi.fn();
+		const setCachedChatPlanMode = vi.fn();
+
+		await submitChatTurn(
+			buildParams({
+				message: "Implement the plan.",
+				planModeSwitch: "clear",
+				store,
+				sendMessage,
+				setCacheQueuedMessages,
+				setCachedChatPlanMode,
+				fetchQueueConvergence,
+			}),
+		);
+
+		expect(setCacheQueuedMessages).toHaveBeenCalled();
+		expect(setCachedChatPlanMode).toHaveBeenCalledWith("chat-1", undefined);
+		expect(sendMessage).toHaveBeenCalledWith(
+			expect.objectContaining({
+				plan_mode: "",
+			}),
+		);
+		await vi.waitFor(() => {
+			expect(fetchQueueConvergence).toHaveBeenCalledWith("chat-1");
+		});
+	});
+});

--- a/site/src/pages/AgentsPage/components/ChatConversation/submitChatTurn.test.ts
+++ b/site/src/pages/AgentsPage/components/ChatConversation/submitChatTurn.test.ts
@@ -8,6 +8,7 @@ vi.mock("sonner", () => ({
 }));
 
 import { toast } from "sonner";
+import type { ChatMessage } from "#/api/typesGenerated";
 import type { ModelSelectorOption } from "#/modules/aiModels/ModelSelector";
 import {
 	MockChatMessage,
@@ -213,11 +214,11 @@ describe("submitChatTurn", () => {
 	});
 
 	it("edits with a recovered model and scrolls to the end", async () => {
-		const originalMessage = {
+		const originalMessage: ChatMessage = {
 			...MockChatMessage,
 			id: 5,
 			model_config_id: "stale-model",
-			content: [{ type: "text" as const, text: "old" }],
+			content: [{ type: "text", text: "old" }],
 		};
 		const editMessage = vi.fn().mockResolvedValue(undefined);
 		const scrollToEnd = vi.fn();
@@ -338,10 +339,10 @@ describe("submitChatTurn", () => {
 		store.setActiveChatID("chat-1");
 		const queuedHead = { ...MockChatQueuedMessage, id: 3 };
 		store.setQueuedMessages([queuedHead]);
-		const promotedUser = {
+		const promotedUser: ChatMessage = {
 			...MockChatMessage,
 			id: 10,
-			role: "user" as const,
+			role: "user",
 		};
 		const sendMessage = vi.fn().mockResolvedValue({
 			queued: true,

--- a/site/src/pages/AgentsPage/components/ChatConversation/submitChatTurn.ts
+++ b/site/src/pages/AgentsPage/components/ChatConversation/submitChatTurn.ts
@@ -37,7 +37,7 @@ export const lastModelConfigIDStorageKey = "agents.last-model-config-id";
 
 const clearChatPlanMode = "" satisfies ChatPlanModeOrClear;
 
-export type PlanModeSwitch = TypesGen.ChatPlanMode | "clear";
+type PlanModeSwitch = TypesGen.ChatPlanMode | "clear";
 
 export type SubmitChatTurnParams = {
 	message: string;

--- a/site/src/pages/AgentsPage/components/ChatConversation/submitChatTurn.ts
+++ b/site/src/pages/AgentsPage/components/ChatConversation/submitChatTurn.ts
@@ -1,0 +1,475 @@
+import { toast } from "sonner";
+import type {
+	ChatPlanModeOrClear,
+	CreateChatMessageRequestWithClearablePlanMode,
+} from "#/api/api";
+import { getErrorMessage } from "#/api/errors";
+import { buildOptimisticEditedMessage } from "#/api/queries/chatMessageEdits";
+import type * as TypesGen from "#/api/typesGenerated";
+import type { ModelSelectorOption } from "#/modules/aiModels/ModelSelector";
+import { BuiltInCommandPendingError } from "../../hooks/useConversationEditingState";
+import {
+	buildAttachmentMediaTypes,
+	buildChatInputContent,
+	type ChatComposerContentPart,
+} from "../../utils/chatInputContent";
+import { isUnavailableHistoricalModelID } from "../../utils/modelOptions";
+import {
+	CHAT_SLASH_COMMANDS,
+	CLEAR_SLASH_COMMAND,
+	COMPACT_SLASH_COMMAND,
+	chatSlashCommandTriggerText,
+	resolveChatSlashCommandAvailability,
+} from "../../utils/slashCommands";
+import type { PendingAttachment } from "../ChatPageContent";
+import {
+	buildInactiveChatQueueReconciliation,
+	reconcilePromotedQueueHead,
+	restoreOptimisticRequestSnapshot,
+	settlePromotedQueueHead,
+	submitEdit,
+	waitForPendingChatSettingsSyncs,
+} from "./chatQueueReconciliation";
+import type { ChatStore } from "./chatStore";
+
+/** @internal Exported for testing. */
+export const lastModelConfigIDStorageKey = "agents.last-model-config-id";
+
+const clearChatPlanMode = "" satisfies ChatPlanModeOrClear;
+
+export type PlanModeSwitch = TypesGen.ChatPlanMode | "clear";
+
+export type SubmitChatTurnParams = {
+	message: string;
+	attachments?: readonly PendingAttachment[];
+	editedMessageID?: number;
+	composerParts?: readonly ChatComposerContentPart[];
+	planModeSwitch?: PlanModeSwitch;
+	isSubmissionPending: boolean;
+	hasModelOptions: boolean;
+	pendingPlanModeSyncRef: { current: Promise<unknown> | null };
+	pendingWorkspaceSyncRef: { current: Promise<unknown> | null };
+	isEditReasoningEffortDirtyRef: { current: boolean };
+	personalSkills: readonly { name: string }[] | undefined;
+	workspaceSkills: readonly { name: string }[] | undefined;
+	compact: () => Promise<unknown>;
+	clearChatContext: () => Promise<unknown>;
+	store: ChatStore;
+	agentId: string;
+	clearChatErrorReason: (chatId: string) => void;
+	acceptServerChatStatus: () => void;
+	chatMessages: readonly TypesGen.ChatMessage[] | undefined;
+	effectiveSelectedModel: string;
+	modelOptions: readonly ModelSelectorOption[];
+	effectiveReasoningEffort: string | undefined;
+	mcpServerIds: readonly string[];
+	editMessage: (args: {
+		messageId: number;
+		optimisticMessage?: TypesGen.ChatMessage;
+		req: TypesGen.EditChatMessageRequest;
+	}) => Promise<unknown>;
+	sendMessage: (
+		req: CreateChatMessageRequestWithClearablePlanMode,
+	) => Promise<TypesGen.CreateChatMessageResponse>;
+	onRequestError: (error: unknown) => void;
+	invalidateChat: (chatId: string) => void;
+	scrollToEnd: (options: { behavior: "smooth" }) => void;
+	upsertCacheMessages: (messages: readonly TypesGen.ChatMessage[]) => void;
+	getCacheQueuedMessages: () =>
+		| readonly TypesGen.ChatQueuedMessage[]
+		| undefined;
+	setCacheQueuedMessages: (
+		messages: readonly TypesGen.ChatQueuedMessage[],
+	) => void;
+	fetchQueueConvergence: (
+		chatId: string,
+	) => Promise<TypesGen.ChatMessagesResponse>;
+	setCachedChatPlanMode: (
+		chatId: string,
+		planMode?: TypesGen.ChatPlanMode,
+	) => void;
+};
+
+/** @internal Exported for testing. */
+export const resolveEditModelConfigID = ({
+	pickerModelConfigID,
+	originalModelConfigID,
+	modelOptions,
+}: {
+	pickerModelConfigID: string | undefined;
+	originalModelConfigID: string | undefined;
+	modelOptions: readonly ModelSelectorOption[];
+}): string | undefined => {
+	if (!pickerModelConfigID) {
+		return undefined;
+	}
+	const originalIsSelectable =
+		originalModelConfigID !== undefined &&
+		modelOptions.some((option) => option.id === originalModelConfigID);
+	const originalIsUnavailable = isUnavailableHistoricalModelID(
+		originalModelConfigID,
+		modelOptions,
+	);
+	// Use the picker fallback for an unavailable historical model.
+	// Override a selectable model only after the user changes it.
+	// Omit blank and nil references so the backend preserves the original.
+	if (
+		originalIsUnavailable ||
+		(originalIsSelectable && pickerModelConfigID !== originalModelConfigID)
+	) {
+		return pickerModelConfigID;
+	}
+	return undefined;
+};
+
+const persistLastModelConfigID = (modelConfigID: string): void => {
+	localStorage.setItem(lastModelConfigIDStorageKey, modelConfigID);
+};
+
+const findBuiltInChatCommand = (
+	content: readonly TypesGen.ChatInputPart[],
+	editedMessageID: number | undefined,
+): (typeof CHAT_SLASH_COMMANDS)[number] | undefined => {
+	// Built-ins only intercept new, text-only sends. A personal or workspace
+	// skill with the same name takes precedence at availability resolution.
+	if (editedMessageID !== undefined || content.length !== 1) {
+		return undefined;
+	}
+	const [part] = content;
+	if (part.type !== "text") {
+		return undefined;
+	}
+	const trigger = part.text?.trim();
+	return CHAT_SLASH_COMMANDS.find(
+		(command) => trigger === chatSlashCommandTriggerText(command),
+	);
+};
+
+const runBuiltInChatCommand = async ({
+	command,
+	store,
+	agentId,
+	clearChatErrorReason,
+	compact,
+	clearChatContext,
+}: {
+	command: (typeof CHAT_SLASH_COMMANDS)[number];
+	store: ChatStore;
+	agentId: string;
+	clearChatErrorReason: (chatId: string) => void;
+	compact: () => Promise<unknown>;
+	clearChatContext: () => Promise<unknown>;
+}): Promise<void> => {
+	switch (command.name) {
+		case COMPACT_SLASH_COMMAND.name: {
+			// Set running before awaiting so the worker's streamed waiting status
+			// cannot be overwritten if it arrives before the POST resolves.
+			const previousSnapshot = store.getSnapshot();
+			clearChatErrorReason(agentId);
+			store.clearStreamError();
+			store.clearStreamState();
+			store.setChatStatus("running");
+			try {
+				await compact();
+			} catch (error) {
+				restoreOptimisticRequestSnapshot(store, previousSnapshot);
+				toast.error(getErrorMessage(error, "Failed to compact chat."));
+				throw error;
+			}
+			return;
+		}
+		case CLEAR_SLASH_COMMAND.name:
+			try {
+				await clearChatContext();
+			} catch (error) {
+				toast.error(getErrorMessage(error, "Failed to clear chat."));
+				throw error;
+			}
+	}
+};
+
+const applyQueuedSendReconciliation = ({
+	store,
+	agentId,
+	isActiveChat,
+	insertedMessages,
+	queuedMessagesBeforeSend,
+	queueHeadIDBeforeSend,
+	statusVersionBeforeSend,
+	queuedTail,
+	getCacheQueuedMessages,
+	setCacheQueuedMessages,
+	fetchQueueConvergence,
+}: {
+	store: ChatStore;
+	agentId: string;
+	isActiveChat: boolean;
+	insertedMessages: readonly TypesGen.ChatMessage[];
+	queuedMessagesBeforeSend: readonly TypesGen.ChatQueuedMessage[];
+	queueHeadIDBeforeSend: number | undefined;
+	statusVersionBeforeSend: number;
+	queuedTail: TypesGen.ChatQueuedMessage | undefined;
+	getCacheQueuedMessages: SubmitChatTurnParams["getCacheQueuedMessages"];
+	setCacheQueuedMessages: SubmitChatTurnParams["setCacheQueuedMessages"];
+	fetchQueueConvergence: SubmitChatTurnParams["fetchQueueConvergence"];
+}): void => {
+	const reconciledQueue = isActiveChat
+		? reconcilePromotedQueueHead(
+				store,
+				insertedMessages,
+				queueHeadIDBeforeSend,
+				queuedTail,
+			)
+		: buildInactiveChatQueueReconciliation(
+				getCacheQueuedMessages(),
+				queuedMessagesBeforeSend,
+				insertedMessages,
+				queueHeadIDBeforeSend,
+				queuedTail,
+			);
+	if (!reconciledQueue) {
+		return;
+	}
+	setCacheQueuedMessages(reconciledQueue);
+	// A promoted head starts a turn, but any server status received during
+	// the request is newer and must win.
+	if (
+		isActiveChat &&
+		store.getServerChatStatusVersion() === statusVersionBeforeSend
+	) {
+		store.clearStreamState();
+		store.setChatStatus("running");
+	}
+	if (isActiveChat && queueHeadIDBeforeSend !== undefined) {
+		void settlePromotedQueueHead(
+			store,
+			agentId,
+			queueHeadIDBeforeSend,
+			fetchQueueConvergence,
+		).then((settled) => {
+			if (settled) {
+				setCacheQueuedMessages(settled);
+			}
+		});
+	}
+};
+
+export async function submitChatTurn(
+	params: SubmitChatTurnParams,
+): Promise<void> {
+	const {
+		message,
+		attachments,
+		editedMessageID,
+		composerParts,
+		planModeSwitch,
+		isSubmissionPending,
+		hasModelOptions,
+		pendingPlanModeSyncRef,
+		pendingWorkspaceSyncRef,
+		personalSkills,
+		workspaceSkills,
+		compact,
+		clearChatContext,
+		store,
+		agentId,
+		clearChatErrorReason,
+		acceptServerChatStatus,
+		chatMessages,
+		effectiveSelectedModel,
+		modelOptions,
+		effectiveReasoningEffort,
+		isEditReasoningEffortDirtyRef,
+		mcpServerIds,
+		editMessage,
+		sendMessage,
+		onRequestError,
+		invalidateChat,
+		scrollToEnd,
+		upsertCacheMessages,
+		getCacheQueuedMessages,
+		setCacheQueuedMessages,
+		fetchQueueConvergence,
+		setCachedChatPlanMode,
+	} = params;
+
+	const { content, hasContent } = buildChatInputContent({
+		message,
+		attachments,
+		composerParts,
+	});
+	if (!hasContent || isSubmissionPending || !hasModelOptions) {
+		return;
+	}
+	// Wait for chat-setting mutations to settle before sending so the
+	// message observes the workspace and plan-mode choices the user just made.
+	await waitForPendingChatSettingsSyncs([
+		pendingPlanModeSyncRef.current,
+		pendingWorkspaceSyncRef.current,
+	]);
+
+	const builtInCommand = findBuiltInChatCommand(content, editedMessageID);
+	const builtInCommandResolution = builtInCommand
+		? resolveChatSlashCommandAvailability(
+				builtInCommand,
+				personalSkills,
+				workspaceSkills,
+			)
+		: undefined;
+	if (builtInCommandResolution === "pending" && builtInCommand) {
+		const triggerText = chatSlashCommandTriggerText(builtInCommand);
+		toast.info(
+			`Checking whether ${triggerText} is available. Try again in a moment.`,
+		);
+		throw new BuiltInCommandPendingError();
+	}
+	if (builtInCommandResolution === "available" && builtInCommand) {
+		await runBuiltInChatCommand({
+			command: builtInCommand,
+			store,
+			agentId,
+			clearChatErrorReason,
+			compact,
+			clearChatContext,
+		});
+		return;
+	}
+
+	if (editedMessageID !== undefined) {
+		const originalEditedMessage = chatMessages?.find(
+			(existingMessage) => existingMessage.id === editedMessageID,
+		);
+		const editSelectedModelConfigID = resolveEditModelConfigID({
+			pickerModelConfigID: effectiveSelectedModel || undefined,
+			originalModelConfigID: originalEditedMessage?.model_config_id,
+			modelOptions,
+		});
+		const request: TypesGen.EditChatMessageRequest = {
+			content,
+			model_config_id: editSelectedModelConfigID,
+			// Omit so the backend preserves the original effort.
+			reasoning_effort: isEditReasoningEffortDirtyRef.current
+				? effectiveReasoningEffort
+				: undefined,
+			mcp_server_ids: [...mcpServerIds],
+		};
+		const optimisticMessage = originalEditedMessage
+			? buildOptimisticEditedMessage({
+					requestContent: request.content,
+					originalMessage: originalEditedMessage,
+					attachmentMediaTypes: buildAttachmentMediaTypes(attachments),
+				})
+			: undefined;
+		const previousSnapshot = store.getSnapshot();
+		clearChatErrorReason(agentId);
+		store.clearStreamError();
+		store.batch(() => {
+			store.setQueuedMessages([]);
+			store.setChatStatus("running");
+			store.clearStreamState();
+		});
+		await submitEdit({
+			editMessage,
+			editArgs: {
+				messageId: editedMessageID,
+				optimisticMessage,
+				req: request,
+			},
+			onError: (error) => {
+				restoreOptimisticRequestSnapshot(store, previousSnapshot);
+				onRequestError(error);
+				// Hook dispatch failures can park an idle chat in error before
+				// returning the request error.
+				acceptServerChatStatus();
+				invalidateChat(agentId);
+			},
+		});
+		scrollToEnd({ behavior: "smooth" });
+		if (editSelectedModelConfigID) {
+			persistLastModelConfigID(editSelectedModelConfigID);
+		}
+		return;
+	}
+
+	const selectedModelConfigID = effectiveSelectedModel || undefined;
+	const request: CreateChatMessageRequestWithClearablePlanMode = {
+		content,
+		model_config_id: selectedModelConfigID,
+		reasoning_effort: effectiveReasoningEffort,
+		mcp_server_ids: [...mcpServerIds],
+		...(planModeSwitch !== undefined
+			? {
+					plan_mode:
+						planModeSwitch === "clear" ? clearChatPlanMode : planModeSwitch,
+				}
+			: {}),
+	};
+	clearChatErrorReason(agentId);
+	store.clearStreamError();
+
+	// An errored-chat send may promote the queue head that existed when
+	// the request began.
+	const queuedMessagesBeforeSend = store.getSnapshot().queuedMessages;
+	const queueHeadIDBeforeSend = queuedMessagesBeforeSend[0]?.id;
+	const statusVersionBeforeSend = store.getServerChatStatusVersion();
+
+	// Don't clear stream state before the POST completes. For queued sends
+	// the WebSocket status events handle clearing; for non-queued sends we
+	// clear explicitly below. Clearing eagerly causes a visible cutoff.
+	let response: TypesGen.CreateChatMessageResponse;
+	try {
+		response = await sendMessage(request);
+	} catch (error) {
+		onRequestError(error);
+		acceptServerChatStatus();
+		invalidateChat(agentId);
+		throw error;
+	}
+	const isActiveChat = store.getActiveChatID() === agentId;
+	// Waiting for the WebSocket on non-queued sends leaves stale stream
+	// state visible.
+	if (!response.queued && isActiveChat) {
+		store.clearStreamState();
+		// The server accepted the message (not queued), so it will start
+		// processing. The WebSocket status:running event no-ops via the
+		// setChatStatus guard. If the server transitions to error/pending
+		// instead, the WebSocket event overrides this optimistic value.
+		store.setChatStatus("running");
+	}
+	// Upsert the full batch because a queued send can insert a promoted
+	// head below the highest cached ID, which a reconnect would skip.
+	const insertedMessages =
+		response.messages ?? (response.message ? [response.message] : []);
+	if (insertedMessages.length > 0) {
+		upsertCacheMessages(insertedMessages);
+		if (isActiveChat) {
+			store.upsertDurableMessages(insertedMessages);
+		}
+		if (response.queued) {
+			applyQueuedSendReconciliation({
+				store,
+				agentId,
+				isActiveChat,
+				insertedMessages,
+				queuedMessagesBeforeSend,
+				queueHeadIDBeforeSend,
+				statusVersionBeforeSend,
+				queuedTail: response.queued_message,
+				getCacheQueuedMessages,
+				setCacheQueuedMessages,
+				fetchQueueConvergence,
+			});
+		}
+	}
+	if (selectedModelConfigID) {
+		persistLastModelConfigID(selectedModelConfigID);
+	} else {
+		localStorage.removeItem(lastModelConfigIDStorageKey);
+	}
+	if (planModeSwitch !== undefined) {
+		setCachedChatPlanMode(
+			agentId,
+			planModeSwitch === "clear" ? undefined : planModeSwitch,
+		);
+	}
+}

--- a/site/src/pages/AgentsPage/utils/chatInputContent.test.ts
+++ b/site/src/pages/AgentsPage/utils/chatInputContent.test.ts
@@ -1,0 +1,131 @@
+import { describe, expect, it } from "vitest";
+import {
+	buildAttachmentMediaTypes,
+	buildChatInputContent,
+} from "./chatInputContent";
+
+describe("buildAttachmentMediaTypes", () => {
+	it("returns undefined when attachments are missing or empty", () => {
+		expect(buildAttachmentMediaTypes()).toBeUndefined();
+		expect(buildAttachmentMediaTypes([])).toBeUndefined();
+	});
+
+	it("maps file IDs to media types", () => {
+		expect(
+			buildAttachmentMediaTypes([
+				{ fileId: "a", mediaType: "image/png" },
+				{ fileId: "b", mediaType: "text/plain" },
+			]),
+		).toEqual(
+			new Map([
+				["a", "image/png"],
+				["b", "text/plain"],
+			]),
+		);
+	});
+});
+
+describe("buildChatInputContent", () => {
+	it("has no content when message, composer, and attachments are empty", () => {
+		expect(buildChatInputContent({ message: "   " })).toEqual({
+			content: [],
+			hasContent: false,
+		});
+	});
+
+	it("sends trimmed message text when composer parts are omitted", () => {
+		expect(buildChatInputContent({ message: "  hello  " })).toEqual({
+			content: [{ type: "text", text: "  hello  " }],
+			hasContent: true,
+		});
+	});
+
+	it("walks composer parts in document order and skips blank text", () => {
+		expect(
+			buildChatInputContent({
+				message: "fallback",
+				composerParts: [
+					{ type: "text", text: "before" },
+					{ type: "text", text: "   " },
+					{
+						type: "file-reference",
+						reference: {
+							fileName: "a.ts",
+							startLine: 2,
+							endLine: 4,
+							content: "code",
+						},
+					},
+					{ type: "text", text: "after" },
+				],
+			}),
+		).toEqual({
+			content: [
+				{ type: "text", text: "before" },
+				{
+					type: "file-reference",
+					file_name: "a.ts",
+					start_line: 2,
+					end_line: 4,
+					content: "code",
+				},
+				{ type: "text", text: "after" },
+			],
+			hasContent: true,
+		});
+	});
+
+	it("falls back to message text when composer parts yield nothing", () => {
+		expect(
+			buildChatInputContent({
+				message: "typed",
+				composerParts: [{ type: "text", text: "   " }],
+			}),
+		).toEqual({
+			content: [{ type: "text", text: "typed" }],
+			hasContent: true,
+		});
+	});
+
+	it("does not mix composer file references into a message-only send", () => {
+		expect(
+			buildChatInputContent({
+				message: "Implement the plan.",
+			}),
+		).toEqual({
+			content: [{ type: "text", text: "Implement the plan." }],
+			hasContent: true,
+		});
+	});
+
+	it("appends attachment file parts after text", () => {
+		expect(
+			buildChatInputContent({
+				message: "see files",
+				attachments: [
+					{ fileId: "file-1", mediaType: "image/png" },
+					{ fileId: "file-2", mediaType: "text/plain" },
+				],
+			}),
+		).toEqual({
+			content: [
+				{ type: "text", text: "see files" },
+				{ type: "file", file_id: "file-1" },
+				{ type: "file", file_id: "file-2" },
+			],
+			hasContent: true,
+		});
+	});
+
+	it("treats attachments alone as content", () => {
+		expect(
+			buildChatInputContent({
+				message: "  ",
+				attachments: [{ fileId: "file-1", mediaType: "image/png" }],
+			}),
+		).toEqual({
+			content: [{ type: "file", file_id: "file-1" }],
+			hasContent: true,
+		});
+	});
+});

--- a/site/src/pages/AgentsPage/utils/chatInputContent.ts
+++ b/site/src/pages/AgentsPage/utils/chatInputContent.ts
@@ -1,0 +1,75 @@
+import type * as TypesGen from "#/api/typesGenerated";
+import type { PendingAttachment } from "../components/ChatPageContent";
+
+export type ChatComposerContentPart =
+	| { readonly type: "text"; readonly text: string }
+	| {
+			readonly type: "file-reference";
+			readonly reference: {
+				readonly fileName: string;
+				readonly startLine: number;
+				readonly endLine: number;
+				readonly content: string;
+			};
+	  };
+
+export const buildAttachmentMediaTypes = (
+	attachments?: readonly PendingAttachment[],
+): ReadonlyMap<string, string> | undefined => {
+	if (!attachments?.length) {
+		return undefined;
+	}
+
+	return new Map(
+		attachments.map(({ fileId, mediaType }) => [fileId, mediaType]),
+	);
+};
+
+/**
+ * When `composerParts` is provided, file-reference chips stay in document
+ * order. Omit it to send `message` as text only.
+ */
+export const buildChatInputContent = ({
+	message,
+	attachments,
+	composerParts,
+}: {
+	message: string;
+	attachments?: readonly PendingAttachment[];
+	composerParts?: readonly ChatComposerContentPart[];
+}): { content: TypesGen.ChatInputPart[]; hasContent: boolean } => {
+	const content: TypesGen.ChatInputPart[] = [];
+
+	if (composerParts) {
+		for (const part of composerParts) {
+			if (part.type === "text") {
+				if (part.text.trim()) {
+					content.push({ type: "text", text: part.text });
+				}
+			} else {
+				const reference = part.reference;
+				content.push({
+					type: "file-reference",
+					file_name: reference.fileName,
+					start_line: reference.startLine,
+					end_line: reference.endLine,
+					content: reference.content,
+				});
+			}
+		}
+
+		if (content.length === 0 && message.trim()) {
+			content.push({ type: "text", text: message });
+		}
+	} else if (message.trim()) {
+		content.push({ type: "text", text: message });
+	}
+
+	if (attachments && attachments.length > 0) {
+		for (const { fileId } of attachments) {
+			content.push({ type: "file", file_id: fileId });
+		}
+	}
+
+	return { content, hasContent: content.length > 0 };
+};


### PR DESCRIPTION
Move composer content building, slash-command intercept, edit-model override, and send/queue upsert out of AgentChatPage into function modules so the page is easier to navigate.