### PR TITLE
refactor(site): derive the SSH command in WorkspacePill

### DIFF
--- a/site/src/api/queries/deployment.ts
+++ b/site/src/api/queries/deployment.ts
@@ -27,10 +27,12 @@ export const deploymentStats = () => {
 	};
 };
 
+export const deploymentSSHConfigQueryKey = ["deployment", "sshConfig"] as const;
+
 export const deploymentSSHConfig = () => {
 	return {
 		...disabledRefetchOptions,
-		queryKey: ["deployment", "sshConfig"],
+		queryKey: deploymentSSHConfigQueryKey,
 		queryFn: API.getDeploymentSSHConfig,
 	};
 };

--- a/site/src/pages/AgentsPage/AgentChatPage.stories.tsx
+++ b/site/src/pages/AgentsPage/AgentChatPage.stories.tsx
@@ -36,6 +36,7 @@ import {
 	MockChatModelProviderDescriptor,
 } from "#/testHelpers/chatModels";
 import {
+	MockDeploymentSSH,
 	MockUserChatCompactionThresholds,
 	MockUserOwner,
 	MockUserPreferenceSettings,
@@ -936,6 +937,7 @@ const meta: Meta<typeof AgentChatPageLayout> = {
 	beforeEach: () => {
 		localStorage.removeItem(RIGHT_PANEL_OPEN_KEY);
 		spyOn(API, "getApiKey").mockRejectedValue(new Error("missing API key"));
+		spyOn(API, "getDeploymentSSHConfig").mockResolvedValue(MockDeploymentSSH);
 		spyOn(API.experimental, "updateChat").mockResolvedValue();
 		spyOn(API.experimental, "getMCPServerConfigs").mockResolvedValue([]);
 		spyOn(API.experimental, "getUserAIProviderKeyConfigs").mockResolvedValue([

--- a/site/src/pages/AgentsPage/AgentChatPage.tsx
+++ b/site/src/pages/AgentsPage/AgentChatPage.tsx
@@ -40,7 +40,6 @@ import {
 	updateChatWorkspace,
 	updateInfiniteChatsCache,
 } from "#/api/queries/chats";
-import { deploymentSSHConfig } from "#/api/queries/deployment";
 import { userSkills } from "#/api/queries/userSkills";
 import { workspaceById, workspaceByIdKey } from "#/api/queries/workspaces";
 import type * as TypesGen from "#/api/typesGenerated";
@@ -261,7 +260,6 @@ const AgentChatPage: FC = () => {
 		agentId,
 		chatAgentId,
 	});
-	const sshConfigQuery = useQuery(deploymentSSHConfig());
 	const workspaceAgent = getWorkspaceAgent(workspace, chatAgentId);
 	const { proxy } = useProxy();
 
@@ -620,11 +618,6 @@ const AgentChatPage: FC = () => {
 	};
 
 	const chatTitle = chatQuery.data?.title;
-
-	const sshCommand =
-		workspace && workspaceAgent && sshConfigQuery.data?.hostname_suffix
-			? `ssh ${workspaceAgent.name}.${workspace.name}.${workspace.owner_name}.${sshConfigQuery.data.hostname_suffix}`
-			: undefined;
 
 	// Signal ready only after the store has synced fetched messages,
 	// so the DOM actually contains them when the parent scrolls.
@@ -1097,7 +1090,6 @@ const AgentChatPage: FC = () => {
 					showSidebarPanel={showSidebarPanel}
 					onSetShowSidebarPanel={handleSetShowSidebarPanel}
 					gitWatcher={gitWatcher}
-					sshCommand={sshCommand}
 					handleCommit={handleCommit}
 					handleInterrupt={handleInterrupt}
 					handleDeleteQueuedMessage={handleDeleteQueuedMessage}

--- a/site/src/pages/AgentsPage/AgentChatPageView.stories.tsx
+++ b/site/src/pages/AgentsPage/AgentChatPageView.stories.tsx
@@ -27,6 +27,7 @@ import { AGENT_BROWSER_APP_SLUG } from "#/modules/apps/apps";
 import { MockChat } from "#/testHelpers/chatEntities";
 import {
 	MockDefaultOrganization,
+	MockDeploymentSSH,
 	MockGroup,
 	MockOrganizationMember,
 	MockOrganizationMember2,
@@ -193,7 +194,6 @@ const StoryAgentChatPageView: FC<StoryProps> = ({
 		showSidebarPanel: false,
 		onSetShowSidebarPanel: fn(),
 		gitWatcher: buildGitWatcher(),
-		sshCommand: undefined as string | undefined,
 		handleCommit: fn(),
 		handleInterrupt: fn(),
 		handleDeleteQueuedMessage: fn(),
@@ -234,6 +234,7 @@ const meta: Meta<typeof AgentChatPageView> = {
 		spyOn(API, "checkAuthorization").mockResolvedValue({
 			canShareChat: false,
 		});
+		spyOn(API, "getDeploymentSSHConfig").mockResolvedValue(MockDeploymentSSH);
 		spyOn(API.experimental, "getUserChatDebugLogging").mockResolvedValue(
 			userDebugLoggingOff,
 		);
@@ -846,7 +847,6 @@ export const WithWorkspace: Story = {
 		<StoryAgentChatPageView
 			workspace={MockWorkspace}
 			workspaceAgent={MockWorkspaceAgent}
-			sshCommand="ssh coder.workspace"
 		/>
 	),
 };
@@ -1654,7 +1654,6 @@ export const RestoresPersistedSidebarTab: Story = {
 			showSidebarPanel
 			workspace={MockWorkspace}
 			workspaceAgent={MockWorkspaceAgent}
-			sshCommand="ssh coder.workspace"
 		/>
 	),
 	play: async ({ canvasElement }) => {
@@ -1686,7 +1685,6 @@ export const PersistsSidebarTabClick: Story = {
 			showSidebarPanel
 			workspace={MockWorkspace}
 			workspaceAgent={MockWorkspaceAgent}
-			sshCommand="ssh coder.workspace"
 		/>
 	),
 	play: async ({ canvasElement }) => {
@@ -1783,7 +1781,6 @@ export const BrowserTabForHealthyAgentBrowserApp: Story = {
 			showSidebarPanel
 			workspace={MockWorkspace}
 			workspaceAgent={mockAgentWithBrowserApp}
-			sshCommand="ssh coder.workspace"
 		/>
 	),
 	play: async ({ canvasElement }) => {
@@ -1817,7 +1814,6 @@ export const BrowserTabForHealthDisabledAgentBrowserApp: Story = {
 				...MockWorkspaceAgent,
 				apps: [{ ...mockAgentBrowserApp, health: "disabled" }],
 			}}
-			sshCommand="ssh coder.workspace"
 		/>
 	),
 	play: async ({ canvasElement }) => {
@@ -1845,7 +1841,6 @@ export const NoBrowserTabForUnhealthyAgentBrowserApp: Story = {
 				...MockWorkspaceAgent,
 				apps: [{ ...mockAgentBrowserApp, health: "unhealthy" }],
 			}}
-			sshCommand="ssh coder.workspace"
 		/>
 	),
 };
@@ -1877,7 +1872,6 @@ export const NoBrowserTabForAppOnNonBoundAgent: Story = {
 				},
 			}}
 			workspaceAgent={MockWorkspaceAgent}
-			sshCommand="ssh coder.workspace"
 		/>
 	),
 	play: async ({ canvasElement }) => {
@@ -1900,7 +1894,6 @@ export const PreservesUnavailableBrowserTab: Story = {
 			showSidebarPanel
 			workspace={MockWorkspace}
 			workspaceAgent={MockWorkspaceAgent}
-			sshCommand="ssh coder.workspace"
 		/>
 	),
 	play: async ({ canvasElement }) => {
@@ -1922,7 +1915,6 @@ const renderWithSingletonSupport = () => (
 		showSidebarPanel
 		workspace={MockWorkspace}
 		workspaceAgent={mockAgentWithBrowserApp}
-		sshCommand="ssh coder.workspace"
 	/>
 );
 
@@ -2109,7 +2101,6 @@ export const DoesNotPersistSingletonTabsForArchivedChat: Story = {
 			isInputDisabled
 			workspace={MockWorkspace}
 			workspaceAgent={mockAgentWithBrowserApp}
-			sshCommand="ssh coder.workspace"
 		/>
 	),
 	play: async ({ canvasElement }) => {
@@ -2157,7 +2148,6 @@ export const HidesUnsupportedSingletonPanels: Story = {
 			showSidebarPanel
 			workspace={MockWorkspace}
 			workspaceAgent={MockWorkspaceAgent}
-			sshCommand="ssh coder.workspace"
 		/>
 	),
 	play: async ({ canvasElement }) => {
@@ -2203,7 +2193,6 @@ export const DoesNotPersistForArchivedChat: Story = {
 			isInputDisabled
 			workspace={MockWorkspace}
 			workspaceAgent={MockWorkspaceAgent}
-			sshCommand="ssh coder.workspace"
 		/>
 	),
 	play: async ({ canvasElement }) => {

--- a/site/src/pages/AgentsPage/AgentChatPageView.tsx
+++ b/site/src/pages/AgentsPage/AgentChatPageView.tsx
@@ -164,7 +164,6 @@ interface AgentChatPageViewProps {
 	};
 
 	// Workspace action handlers.
-	sshCommand: string | undefined;
 	handleCommit: (repoRoot: string) => void;
 
 	// Chat action handlers.
@@ -310,7 +309,6 @@ export const AgentChatPageView: FC<AgentChatPageViewProps> = ({
 	showSidebarPanel,
 	onSetShowSidebarPanel,
 	gitWatcher,
-	sshCommand,
 	handleCommit,
 	handleInterrupt,
 	handleDeleteQueuedMessage,
@@ -997,7 +995,6 @@ export const AgentChatPageView: FC<AgentChatPageViewProps> = ({
 									onMCPAuthComplete={onMCPAuthComplete}
 									workspace={workspace}
 									workspaceAgent={workspaceAgent}
-									sshCommand={sshCommand}
 									attachedWorkspace={attachedWorkspace}
 									folder={preferredFolder}
 								/>

--- a/site/src/pages/AgentsPage/components/AgentChatInput.stories.tsx
+++ b/site/src/pages/AgentsPage/components/AgentChatInput.stories.tsx
@@ -10,6 +10,7 @@ import {
 	MockMCPServerConfig,
 } from "#/testHelpers/chatEntities";
 import {
+	MockDeploymentSSH,
 	MockUserPreferenceSettings,
 	MockWorkspace,
 	MockWorkspaceAgent,
@@ -42,6 +43,14 @@ const meta: Meta<typeof AgentChatInput> = {
 	title: "pages/AgentsPage/AgentChatInput",
 	component: AgentChatInput,
 	decorators: [withDashboardProvider, withProxyProvider()],
+	// Deployment without an SSH hostname suffix, so the workspace pill
+	// menus opened here omit the copy action. WorkspacePill covers it.
+	beforeEach: () => {
+		spyOn(API, "getDeploymentSSHConfig").mockResolvedValue({
+			...MockDeploymentSSH,
+			hostname_suffix: "",
+		});
+	},
 	parameters: {
 		queries: [
 			{

--- a/site/src/pages/AgentsPage/components/AgentChatInput.tsx
+++ b/site/src/pages/AgentsPage/components/AgentChatInput.tsx
@@ -189,7 +189,6 @@ interface AgentChatInputProps {
 	workspace?: TypesGen.Workspace;
 	workspaceAgent?: TypesGen.WorkspaceAgent;
 	chatId?: string;
-	sshCommand?: string;
 	attachedWorkspace?: AttachedWorkspaceInfo;
 	folder?: string;
 	canConfigureAgentSetup: boolean;
@@ -411,7 +410,6 @@ export const AgentChatInput: FC<AgentChatInputProps> = ({
 	workspace,
 	workspaceAgent,
 	chatId,
-	sshCommand,
 	attachedWorkspace,
 	folder,
 	canConfigureAgentSetup,
@@ -1501,7 +1499,6 @@ export const AgentChatInput: FC<AgentChatInputProps> = ({
 												workspace={workspace}
 												agent={workspaceAgent}
 												chatId={chatId}
-												sshCommand={sshCommand}
 												folder={folder}
 												onRemoveWorkspace={removeWorkspaceHandler}
 											/>
@@ -1577,7 +1574,6 @@ export const AgentChatInput: FC<AgentChatInputProps> = ({
 														workspace={workspace}
 														agent={workspaceAgent}
 														chatId={chatId}
-														sshCommand={sshCommand}
 														folder={folder}
 														onRemoveWorkspace={removeWorkspaceHandler}
 														inOverflowPopover

--- a/site/src/pages/AgentsPage/components/ChatPageContent.tsx
+++ b/site/src/pages/AgentsPage/components/ChatPageContent.tsx
@@ -303,7 +303,6 @@ interface ChatPageInputProps {
 	isWorkspaceLoading?: boolean;
 	workspace?: TypesGen.Workspace;
 	workspaceAgent?: TypesGen.WorkspaceAgent;
-	sshCommand?: string;
 	attachedWorkspace?: AttachedWorkspaceInfo;
 	folder?: string;
 }
@@ -350,7 +349,6 @@ export const ChatPageInput: FC<ChatPageInputProps> = ({
 	isWorkspaceLoading = false,
 	workspace,
 	workspaceAgent,
-	sshCommand,
 	attachedWorkspace,
 	folder,
 }) => {
@@ -610,7 +608,6 @@ export const ChatPageInput: FC<ChatPageInputProps> = ({
 			workspace={workspace}
 			workspaceAgent={workspaceAgent}
 			chatId={chatId}
-			sshCommand={sshCommand}
 			attachedWorkspace={attachedWorkspace}
 			folder={folder}
 			canConfigureAgentSetup={canConfigureAgentSetup}

--- a/site/src/pages/AgentsPage/components/WorkspacePill.stories.tsx
+++ b/site/src/pages/AgentsPage/components/WorkspacePill.stories.tsx
@@ -1,7 +1,9 @@
 import type { Meta, StoryObj } from "@storybook/react-vite";
-import { expect, fn, userEvent, waitFor, within } from "storybook/test";
+import { expect, fn, spyOn, userEvent, waitFor, within } from "storybook/test";
+import { API } from "#/api/api";
 import type { WorkspaceApp } from "#/api/typesGenerated";
 import {
+	MockDeploymentSSH,
 	MockListeningPortsResponse,
 	MockSharedPortsResponse,
 	MockStoppedWorkspace,
@@ -118,6 +120,15 @@ const meta: Meta<typeof WorkspacePill> = {
 		}),
 	],
 
+	// Deployment without an SSH hostname suffix, so open menus omit the
+	// copy action. WithAllApps overrides it to cover the action itself.
+	beforeEach: () => {
+		spyOn(API, "getDeploymentSSHConfig").mockResolvedValue({
+			...MockDeploymentSSH,
+			hostname_suffix: "",
+		});
+	},
+
 	parameters: {
 		layout: "centered",
 		queries: [{ key: ["me", "apiKey"], data: { key: "mock-api-key" } }],
@@ -135,7 +146,9 @@ export const WithAllApps: Story = {
 		...defaultProps,
 		workspace: MockWorkspace,
 		agent: agentWithApps,
-		sshCommand: "ssh coder.test-workspace",
+	},
+	beforeEach: () => {
+		spyOn(API, "getDeploymentSSHConfig").mockResolvedValue(MockDeploymentSSH);
 	},
 	play: async ({ canvasElement }) => {
 		const canvas = within(canvasElement);

--- a/site/src/pages/AgentsPage/components/WorkspacePill.test.tsx
+++ b/site/src/pages/AgentsPage/components/WorkspacePill.test.tsx
@@ -1,0 +1,82 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import type { FC, PropsWithChildren } from "react";
+import { QueryClientProvider } from "react-query";
+import { MemoryRouter } from "react-router";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { deploymentSSHConfigQueryKey } from "#/api/queries/deployment";
+import { TooltipProvider } from "#/components/Tooltip/Tooltip";
+import {
+	getPreferredProxy,
+	ProxyContext,
+	type ProxyContextValue,
+} from "#/contexts/ProxyContext";
+import {
+	MockDeploymentSSH,
+	MockProxyLatencies,
+	MockWorkspace,
+	MockWorkspaceAgent,
+} from "#/testHelpers/entities";
+import { createTestQueryClient } from "#/testHelpers/renderHelpers";
+import { WorkspacePill } from "./WorkspacePill";
+
+const proxyContextValue: ProxyContextValue = {
+	latenciesLoaded: true,
+	proxyLatencies: MockProxyLatencies,
+	proxy: getPreferredProxy([], undefined),
+	proxies: [],
+	isLoading: false,
+	isFetched: true,
+	setProxy: () => {},
+	clearProxy: () => {},
+	refetchProxyLatencies: () => new Date(),
+};
+
+const renderPill = () => {
+	const queryClient = createTestQueryClient();
+	queryClient.setQueryData(deploymentSSHConfigQueryKey, MockDeploymentSSH);
+
+	const Wrapper: FC<PropsWithChildren> = ({ children }) => (
+		<QueryClientProvider client={queryClient}>
+			<ProxyContext.Provider value={proxyContextValue}>
+				<TooltipProvider>
+					<MemoryRouter>{children}</MemoryRouter>
+				</TooltipProvider>
+			</ProxyContext.Provider>
+		</QueryClientProvider>
+	);
+
+	return render(
+		<WorkspacePill
+			workspace={MockWorkspace}
+			agent={{ ...MockWorkspaceAgent, display_apps: [], apps: [] }}
+			chatId="chat-1"
+		/>,
+		{ wrapper: Wrapper },
+	);
+};
+
+describe("WorkspacePill", () => {
+	afterEach(() => {
+		vi.unstubAllGlobals();
+	});
+
+	it("copies the SSH command built from the deployment hostname suffix", async () => {
+		const writeText = vi.fn().mockResolvedValue(undefined);
+		vi.stubGlobal("navigator", { clipboard: { writeText } });
+
+		renderPill();
+		await userEvent.click(
+			screen.getByRole("button", {
+				name: `${MockWorkspace.name} workspace menu`,
+			}),
+		);
+		await userEvent.click(
+			await screen.findByRole("menuitem", { name: "Copy SSH Command" }),
+		);
+
+		expect(writeText).toHaveBeenCalledWith(
+			`ssh ${MockWorkspaceAgent.name}.${MockWorkspace.name}.${MockWorkspace.owner_name}.${MockDeploymentSSH.hostname_suffix}`,
+		);
+	});
+});

--- a/site/src/pages/AgentsPage/components/WorkspacePill.tsx
+++ b/site/src/pages/AgentsPage/components/WorkspacePill.tsx
@@ -9,11 +9,12 @@ import {
 } from "lucide-react";
 import type { FC } from "react";
 import { useEffect, useState } from "react";
-import { useMutation } from "react-query";
+import { useMutation, useQuery } from "react-query";
 import { Link } from "react-router";
 import { toast } from "sonner";
 import { API } from "#/api/api";
 import { getErrorMessage } from "#/api/errors";
+import { deploymentSSHConfig } from "#/api/queries/deployment";
 import type {
 	Workspace,
 	WorkspaceAgent,
@@ -53,7 +54,6 @@ interface WorkspacePillProps {
 	workspace: Workspace;
 	agent: WorkspaceAgent;
 	chatId: string;
-	sshCommand?: string;
 	folder?: string;
 	onRemoveWorkspace?: () => void;
 	// Rendered inside the +N overflow popover: suppresses the status
@@ -66,7 +66,6 @@ export const WorkspacePill: FC<WorkspacePillProps> = ({
 	workspace,
 	agent,
 	chatId,
-	sshCommand,
 	folder,
 	onRemoveWorkspace,
 	inOverflowPopover,
@@ -83,6 +82,12 @@ export const WorkspacePill: FC<WorkspacePillProps> = ({
 	});
 	const { proxy } = useProxy();
 	const host = proxy.preferredWildcardHostname;
+
+	const { data: sshConfig } = useQuery(deploymentSSHConfig());
+	const hostnameSuffix = sshConfig?.hostname_suffix;
+	const sshCommand = hostnameSuffix
+		? `ssh ${agent.name}.${workspace.name}.${workspace.owner_name}.${hostnameSuffix}`
+		: undefined;
 
 	const builtinApps = new Set(agent.display_apps);
 	const hasVSCode = builtinApps.has("vscode");


### PR DESCRIPTION
> 🤖 This PR was written by Coder Agents on behalf of Jake Howell.

Moves deployment SSH configuration loading into `WorkspacePill`, the sole consumer of the constructed SSH command.

This removes the command prop from the chat page, view, composer, and input layers. The Copy SSH action remains hidden until a hostname suffix is available, and its clipboard payload now has focused behavior coverage.

Depends on #29164

<details>
<summary>Implementation plan</summary>

This is the fourth PR in the AgentChatPage data-ownership stack. It removes the longest display-only prop chain by colocating the query and derived command with the workspace menu that renders it.

</details>
