### PR TITLE
refactor(site/src/pages/AgentsPage): own panel capabilities in the view

### DIFF
--- a/site/src/pages/AgentsPage/AgentChatPage.tsx
+++ b/site/src/pages/AgentsPage/AgentChatPage.tsx
@@ -39,7 +39,6 @@ import {
 	updateChatPlanMode,
 	updateChatWorkspace,
 	updateInfiniteChatsCache,
-	userChatDebugLogging,
 } from "#/api/queries/chats";
 import { deploymentSSHConfig } from "#/api/queries/deployment";
 import { userSkills } from "#/api/queries/userSkills";
@@ -153,7 +152,7 @@ const AgentChatPage: FC = () => {
 	} = useOutletContext<AgentsPageOutletContext>();
 	const queryClient = useQueryClient();
 	const { permissions, user: currentUser } = useAuthenticated();
-	const { organizations, experiments } = useDashboard();
+	const { organizations } = useDashboard();
 	const organizationName = getDefaultOrganizationName(organizations);
 	const [selectedModel, setSelectedModel] = useState("");
 	const [selectedReasoningEffort, setSelectedReasoningEffort] = useState("");
@@ -210,7 +209,6 @@ const AgentChatPage: FC = () => {
 		...chatProviderConfigs(),
 		enabled: permissions.editDeploymentConfig,
 	});
