### PR TITLE
ci(.github): retry Go module downloads in all Go jobs

### DIFF
--- a/.github/actions/test-go-pg/action.yaml
+++ b/.github/actions/test-go-pg/action.yaml
@@ -63,6 +63,10 @@ runs:
         mkdir -p "${GOTMPDIR}"
         sudo mount -t tmpfs -o size=8g tmpfs "${GOTMPDIR}"
 
+    - name: Download Go modules
+      shell: bash
+      run: ./.github/scripts/retry.sh -- go mod download
+
     - name: Start PostgreSQL Docker container (Linux)
       if: runner.os == 'Linux'
       shell: bash

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -452,6 +452,9 @@ jobs:
       - name: Install Go mise tools
         run: ./.github/scripts/retry.sh -- mise install --locked go:storj.io/drpc/cmd/protoc-gen-go-drpc go:github.com/coder/sqlc/cmd/sqlc
 
+      - name: Download Go modules
+        run: ./.github/scripts/retry.sh -- go mod download
+
       - name: Start PostgreSQL container
         run: make test-postgres-docker
 
@@ -509,6 +512,9 @@ jobs:
 
       - name: Install Go mise tools
         run: ./.github/scripts/retry.sh -- mise install --locked go:mvdan.cc/sh/v3/cmd/shfmt
+
+      - name: Download Go modules
+        run: ./.github/scripts/retry.sh -- go mod download
 
       - name: make fmt
         timeout-minutes: 7
@@ -923,6 +929,9 @@ jobs:
       - name: Install Nginx
         run: sudo apt-get update && sudo apt-get install -y nginx
 
+      - name: Download Go modules
+        run: ./.github/scripts/retry.sh -- go mod download
+
       - name: Run Tests
         run: make test-tailnet-integration
 
@@ -1149,6 +1158,9 @@ jobs:
 
       - name: Install Go mise tools
         run: ./.github/scripts/retry.sh -- mise install --locked go:storj.io/drpc/cmd/protoc-gen-go-drpc go:github.com/coder/sqlc/cmd/sqlc
+
+      - name: Download Go modules
+        run: ./.github/scripts/retry.sh -- go mod download
 
       - name: Format
         run: |
@@ -1666,6 +1678,9 @@ jobs:
 
       - name: Install Go mise tools
         run: ./.github/scripts/retry.sh -- mise install --locked go:github.com/coder/sqlc/cmd/sqlc
+
+      - name: Download Go modules
+        run: ./.github/scripts/retry.sh -- go mod download
 
       - name: Setup and run sqlc vet
         run: |

--- a/.github/workflows/pr-deploy.yaml
+++ b/.github/workflows/pr-deploy.yaml
@@ -259,7 +259,7 @@ jobs:
       - name: Build and push Linux amd64 Docker image
         run: |
           set -euo pipefail
-          go mod download
+          ./.github/scripts/retry.sh -- go mod download
           make gen/mark-fresh
           export DOCKER_IMAGE_NO_PREREQUISITES=true
           version="$(./scripts/version.sh)"


### PR DESCRIPTION
Closes CODAGT-878

This issue has bounced between Done and Triage since July, so I spent some time working out where it was actually coming from before touching anything.

The error is a server-sent HTTP/2 `RST_STREAM` from `proxy.golang.org`, e.g. from https://github.com/coder/coder/actions/runs/34257346575:
```
github.com/armon/circbuf@v0.0.0-20190214190532-5111143e8da2: read "https://proxy.golang.org/github.com/armon/circbuf/@v/v0.0.0-20190214190532-5111143e8da2.zip": stream error: stream ID 173; INTERNAL_ERROR; received from peer
make: *** [Makefile:645: fmt/go] Error 1
```
It isn't Depot. The Go project sees the identical error on its own LUCI builders (https://github.com/golang/go/issues/51323, 9 reports in August and 4 so far in September, versus roughly one a month before that), and someone on that thread reported it from GitHub-hosted runners too. There's a CL in review to have `cmd/go` resume broken downloads (https://go-review.googlesource.com/c/go/+/824044), but that won't reach us on 1.26.x.

The reason it only started for us in July is on me: #27250 removed the `go-cache` action, which also removed the retried `go mod download` prefetch from every Go job, and the first report was the next day. #27816 put the prefetch back for `lint` and `test-e2e` only, and since then those two jobs have had zero recurrences across the 19 later failing runs, whilst every recurrence has been in a job without it (`fmt`, `gen`, `test-go-pg`, `test-go-race-pg`, `offlinedocs`).

So, the fix is just to add the same step everywhere else: `gen`, `fmt`, `test-go-tailnet-integration`, `offlinedocs`, `sqlc-vet`, the shared `test-go-pg` action (which covers the test matrix, `flake-go` and `nightly-gauntlet`), and the bare `go mod download` in `pr-deploy`.

I did initially also set `GOPROXY=https://proxy.golang.org|direct`, so `cmd/go` would fall through to a VCS fetch on any proxy error rather than just 404/410, but I've dropped it. The Go team explicitly declined to make that the default for security reasons (https://github.com/golang/go/issues/37367), the fallback is silent so we'd lose visibility of proxy incidents, and `github.com/charmbracelet/glamour` contains Git LFS files, so a direct fetch of it on our runners (which have `git-lfs` installed) would produce a different zip and fail with a checksum mismatch (https://github.com/golang/go/issues/41708). Not worth it for the rare case where three consecutive proxy attempts all fail.
