### PR TITLE
refactor(site/src/pages/AgentsPage): share MCP selection resolution

### DIFF
--- a/site/src/pages/AgentsPage/AgentChatPage.tsx
+++ b/site/src/pages/AgentsPage/AgentChatPage.tsx
@@ -89,8 +89,7 @@ import { isChatAgentBindingUnresolved } from "./components/ChatConversation/watc
 import type { PendingAttachment } from "./components/ChatPageContent";
 import { workspaceSkillsFromChat } from "./components/ChatPageContent";
 import {
-	getDefaultMCPSelection,
-	getSavedMCPSelection,
+	resolveMCPSelection,
 	saveMCPSelection,
 } from "./components/MCPServerPicker";
 import { getModelSelectorHelp } from "./components/ModelSelectorHelp";
@@ -277,29 +276,13 @@ const AgentChatPage: FC = () => {
 		chat !== undefined && currentUser.id !== chat.owner_id;
 	const planModeEnabled = chat?.plan_mode === "plan";
 
-	// Initialize MCP selection from chat record or defaults.
-	const effectiveMCPServerIds = (() => {
-		if (selectedMCPServerIds !== null) {
-			return selectedMCPServerIds;
-		}
-		// If the chat has MCP server IDs recorded (even empty, meaning
-		// the user deliberately opted out), use those.
-		if (chat?.mcp_server_ids) {
-			return chat.mcp_server_ids;
-		}
-		const saved = chatOrganizationId
-			? getSavedMCPSelection(
-					chatOrganizationId,
-					mcpServers,
-					isDefaultChatOrganization,
-				)
-			: null;
-		if (saved !== null) {
-			return saved;
-		}
-		// Otherwise, compute defaults from server availability.
-		return getDefaultMCPSelection(mcpServers);
-	})();
+	const effectiveMCPServerIds = resolveMCPSelection({
+		userSelection: selectedMCPServerIds,
+		chatSelection: chat?.mcp_server_ids,
+		organizationId: chatOrganizationId,
+		servers: mcpServers,
+		isDefaultOrganization: isDefaultChatOrganization,
+	});
 
 	// Flatten paginated messages into chronological order.
 	// Pages arrive newest-first per page, and pages[0] is the

--- a/site/src/pages/AgentsPage/components/AgentCreateForm.tsx
+++ b/site/src/pages/AgentsPage/components/AgentCreateForm.tsx
@@ -38,11 +38,7 @@ import {
 } from "./ChatConversation/chatError";
 import { getErrorTitle } from "./ChatConversation/chatStatusHelpers";
 import { CompactOrgSelector } from "./ChatElements/CompactOrgSelector";
-import {
-	getDefaultMCPSelection,
-	getSavedMCPSelection,
-	saveMCPSelection,
-} from "./MCPServerPicker";
+import { resolveMCPSelection, saveMCPSelection } from "./MCPServerPicker";
 import { getModelSelectorHelp } from "./ModelSelectorHelp";
 
 /** @internal Exported for testing. */
@@ -423,20 +419,12 @@ export const AgentCreateForm: FC<AgentCreateFormProps> = ({
 		modelsQuery.data,
 	);
 
-	const effectiveMCPServerIds = (() => {
-		if (userMCPServerIds !== null) {
-			return userMCPServerIds;
-		}
-		const saved = getSavedMCPSelection(
-			organizationId,
-			mcpServers,
-			effectiveOrg?.is_default,
-		);
-		if (saved !== null) {
-			return saved;
-		}
-		return getDefaultMCPSelection(mcpServers);
-	})();
+	const effectiveMCPServerIds = resolveMCPSelection({
+		userSelection: userMCPServerIds,
+		organizationId,
+		servers: mcpServers,
+		isDefaultOrganization: effectiveOrg?.is_default,
+	});
 	const handleWorkspaceChange = (value: string | null) => {
 		if (value === null) {
 			setSelectedWorkspaceId(null);

--- a/site/src/pages/AgentsPage/components/MCPServerPicker.test.ts
+++ b/site/src/pages/AgentsPage/components/MCPServerPicker.test.ts
@@ -5,6 +5,7 @@ import {
 	getDefaultMCPSelection,
 	getSavedMCPSelection,
 	mcpSelectionStorageKey,
+	resolveMCPSelection,
 	saveMCPSelection,
 } from "./MCPServerPicker";
 
@@ -227,6 +228,130 @@ describe("MCP selection persistence", () => {
 				buildServer({ id: "a", availability: "default_on", enabled: false }),
 			];
 			expect(getDefaultMCPSelection(servers)).toEqual([]);
+		});
+	});
+
+	describe("resolveMCPSelection", () => {
+		const servers = [
+			buildServer({ id: "s1", availability: "force_on" }),
+			buildServer({ id: "s2", availability: "default_on" }),
+			buildServer({ id: "s3", availability: "default_off" }),
+		];
+
+		it("prefers the user selection over every other source", () => {
+			saveMCPSelection(organizationId, ["s2"]);
+			expect(
+				resolveMCPSelection({
+					userSelection: ["s3"],
+					chatSelection: ["s2"],
+					organizationId,
+					servers,
+				}),
+			).toEqual(["s3"]);
+		});
+
+		it("treats an empty user selection as a deliberate opt-out", () => {
+			saveMCPSelection(organizationId, ["s2"]);
+			expect(
+				resolveMCPSelection({
+					userSelection: [],
+					chatSelection: ["s2"],
+					organizationId,
+					servers,
+				}),
+			).toEqual([]);
+		});
+
+		it("falls back to the chat selection when the user has not chosen", () => {
+			saveMCPSelection(organizationId, ["s2"]);
+			expect(
+				resolveMCPSelection({
+					userSelection: null,
+					chatSelection: ["s3"],
+					organizationId,
+					servers,
+				}),
+			).toEqual(["s3"]);
+		});
+
+		it("treats an empty chat selection as a deliberate opt-out", () => {
+			saveMCPSelection(organizationId, ["s2"]);
+			expect(
+				resolveMCPSelection({
+					userSelection: null,
+					chatSelection: [],
+					organizationId,
+					servers,
+				}),
+			).toEqual([]);
+		});
+
+		it("falls back past a chat without a recorded selection", () => {
+			saveMCPSelection(organizationId, ["s3"]);
+			expect(
+				resolveMCPSelection({
+					userSelection: null,
+					chatSelection: null,
+					organizationId,
+					servers,
+				}),
+			).toEqual(["s3", "s1"]);
+		});
+
+		it("reads the legacy selection only for the default organization", () => {
+			localStorage.setItem(
+				"agents.selected-mcp-server-ids",
+				JSON.stringify(["s3"]),
+			);
+
+			expect(
+				resolveMCPSelection({
+					userSelection: null,
+					organizationId,
+					servers,
+				}),
+			).toEqual(["s1", "s2"]);
+
+			expect(
+				resolveMCPSelection({
+					userSelection: null,
+					organizationId,
+					servers,
+					isDefaultOrganization: true,
+				}),
+			).toEqual(["s3", "s1"]);
+		});
+
+		it("falls back to availability defaults without a saved selection", () => {
+			expect(
+				resolveMCPSelection({
+					userSelection: null,
+					organizationId,
+					servers,
+				}),
+			).toEqual(["s1", "s2"]);
+		});
+
+		it("falls back to availability defaults while servers are still loading", () => {
+			saveMCPSelection(organizationId, ["s3"]);
+			expect(
+				resolveMCPSelection({
+					userSelection: null,
+					organizationId,
+					servers: [],
+				}),
+			).toEqual([]);
+		});
+
+		it("skips the saved selection without an organization", () => {
+			saveMCPSelection("", ["s3"]);
+			expect(
+				resolveMCPSelection({
+					userSelection: null,
+					organizationId: "",
+					servers,
+				}),
+			).toEqual(["s1", "s2"]);
 		});
 	});
 });

