### PR TITLE
refactor(site/src/pages/AgentsPage): resolve unavailable model notices

### DIFF
--- a/site/src/pages/AgentsPage/AgentChatPage.tsx
+++ b/site/src/pages/AgentsPage/AgentChatPage.tsx
@@ -106,6 +106,7 @@ import {
 import {
 	countConfiguredProviderConfigs,
 	getModelSelectorPlaceholder,
+	getUnavailableModelNotice,
 	getUnsupportedProviderNames,
 	getUsableDefaultModelIDForOrganization,
 	hasUserFixableProviders,
@@ -489,21 +490,13 @@ const AgentChatPage: FC = () => {
 	const hasModelOptions = modelOptions.length > 0;
 	const hasResolvedModelData =
 		!isModelDataPending && Boolean(modelsQuery.data) && !modelsQuery.error;
-	const hasUnavailableHistoricalModel =
-		hasResolvedModelData &&
-		isUnavailableHistoricalModelID(chatLastModelConfigID, modelOptions);
 	const hasUserFixableModelProviders = hasUserFixableProviders(modelCatalog);
-	const unavailableModelNotice = hasUnavailableHistoricalModel
-		? hasModelOptions
-			? "The model used by this chat is not available. A usable model is selected for new messages."
-			: hasUserFixableModelProviders
-				? "The model used by this chat is not available. Add your API key in provider settings to enable models."
-				: "The model used by this chat is not available. Generation is disabled because no usable model is available."
-		: hasResolvedModelData && !hasModelOptions
-			? hasUserFixableModelProviders
-				? "No usable chat model is available. Add your API key in provider settings to enable models."
-				: "No usable chat model is currently available. Generation is disabled."
-			: undefined;
+	const unavailableModelNotice = getUnavailableModelNotice({
+		hasResolvedModelData,
+		storedModelRef: chatLastModelConfigID,
+		modelOptions,
+		catalog: modelCatalog,
+	});
 
 	const effectiveModelOption = modelOptions.find(
 		(option) => option.id === effectiveSelectedModel,

--- a/site/src/pages/AgentsPage/utils/modelOptions.test.ts
+++ b/site/src/pages/AgentsPage/utils/modelOptions.test.ts
@@ -5,6 +5,7 @@ import type {
 	ChatProviderConfig,
 	OrganizationChatModelsResponse,
 } from "#/api/typesGenerated";
+import type { ModelSelectorOption } from "#/modules/aiModels/ModelSelector";
 import {
 	MockChatModel,
 	MockChatModelProviderDescriptor,
@@ -16,6 +17,7 @@ import {
 	formatProviderLabel,
 	getModelOptionsFromModels,
 	getModelSelectorPlaceholder,
+	getUnavailableModelNotice,
 	getUnsupportedProviderNames,
 	getUsableDefaultModelIDForOrganization,
 	hasConfiguredProviderConfigs,
@@ -1208,5 +1210,103 @@ describe("resolveCompactionThreshold", () => {
 
 	it("returns undefined when the model is not in the catalog", () => {
 		expect(resolveCompactionThreshold("missing", [], models)).toBe(undefined);
+	});
+});
+
+describe("getUnavailableModelNotice", () => {
+	const modelOptions = [
+		{
+			id: "config-1",
+			provider: "openai",
+			model: "gpt-4o",
+			displayName: "GPT-4o",
+		},
+	] as const;
+	const userFixableCatalog = createCatalog([
+		{
+			provider: "openai",
+			available: false,
+			unavailable_reason: "user_api_key_required",
+		},
+	]);
+	const adminFixableCatalog = createCatalog([
+		{
+			provider: "openai",
+			available: false,
+			unavailable_reason: "missing_api_key",
+		},
+	]);
+
+	it.each<{
+		name: string;
+		hasResolvedModelData: boolean;
+		storedModelRef: string | null | undefined;
+		modelOptions: readonly ModelSelectorOption[];
+		catalog: OrganizationChatModelsResponse | undefined;
+		expected: string | undefined;
+	}>([
+		{
+			name: "stays silent while model data is unresolved",
+			hasResolvedModelData: false,
+			storedModelRef: "missing-config",
+			modelOptions: [],
+			catalog: undefined,
+			expected: undefined,
+		},
+		{
+			name: "stays silent when the stored model is still available",
+			hasResolvedModelData: true,
+			storedModelRef: "config-1",
+			modelOptions,
+			catalog: userFixableCatalog,
+			expected: undefined,
+		},
+		{
+			name: "reports the replacement model for an unavailable historical model",
+			hasResolvedModelData: true,
+			storedModelRef: "missing-config",
+			modelOptions,
+			catalog: adminFixableCatalog,
+			expected:
+				"The model used by this chat is not available. A usable model is selected for new messages.",
+		},
+		{
+			name: "asks for an API key when no replacement model exists",
+			hasResolvedModelData: true,
+			storedModelRef: "missing-config",
+			modelOptions: [],
+			catalog: userFixableCatalog,
+			expected:
+				"The model used by this chat is not available. Add your API key in provider settings to enable models.",
+		},
+		{
+			name: "reports disabled generation when no provider is user-fixable",
+			hasResolvedModelData: true,
+			storedModelRef: "missing-config",
+			modelOptions: [],
+			catalog: adminFixableCatalog,
+			expected:
+				"The model used by this chat is not available. Generation is disabled because no usable model is available.",
+		},
+		{
+			name: "asks for an API key when no model is usable at all",
+			hasResolvedModelData: true,
+			storedModelRef: "",
+			modelOptions: [],
+			catalog: userFixableCatalog,
+			expected:
+				"No usable chat model is available. Add your API key in provider settings to enable models.",
+		},
+		{
+			name: "reports disabled generation when no model is usable at all",
+			hasResolvedModelData: true,
+			storedModelRef: undefined,
+			modelOptions: [],
+			catalog: adminFixableCatalog,
+			expected:
+				"No usable chat model is currently available. Generation is disabled.",
+		},
+	])("$name", ({ name: _name, expected, ...options }) => {
+		expect(getUnavailableModelNotice(options)).toBe(expected);
 	});
 });

--- a/site/src/pages/AgentsPage/utils/modelOptions.ts
+++ b/site/src/pages/AgentsPage/utils/modelOptions.ts
@@ -342,6 +342,52 @@ export function resolveCompactionThreshold(
 	return model.compression_threshold;
 }
 
+interface UnavailableModelNoticeOptions {
+	/**
+	 * False while the model queries are pending or errored. Notices stay hidden
+	 * until the data settles so a usable model is not reported as missing.
+	 */
+	readonly hasResolvedModelData: boolean;
+	readonly storedModelRef: string | null | undefined;
+	readonly modelOptions: readonly ModelSelectorOption[];
+	readonly catalog: TypesGen.OrganizationChatModelsResponse | null | undefined;
+}
+
+/**
+ * Explains why a chat cannot use its stored model, or why no model is usable
+ * at all. Returns undefined when generation can proceed normally.
+ */
+export const getUnavailableModelNotice = ({
+	hasResolvedModelData,
+	storedModelRef,
+	modelOptions,
+	catalog,
+}: UnavailableModelNoticeOptions): string | undefined => {
+	if (!hasResolvedModelData) {
+		return undefined;
+	}
+
+	const hasModelOptions = modelOptions.length > 0;
+	const hasUserFixableModelProviders = hasUserFixableProviders(catalog);
+
+	if (isUnavailableHistoricalModelID(storedModelRef, modelOptions)) {
+		if (hasModelOptions) {
+			return "The model used by this chat is not available. A usable model is selected for new messages.";
+		}
+		return hasUserFixableModelProviders
+			? "The model used by this chat is not available. Add your API key in provider settings to enable models."
+			: "The model used by this chat is not available. Generation is disabled because no usable model is available.";
+	}
+
+	if (!hasModelOptions) {
+		return hasUserFixableModelProviders
+			? "No usable chat model is available. Add your API key in provider settings to enable models."
+			: "No usable chat model is currently available. Generation is disabled.";
+	}
+
+	return undefined;
+};
+
 export const getModelSelectorPlaceholder = (
 	modelOptions: readonly ModelSelectorOption[],
 	isModelCatalogLoading: boolean,


### PR DESCRIPTION
> 🤖 This PR was written by Coder Agents on behalf of Jake Howell.

Moves unavailable-model notice selection into `utils/modelOptions.ts`, alongside the existing model availability and selector logic.

The helper preserves the existing notice copy and adds direct coverage for every output branch.

Depends on #29161

<details>
<summary>Implementation plan</summary>

This is the second PR in the AgentChatPage data-ownership stack. It moves model-domain presentation logic out of the page before model queries and selection state move to a shared owner later in the stack.

</details>