-	const userDebugLoggingQuery = useQuery(userChatDebugLogging());
 	const mcpServersQuery = useQuery({
 		...mcpServerConfigs(chatOrganizationId),
 		enabled: Boolean(chatOrganizationId),
@@ -218,10 +216,6 @@ const AgentChatPage: FC = () => {
 	const isDefaultChatOrganization = organizations.some(
 		(organization) =>
 			organization.id === chatOrganizationId && organization.is_default,
-	);
-	const desktopEnabled = experiments.includes("chat-virtual-desktop");
-	const debugLoggingEnabled = Boolean(
-		userDebugLoggingQuery.data?.debug_logging_enabled,
 	);
 
 	// MCP server selection state.
@@ -1102,7 +1096,6 @@ const AgentChatPage: FC = () => {
 					isWorkspaceLoading={isUpdateChatWorkspacePending}
 					showSidebarPanel={showSidebarPanel}
 					onSetShowSidebarPanel={handleSetShowSidebarPanel}
-					debugLoggingEnabled={debugLoggingEnabled}
 					gitWatcher={gitWatcher}
 					sshCommand={sshCommand}
 					handleCommit={handleCommit}
@@ -1117,7 +1110,6 @@ const AgentChatPage: FC = () => {
 					isHydratingMessages={isHydratingMessages}
 					hasFetchMoreError={chatMessagesQuery.isFetchNextPageError}
 					onFetchMoreMessages={chatMessagesQuery.fetchNextPage}
-					desktopChatId={desktopEnabled ? agentId : undefined}
 					mcpServers={mcpServers}
 					selectedMCPServerIds={effectiveMCPServerIds}
 					onMCPSelectionChange={handleMCPSelectionChange}

--- a/site/src/pages/AgentsPage/AgentChatPageView.stories.tsx
+++ b/site/src/pages/AgentsPage/AgentChatPageView.stories.tsx
@@ -110,6 +110,16 @@ const buildGitWatcher = (): ComponentProps<
 	refresh: fn().mockReturnValue(true),
 });
 
+const userDebugLoggingOff: TypesGen.UserChatDebugLoggingSettings = {
+	debug_logging_enabled: false,
+	user_toggle_allowed: true,
+	forced_by_deployment: false,
+};
+const userDebugLoggingOn: TypesGen.UserChatDebugLoggingSettings = {
+	...userDebugLoggingOff,
+	debug_logging_enabled: true,
+};
+
 const agentsRouting = [
 	{ path: "/agents/:agentId", useStoryElement: true },
 	{ path: "/agents", useStoryElement: true },
@@ -182,7 +192,6 @@ const StoryAgentChatPageView: FC<StoryProps> = ({
 		isInterruptPending: false,
 		showSidebarPanel: false,
 		onSetShowSidebarPanel: fn(),
-		debugLoggingEnabled: false,
 		gitWatcher: buildGitWatcher(),
 		sshCommand: undefined as string | undefined,
 		handleCommit: fn(),
@@ -225,6 +234,9 @@ const meta: Meta<typeof AgentChatPageView> = {
 		spyOn(API, "checkAuthorization").mockResolvedValue({
 			canShareChat: false,
 		});
+		spyOn(API.experimental, "getUserChatDebugLogging").mockResolvedValue(
+			userDebugLoggingOff,
+		);
 	},
 	decorators: [
 		(Story) => (
@@ -1908,16 +1920,20 @@ export const PreservesUnavailableBrowserTab: Story = {
 const renderWithSingletonSupport = () => (
 	<StoryAgentChatPageView
 		showSidebarPanel
-		debugLoggingEnabled
 		workspace={MockWorkspace}
 		workspaceAgent={mockAgentWithBrowserApp}
-		desktopChatId={AGENT_ID}
 		sshCommand="ssh coder.workspace"
 	/>
 );
 
 export const SingletonPanelsHiddenByDefault: Story = {
-	beforeEach: clearVisibleSingletonTabs,
+	parameters: { experiments: ["chat-virtual-desktop"] },
+	beforeEach: () => {
+		spyOn(API.experimental, "getUserChatDebugLogging").mockResolvedValue(
+			userDebugLoggingOn,
+		);
+		return clearVisibleSingletonTabs();
+	},
 	render: renderWithSingletonSupport,
 	play: async ({ canvasElement }) => {
 		const canvas = within(canvasElement);
@@ -1936,7 +1952,13 @@ export const SingletonPanelsHiddenByDefault: Story = {
 };
 
 export const TogglesSingletonPanelFromDropdown: Story = {
-	beforeEach: clearVisibleSingletonTabs,
+	parameters: { experiments: ["chat-virtual-desktop"] },
+	beforeEach: () => {
+		spyOn(API.experimental, "getUserChatDebugLogging").mockResolvedValue(
+			userDebugLoggingOn,
+		);
+		return clearVisibleSingletonTabs();
+	},
 	render: renderWithSingletonSupport,
 	play: async ({ canvasElement }) => {
 		const canvas = within(canvasElement);
@@ -1987,7 +2009,13 @@ export const TogglesSingletonPanelFromDropdown: Story = {
 };
 
 export const ClosesActiveSingletonPanel: Story = {
-	beforeEach: () => seedVisibleSingletonTabs(["browser", "debug"]),
+	parameters: { experiments: ["chat-virtual-desktop"] },
+	beforeEach: () => {
+		spyOn(API.experimental, "getUserChatDebugLogging").mockResolvedValue(
+			userDebugLoggingOn,
+		);
+		return seedVisibleSingletonTabs(["browser", "debug"]);
+	},
 	render: renderWithSingletonSupport,
 	play: async ({ canvasElement }) => {
 		const canvas = within(canvasElement);
@@ -2029,7 +2057,13 @@ export const ClosesActiveSingletonPanel: Story = {
 };
 
 export const ReopenedSingletonPanelStaysSingle: Story = {
-	beforeEach: () => seedVisibleSingletonTabs(["debug"]),
+	parameters: { experiments: ["chat-virtual-desktop"] },
+	beforeEach: () => {
+		spyOn(API.experimental, "getUserChatDebugLogging").mockResolvedValue(
+			userDebugLoggingOn,
+		);
+		return seedVisibleSingletonTabs(["debug"]);
+	},
 	render: renderWithSingletonSupport,
 	play: async ({ canvasElement }) => {
 		const canvas = within(canvasElement);
@@ -2061,16 +2095,20 @@ export const ReopenedSingletonPanelStaysSingle: Story = {
  * persisting here would recreate it for a chat the user cannot change.
  */
 export const DoesNotPersistSingletonTabsForArchivedChat: Story = {
-	beforeEach: clearVisibleSingletonTabs,
+	parameters: { experiments: ["chat-virtual-desktop"] },
+	beforeEach: () => {
+		spyOn(API.experimental, "getUserChatDebugLogging").mockResolvedValue(
+			userDebugLoggingOn,
+		);
+		return clearVisibleSingletonTabs();
+	},
 	render: () => (
 		<StoryAgentChatPageView
 			showSidebarPanel
 			chat={{ archived: true }}
 			isInputDisabled
-			debugLoggingEnabled
 			workspace={MockWorkspace}
 			workspaceAgent={mockAgentWithBrowserApp}
-			desktopChatId={AGENT_ID}
 			sshCommand="ssh coder.workspace"
 		/>
 	),
@@ -2095,7 +2133,13 @@ export const DoesNotPersistSingletonTabsForArchivedChat: Story = {
 };
 
 export const RestoresPersistedSingletonPanel: Story = {
-	beforeEach: () => seedVisibleSingletonTabs(["desktop"]),
+	parameters: { experiments: ["chat-virtual-desktop"] },
+	beforeEach: () => {
+		spyOn(API.experimental, "getUserChatDebugLogging").mockResolvedValue(
+			userDebugLoggingOn,
+		);
+		return seedVisibleSingletonTabs(["desktop"]);
+	},
 	render: renderWithSingletonSupport,
 	play: async ({ canvasElement }) => {
 		const canvas = within(canvasElement);

--- a/site/src/pages/AgentsPage/AgentChatPageView.tsx
+++ b/site/src/pages/AgentsPage/AgentChatPageView.tsx
@@ -7,9 +7,12 @@ import {
 	useEffect,
 	useState,
 } from "react";
-import { useQueryClient } from "react-query";
+import { useQuery, useQueryClient } from "react-query";
 import type { UrlTransform } from "streamdown";
-import { invalidateChatDiffContents } from "#/api/queries/chats";
+import {
+	invalidateChatDiffContents,
+	userChatDebugLogging,
+} from "#/api/queries/chats";
 import type * as TypesGen from "#/api/typesGenerated";
 import type { ChatMessagePart } from "#/api/typesGenerated";
 import { ErrorAlert } from "#/components/Alert/ErrorAlert";
@@ -152,7 +155,6 @@ interface AgentChatPageViewProps {
 	onSetShowSidebarPanel: (next: boolean) => void;
 
 	// Sidebar content data.
-	debugLoggingEnabled: boolean;
 	gitWatcher: {
 		repositories: ReadonlyMap<string, TypesGen.WorkspaceAgentRepoChanges>;
 		everDirty: ReadonlySet<string>;
@@ -187,9 +189,6 @@ interface AgentChatPageViewProps {
 	selectedMCPServerIds: readonly string[];
 	onMCPSelectionChange: (ids: string[]) => void;
 	onMCPAuthComplete: (serverId: string) => void;
-
-	// Desktop chat ID (optional).
-	desktopChatId?: string;
 }
 
 const UnavailableTabMessage: FC<{ message: string }> = ({ message }) => (
@@ -310,7 +309,6 @@ export const AgentChatPageView: FC<AgentChatPageViewProps> = ({
 	isWorkspaceLoading = false,
 	showSidebarPanel,
 	onSetShowSidebarPanel,
-	debugLoggingEnabled,
 	gitWatcher,
 	sshCommand,
 	handleCommit,
@@ -329,11 +327,14 @@ export const AgentChatPageView: FC<AgentChatPageViewProps> = ({
 	selectedMCPServerIds,
 	onMCPSelectionChange,
 	onMCPAuthComplete,
-	desktopChatId,
 }) => {
 	const queryClient = useQueryClient();
 	const { proxy } = useProxy();
-	const { entitlements } = useDashboard();
+	const { entitlements, experiments } = useDashboard();
+	const userDebugLoggingQuery = useQuery(userChatDebugLogging());
+	const debugLoggingEnabled = Boolean(
+		userDebugLoggingQuery.data?.debug_logging_enabled,
+	);
 	const { permissions, user: currentUser } = useAuthenticated();
 	const wildcardHostname = proxy.preferredWildcardHostname;
 	const agentId = chat.id;
@@ -453,6 +454,10 @@ export const AgentChatPageView: FC<AgentChatPageViewProps> = ({
 		};
 	})();
 
+	const desktopChatId = experiments.includes("chat-virtual-desktop")
+		? agentId
+		: undefined;
+
 	// Desktop is only available when the workspace and agent are ready;
 	// offer it as a singleton panel on that same condition to avoid
 	// selecting "desktop" when no desktop panel is rendered.
@@ -466,7 +471,7 @@ export const AgentChatPageView: FC<AgentChatPageViewProps> = ({
 	const singletonTabSupport: Record<SingletonRightPanelTabId, boolean> = {
 		browser: availableBrowserApp !== undefined,
 		desktop: availableDesktopChatId !== undefined,
-		debug: debugLoggingEnabled === true,
+		debug: debugLoggingEnabled,
 	};
 	const supportedSingletonTabs = singletonRightPanelTabIds.filter(
 		(tabId) => singletonTabSupport[tabId],


### PR DESCRIPTION
> 🤖 This PR was written by Coder Agents on behalf of Jake Howell.

Moves right-panel capability resolution into `AgentChatPageView`, where the singleton tab model is built.

The view now reads the user's debug logging setting and desktop experiment directly. Desktop inline previews retain their existing experiment-only behavior, while the Desktop tab and open action remain gated on workspace-agent availability.

Depends on #29162

<details>
<summary>Implementation plan</summary>

This is the third PR in the AgentChatPage data-ownership stack. It removes debug and desktop capability props from the page while preserving their existing panel behavior.

</details>