--- a/site/src/pages/AgentsPage/components/MCPServerPicker.tsx
+++ b/site/src/pages/AgentsPage/components/MCPServerPicker.tsx
@@ -172,6 +172,48 @@ export const saveMCPSelection = (
 	);
 };
 
+interface MCPSelectionSources {
+	/** The selection the user made in this session, or `null` if untouched. */
+	userSelection: readonly string[] | null;
+	/**
+	 * The selection recorded on the chat, if any. An empty array means the user
+	 * deliberately opted out, so it still wins over saved and default values.
+	 * The API serializes an unrecorded selection as `null`.
+	 */
+	chatSelection?: readonly string[] | null;
+	organizationId: string;
+	servers: readonly TypesGen.MCPServerConfig[];
+	/** Whether the organization inherits the legacy unscoped selection. */
+	isDefaultOrganization?: boolean;
+}
+
+/**
+ * Resolve which MCP servers a chat should use, in precedence order: the current
+ * user selection, the chat record, the organization's saved selection, then the
+ * defaults implied by server availability.
+ */
+export const resolveMCPSelection = ({
+	userSelection,
+	chatSelection,
+	organizationId,
+	servers,
+	isDefaultOrganization,
+}: MCPSelectionSources): readonly string[] => {
+	if (userSelection !== null) {
+		return userSelection;
+	}
+	if (chatSelection) {
+		return chatSelection;
+	}
+	const saved = organizationId
+		? getSavedMCPSelection(organizationId, servers, isDefaultOrganization)
+		: null;
+	if (saved !== null) {
+		return saved;
+	}
+	return getDefaultMCPSelection(servers);
+};
+
 // ── Overlapping icon stack for the trigger ─────────────────────
 
 const ICON_STACK_MAX = 3;


### PR DESCRIPTION
> 🤖 This PR was written by Coder Agents on behalf of Jake Howell.

Extracts MCP server selection precedence into `resolveMCPSelection` and reuses it in the existing-chat and create-chat flows.

The helper preserves explicit user choices, recorded chat choices including an empty opt-out, organization-scoped saved choices, and server availability defaults.

<details>
<summary>Implementation plan</summary>

This is the first PR in a stack that moves fetched presentation data out of `AgentChatPage`. It pins the MCP selection semantics before query and selection ownership move closer to the composer.

</details>
