### PR TITLE
refactor(site/src/pages/AgentsPage): centralize chat submission settings

### DIFF
--- a/site/src/pages/AgentsPage/AgentChatPage.stories.tsx
+++ b/site/src/pages/AgentsPage/AgentChatPage.stories.tsx
@@ -1580,6 +1580,32 @@ export const Loading: Story = {
 	},
 };
 
+/**
+ * The chat record has not arrived, so the settings provider has no
+ * organization to query models for and the composer shows the model selector
+ * skeleton instead of a selector.
+ */
+export const LoadingWithPendingModelCatalog: Story = {
+	parameters: {
+		queries: withoutQuery(
+			buildQueries(
+				{
+					id: CHAT_ID,
+					...baseChatFields,
+					title: "",
+					status: "running",
+				},
+				{ messages: [], queued_messages: [], has_more: false },
+				{ diffUrl: undefined },
+			),
+			chatEntityKey(CHAT_ID),
+		),
+	},
+	beforeEach: () => {
+		spyOn(API.experimental, "getChat").mockReturnValue(new Promise(() => {}));
+	},
+};
+
 const capacityPollingChat: TypesGen.Chat = {
 	id: CHAT_ID,
 	...baseChatFields,

--- a/site/src/pages/AgentsPage/AgentChatPage.tsx
+++ b/site/src/pages/AgentsPage/AgentChatPage.tsx
@@ -2,7 +2,7 @@ import {
 	MessageScroller,
 	useMessageScroller,
 } from "@shadcn/react/message-scroller";
-import { type FC, useEffect, useRef, useState } from "react";
+import { type FC, useEffect, useRef } from "react";
 
 import {
 	useInfiniteQuery,
@@ -17,11 +17,9 @@ import type {
 	CreateChatMessageRequestWithClearablePlanMode,
 } from "#/api/api";
 import { getErrorMessage, getErrorStatus, isApiError } from "#/api/errors";
-import { chatProviderConfigs } from "#/api/queries/aiProviders";
 import { buildOptimisticEditedMessage } from "#/api/queries/chatMessageEdits";
 import {
 	chatMessagesForInfiniteScroll,
-	chatModels,
 	chatQueueConvergence,
 	clearChat,
 	compactChat,
@@ -31,7 +29,6 @@ import {
 	getOpenChatPollInterval,
 	interruptChat,
 	invalidateChatEntity,
-	mcpServerConfigs,
 	openChat,
 	patchChatEntity,
 	promoteChatQueuedMessage,
@@ -83,12 +80,11 @@ import { useWorkspaceWatch } from "./components/ChatConversation/useWorkspaceWat
 import { isChatAgentBindingUnresolved } from "./components/ChatConversation/watchedWorkspace";
 import type { PendingAttachment } from "./components/ChatPageContent";
 import { workspaceSkillsFromChat } from "./components/ChatPageContent";
-import {
-	resolveMCPSelection,
-	saveMCPSelection,
-} from "./components/MCPServerPicker";
-import { getModelSelectorHelp } from "./components/ModelSelectorHelp";
 import { useAgentChatPanelPreference } from "./components/RightPanel/useAgentChatPanelPreference";
+import {
+	AgentChatSettingsProvider,
+	useAgentChatSettings,
+} from "./context/AgentChatSettingsContext";
 import {
 	BuiltInCommandPendingError,
 	useConversationEditingState,
@@ -98,18 +94,7 @@ import {
 	draftInputStorageKeyPrefix,
 	parseStoredDraft,
 } from "./utils/draftStorage";
-import {
-	countConfiguredProviderConfigs,
-	getModelSelectorPlaceholder,
-	getUnavailableModelNotice,
-	getUnsupportedProviderNames,
-	getUsableDefaultModelIDForOrganization,
-	hasUserFixableProviders,
-	isUnavailableHistoricalModelID,
-	resolveModelOptionId,
-	resolveModelSelector,
-} from "./utils/modelOptions";
-import { pickReasoningEffort } from "./utils/reasoningEffort";
+import { isUnavailableHistoricalModelID } from "./utils/modelOptions";
 import {
 	CHAT_SLASH_COMMANDS,
 	CLEAR_SLASH_COMMAND,
@@ -138,8 +123,25 @@ const buildAttachmentMediaTypes = (
 	);
 };
 
-const AgentChatPage: FC = () => {
-	const { agentId } = useParams() as { agentId: string };
+interface AgentChatPageControllerProps {
+	agentId: string;
+	chat: TypesGen.Chat | undefined;
+	chatDataUpdatedAt: number;
+	isChatLoading: boolean;
+	isChatLoadingError: boolean;
+	chatError: unknown;
+	refetchChat: () => Promise<unknown>;
+}
+
+const AgentChatPageController: FC<AgentChatPageControllerProps> = ({
+	agentId,
+	chat,
+	chatDataUpdatedAt,
+	isChatLoading,
+	isChatLoadingError,
+	chatError,
+	refetchChat,
+}) => {
 	const {
 		chatErrorReasons,
 		setChatErrorReason,
@@ -147,12 +149,10 @@ const AgentChatPage: FC = () => {
 		onChatReady,
 	} = useOutletContext<AgentsPageOutletContext>();
 	const queryClient = useQueryClient();
-	const { permissions, user: currentUser } = useAuthenticated();
+	const { user: currentUser } = useAuthenticated();
 	const { organizations } = useDashboard();
 	const organizationName = getDefaultOrganizationName(organizations);
-	const [selectedModel, setSelectedModel] = useState("");
-	const [selectedReasoningEffort, setSelectedReasoningEffort] = useState("");
-	const isEditReasoningEffortDirtyRef = useRef(false);
+	const settings = useAgentChatSettings();
 	const chatInputRef = useRef<ChatMessageInputRef | null>(null);
 	const inputValueRef = useRef(
 		parseStoredDraft(
@@ -163,94 +163,16 @@ const AgentChatPage: FC = () => {
 	const { showSidebarPanel, handleSetShowSidebarPanel } =
 		useAgentChatPanelPreference();
 
-	const chatQuery = useQuery({
-		...openChat(agentId),
-		// Poll while the chat runs (this override replaces openChat's
-		// interval, and queued_for_capacity depends on the poll) or while
-		// the binding is unresolved: repair happens on chat reads and watch
-		// events cannot be relied on for retries because an idle workspace
-		// publishes none.
-		refetchInterval: ({ state }) => {
-			const openPollMs = getOpenChatPollInterval(state.data);
-			if (openPollMs !== false) {
-				return openPollMs;
-			}
-			const workspaceId = state.data?.workspace_id;
-			const workspace = workspaceId
-				? queryClient.getQueryData<TypesGen.Workspace>(
-						workspaceByIdKey(workspaceId),
-					)
-				: undefined;
-			return isChatAgentBindingUnresolved(workspace, state.data?.agent_id)
-				? AGENT_BINDING_REPAIR_POLL_MS
-				: false;
-		},
-		refetchIntervalInBackground: false,
-	});
-	const chatOrganizationId = chatQuery.data?.organization_id ?? "";
 	const chatMessagesQuery = useInfiniteQuery(
 		chatMessagesForInfiniteScroll(agentId),
 	);
-	const workspaceId = chatQuery.data?.workspace_id;
-	const chatAgentId = chatQuery.data?.agent_id;
+	const workspaceId = chat?.workspace_id;
+	const chatAgentId = chat?.agent_id;
 	const workspaceQuery = useQuery({
 		...workspaceById(workspaceId ?? ""),
 		enabled: Boolean(workspaceId),
 	});
 	const workspace = workspaceQuery.data;
-
-	const modelsQuery = useQuery(chatModels(chatOrganizationId));
-	const models = modelsQuery.data?.models ?? [];
-	const chatProviderConfigsQuery = useQuery({
-		...chatProviderConfigs(),
-		enabled: permissions.editDeploymentConfig,
-	});
-	const mcpServersQuery = useQuery({
-		...mcpServerConfigs(chatOrganizationId),
-		enabled: Boolean(chatOrganizationId),
-	});
-	const isDefaultChatOrganization = organizations.some(
-		(organization) =>
-			organization.id === chatOrganizationId && organization.is_default,
-	);
-
-	// MCP server selection state.
-	const mcpServers = mcpServersQuery.data ?? [];
-	const [selectedMCPServerIds, setSelectedMCPServerIds] = useState<
-		string[] | null
-	>(null);
-
-	const handleMCPSelectionChange = (ids: string[]) => {
-		setSelectedMCPServerIds(ids);
-		if (chatOrganizationId) {
-			saveMCPSelection(chatOrganizationId, ids);
-		}
-	};
-
-	const handleMCPAuthComplete = (_serverId: string) => {
-		void mcpServersQuery.refetch();
-	};
-
-	const {
-		options: modelOptions,
-		isModelCatalogLoading,
-		modelCatalog,
-		hasConfiguredModels,
-	} = resolveModelSelector(chatOrganizationId, modelsQuery);
-	const isModelDataPending = chatOrganizationId === "" || isModelCatalogLoading;
-	const providerCount =
-		permissions.editDeploymentConfig &&
-		chatProviderConfigsQuery.data &&
-		modelsQuery.data
-			? countConfiguredProviderConfigs(
-					chatProviderConfigsQuery.data,
-					modelsQuery.data,
-				)
-			: undefined;
-	const modelCount = modelsQuery.data ? modelOptions.length : undefined;
-	const unsupportedProviderNames = getUnsupportedProviderNames(
-		modelsQuery.data,
-	);
 
 	useWorkspaceWatch({
 		workspaceId,
@@ -259,19 +181,10 @@ const AgentChatPage: FC = () => {
 	});
 	const workspaceAgent = getWorkspaceAgent(workspace, chatAgentId);
 
-	const chat = chatQuery.data;
 	const isArchived = Boolean(chat?.archived);
 	const isViewerNotOwner =
 		chat !== undefined && currentUser.id !== chat.owner_id;
 	const planModeEnabled = chat?.plan_mode === "plan";
-
-	const effectiveMCPServerIds = resolveMCPSelection({
-		userSelection: selectedMCPServerIds,
-		chatSelection: chat?.mcp_server_ids,
-		organizationId: chatOrganizationId,
-		servers: mcpServers,
-		isDefaultOrganization: isDefaultChatOrganization,
-	});
 
 	// Flatten paginated messages into chronological order.
 	// Pages arrive newest-first per page, and pages[0] is the
@@ -305,7 +218,6 @@ const AgentChatPage: FC = () => {
 					has_more: Boolean(chatMessagesQuery.data?.pages.at(-1)?.has_more),
 				}
 			: undefined;
-	const chatLastModelConfigID = chat?.last_model_config_id;
 
 	// Destructure mutation results directly so the React Compiler
 	// tracks stable primitives/functions instead of the whole result
@@ -330,7 +242,7 @@ const AgentChatPage: FC = () => {
 		...userSkills(),
 		staleTime: 60_000,
 	});
-	const chatWorkspaceSkills = workspaceSkillsFromChat(chatQuery.data);
+	const chatWorkspaceSkills = workspaceSkillsFromChat(chat);
 	const { mutateAsync: deleteQueuedMessage } = useMutation(
 		deleteChatQueuedMessage(queryClient, agentId),
 	);
@@ -403,7 +315,7 @@ const AgentChatPage: FC = () => {
 		chatID: agentId,
 		chatMessages: chatMessagesList,
 		chatRecord: chat,
-		chatRecordUpdatedAt: chatQuery.dataUpdatedAt,
+		chatRecordUpdatedAt: chatDataUpdatedAt,
 		chatMessagesData,
 		chatQueuedMessages,
 		setChatErrorReason,
@@ -446,69 +358,6 @@ const AgentChatPage: FC = () => {
 		chatInputRef.current?.focus();
 	};
 
-	// Validate explicit and historical choices against organization options.
-	// Prefer the usable organization default before another organization model.
-	const effectiveSelectedModel = (() => {
-		const resolvedSelectedModel = resolveModelOptionId(
-			selectedModel,
-			modelOptions,
-		);
-		if (resolvedSelectedModel) {
-			return resolvedSelectedModel;
-		}
-
-		const resolvedChatModel = resolveModelOptionId(
-			chatLastModelConfigID,
-			modelOptions,
-		);
-		if (resolvedChatModel) {
-			return resolvedChatModel;
-		}
-
-		return (
-			getUsableDefaultModelIDForOrganization(
-				models,
-				modelOptions,
-				chatOrganizationId,
-			) ||
-			modelOptions[0]?.id ||
-			""
-		);
-	})();
-	const hasModelOptions = modelOptions.length > 0;
-	const hasResolvedModelData =
-		!isModelDataPending && Boolean(modelsQuery.data) && !modelsQuery.error;
-	const hasUserFixableModelProviders = hasUserFixableProviders(modelCatalog);
-	const unavailableModelNotice = getUnavailableModelNotice({
-		hasResolvedModelData,
-		storedModelRef: chatLastModelConfigID,
-		modelOptions,
-		catalog: modelCatalog,
-	});
-
-	const effectiveModelOption = modelOptions.find(
-		(option) => option.id === effectiveSelectedModel,
-	);
-	const effectiveReasoningEffort = effectiveModelOption
-		? pickReasoningEffort(
-				selectedReasoningEffort || chat?.last_reasoning_effort,
-				effectiveModelOption.reasoningEfforts ?? [],
-				effectiveModelOption.reasoningEffortDefault,
-			)
-		: undefined;
-
-	const modelSelectorPlaceholder = getModelSelectorPlaceholder(
-		modelOptions,
-		isModelDataPending,
-		hasConfiguredModels,
-		modelCatalog,
-	);
-	const modelSelectorHelp = getModelSelectorHelp({
-		isModelCatalogLoading: isModelDataPending,
-		hasModelOptions,
-		hasConfiguredModels,
-		hasUserFixableModelProviders,
-	});
 	const isSubmissionPending =
 		isSendPending ||
 		isEditPending ||
@@ -518,13 +367,13 @@ const AgentChatPage: FC = () => {
 	const isChatSettingsPending =
 		isUpdateChatPlanModePending || isUpdateChatWorkspacePending;
 	const isInputDisabled =
-		!hasModelOptions ||
+		!settings.hasModelOptions ||
 		isArchived ||
 		isChatSettingsPending ||
 		isViewerNotOwner ||
 		aiGatewayDisabled;
 	const canUpdateChatWorkspace = !isArchived && !isViewerNotOwner;
-	const selectedWorkspaceId = chatQuery.data?.workspace_id ?? null;
+	const selectedWorkspaceId = chat?.workspace_id ?? null;
 	const handlePlanModeToggle = (enabled: boolean) => {
 		if (enabled === planModeEnabled) {
 			return;
@@ -609,11 +458,13 @@ const AgentChatPage: FC = () => {
 	const handleEditUserMessage = (
 		...args: Parameters<typeof editing.handleEditUserMessage>
 	) => {
-		isEditReasoningEffortDirtyRef.current = false;
+		// An edit keeps the message's original effort unless the user picks one
+		// while editing, so every edit starts from a cleared pick.
+		settings.resetPickedReasoningEffort();
 		editing.handleEditUserMessage(...args);
 	};
 
-	const chatTitle = chatQuery.data?.title;
+	const chatTitle = chat?.title;
 
 	// Signal ready only after the store has synced fetched messages,
 	// so the DOM actually contains them when the parent scrolls.
@@ -709,7 +560,7 @@ const AgentChatPage: FC = () => {
 			attachments,
 			useComposerContent,
 		});
-		if (!hasContent || isSubmissionPending || !hasModelOptions) {
+		if (!hasContent || isSubmissionPending || !settings.hasModelOptions) {
 			return;
 		}
 		// Wait for chat-setting mutations to settle before sending so the
@@ -779,13 +630,15 @@ const AgentChatPage: FC = () => {
 				(existingMessage) => existingMessage.id === editedMessageID,
 			);
 			const originalModelConfigID = originalEditedMessage?.model_config_id;
-			const pickerModelConfigID = effectiveSelectedModel || undefined;
+			const pickerModelConfigID = settings.selectedModel || undefined;
 			const originalIsSelectable =
 				originalModelConfigID !== undefined &&
-				modelOptions.some((option) => option.id === originalModelConfigID);
+				settings.modelOptions.some(
+					(option) => option.id === originalModelConfigID,
+				);
 			const originalIsUnavailable = isUnavailableHistoricalModelID(
 				originalModelConfigID,
-				modelOptions,
+				settings.modelOptions,
 			);
 			// Use the picker fallback for an unavailable historical model.
 			// Override a selectable model only after the user changes it.
@@ -801,10 +654,10 @@ const AgentChatPage: FC = () => {
 			const request: TypesGen.EditChatMessageRequest = {
 				content,
 				model_config_id: editSelectedModelConfigID,
-				reasoning_effort: isEditReasoningEffortDirtyRef.current
-					? effectiveReasoningEffort
+				reasoning_effort: settings.hasPickedReasoningEffort
+					? settings.reasoningEffort
 					: undefined,
-				mcp_server_ids: [...effectiveMCPServerIds],
+				mcp_server_ids: [...settings.selectedMCPServerIds],
 			};
 			const optimisticMessage = originalEditedMessage
 				? buildOptimisticEditedMessage({
@@ -846,12 +699,12 @@ const AgentChatPage: FC = () => {
 			return;
 		}
 
-		const selectedModelConfigID = effectiveSelectedModel || undefined;
+		const selectedModelConfigID = settings.selectedModel || undefined;
 		const request: CreateChatMessageRequestWithClearablePlanMode = {
 			content,
 			model_config_id: selectedModelConfigID,
-			reasoning_effort: effectiveReasoningEffort,
-			mcp_server_ids: [...effectiveMCPServerIds],
+			reasoning_effort: settings.reasoningEffort,
+			mcp_server_ids: [...settings.selectedMCPServerIds],
 			...(planModeSwitch !== undefined
 				? {
 						plan_mode:
@@ -990,7 +843,7 @@ const AgentChatPage: FC = () => {
 			<title>
 				{chatTitle ? pageTitle(chatTitle, "Agents") : pageTitle("Agents")}
 			</title>
-			{chatQuery.isLoading || chatMessagesQuery.isLoading ? (
+			{isChatLoading || chatMessagesQuery.isLoading ? (
 				<AgentChatPageLoadingView
 					inputRef={editing.chatInputRef}
 					initialValue={editing.editorInitialValue}
@@ -998,29 +851,19 @@ const AgentChatPage: FC = () => {
 					remountKey={editing.remountKey}
 					onContentChange={editing.handleLoadingDraftChange}
 					isInputDisabled={isInputDisabled}
-					effectiveSelectedModel={effectiveSelectedModel}
-					setSelectedModel={setSelectedModel}
-					modelOptions={modelOptions}
-					modelSelectorPlaceholder={modelSelectorPlaceholder}
-					hasModelOptions={hasModelOptions}
-					isModelCatalogLoading={isModelDataPending}
 					planModeEnabled={planModeEnabled}
 					onPlanModeToggle={handlePlanModeToggle}
 					showRightPanel={showSidebarPanel}
 				/>
-			) : chatQuery.isLoadingError || chatMessagesQuery.isLoadingError ? (
-				getErrorStatus(chatQuery.error) === 404 ? (
+			) : isChatLoadingError || chatMessagesQuery.isLoadingError ? (
+				getErrorStatus(chatError) === 404 ? (
 					<AgentChatPageNotFoundView />
 				) : (
 					<AgentChatPageErrorView
-						error={
-							chatQuery.isLoadingError
-								? chatQuery.error
-								: chatMessagesQuery.error
-						}
+						error={isChatLoadingError ? chatError : chatMessagesQuery.error}
 						onRetry={() => {
-							if (chatQuery.isLoadingError) {
-								void chatQuery.refetch();
+							if (isChatLoadingError) {
+								void refetchChat();
 							}
 							if (chatMessagesQuery.isLoadingError) {
 								void chatMessagesQuery.refetch();
@@ -1040,28 +883,7 @@ const AgentChatPage: FC = () => {
 					store={store}
 					initialMessages={chatMessagesList ?? []}
 					editing={{ ...editing, handleEditUserMessage }}
-					effectiveSelectedModel={effectiveSelectedModel}
-					setSelectedModel={setSelectedModel}
-					modelOptions={modelOptions}
-					models={modelCatalog?.models}
-					modelSelectorPlaceholder={modelSelectorPlaceholder}
-					modelSelectorHelp={modelSelectorHelp}
-					modelCatalogError={modelsQuery.error}
-					unavailableModelNotice={unavailableModelNotice}
-					reasoningEffort={effectiveReasoningEffort}
-					onReasoningEffortChange={(value) => {
-						setSelectedReasoningEffort(value);
-						if (editing.editingMessageId !== null) {
-							isEditReasoningEffortDirtyRef.current = true;
-						}
-					}}
-					canConfigureAgentSetup={permissions.editDeploymentConfig}
-					providerCount={providerCount}
-					modelCount={modelCount}
-					unsupportedProviderNames={unsupportedProviderNames}
 					aiGatewayDisabled={aiGatewayDisabled}
-					hasModelOptions={hasModelOptions}
-					isModelCatalogLoading={isModelDataPending}
 					onPlanModeToggle={handlePlanModeToggle}
 					isInputDisabled={isInputDisabled}
 					isSubmissionPending={isSubmissionPending}
@@ -1084,13 +906,54 @@ const AgentChatPage: FC = () => {
 					isHydratingMessages={isHydratingMessages}
 					hasFetchMoreError={chatMessagesQuery.isFetchNextPageError}
 					onFetchMoreMessages={chatMessagesQuery.fetchNextPage}
-					mcpServers={mcpServers}
-					selectedMCPServerIds={effectiveMCPServerIds}
-					onMCPSelectionChange={handleMCPSelectionChange}
-					onMCPAuthComplete={handleMCPAuthComplete}
 				/>
 			)}
 		</>
+	);
+};
+
+const AgentChatPage: FC = () => {
+	const { agentId } = useParams() as { agentId: string };
+	const queryClient = useQueryClient();
+	const chatQuery = useQuery({
+		...openChat(agentId),
+		// Poll while the chat runs (this override replaces openChat's
+		// interval, and queued_for_capacity depends on the poll) or while
+		// the binding is unresolved: repair happens on chat reads and watch
+		// events cannot be relied on for retries because an idle workspace
+		// publishes none.
+		refetchInterval: ({ state }) => {
+			const openPollMs = getOpenChatPollInterval(state.data);
+			if (openPollMs !== false) {
+				return openPollMs;
+			}
+			const workspaceId = state.data?.workspace_id;
+			const workspace = workspaceId
+				? queryClient.getQueryData<TypesGen.Workspace>(
+						workspaceByIdKey(workspaceId),
+					)
+				: undefined;
+			return isChatAgentBindingUnresolved(workspace, state.data?.agent_id)
+				? AGENT_BINDING_REPAIR_POLL_MS
+				: false;
+		},
+		refetchIntervalInBackground: false,
+	});
+
+	// The settings provider sits above the controller so sends that do not come
+	// from the composer still submit the selections the composer displays.
+	return (
+		<AgentChatSettingsProvider chat={chatQuery.data}>
+			<AgentChatPageController
+				agentId={agentId}
+				chat={chatQuery.data}
+				chatDataUpdatedAt={chatQuery.dataUpdatedAt}
+				isChatLoading={chatQuery.isLoading}
+				isChatLoadingError={chatQuery.isLoadingError}
+				chatError={chatQuery.error}
+				refetchChat={chatQuery.refetch}
+			/>
+		</AgentChatSettingsProvider>
 	);
 };
 

--- a/site/src/pages/AgentsPage/AgentChatPageView.stories.tsx
+++ b/site/src/pages/AgentsPage/AgentChatPageView.stories.tsx
@@ -1,6 +1,6 @@
 import { MessageScroller } from "@shadcn/react/message-scroller";
 import type { Decorator, Meta, StoryObj } from "@storybook/react-vite";
-import { type ComponentProps, type FC, useState } from "react";
+import { type ComponentProps, type FC, type ReactNode, useState } from "react";
 import { Outlet } from "react-router";
 import {
 	expect,
@@ -54,6 +54,10 @@ import {
 import type { ChatDetailError } from "./components/ChatConversation/chatError";
 import { createChatStore } from "./components/ChatConversation/chatStore";
 import { buildLongConversation } from "./components/ChatConversation/storyFixtures";
+import {
+	type AgentChatSettings,
+	AgentChatSettingsValueProvider,
+} from "./context/AgentChatSettingsContext";
 import { visibleSingletonTabsStorageKeyPrefix } from "./utils/rightPanelTabStorage";
 import type { SingletonRightPanelTabId } from "./utils/rightPanelTabs";
 import { lastActiveSidebarTabStorageKeyPrefix } from "./utils/sidebarTabStorage";
@@ -73,6 +77,50 @@ const defaultModelOptions: ModelSelectorOption[] = [
 		displayName: "GPT-4o",
 	},
 ];
+
+// The page resolves these from the model and MCP queries. Supplying them
+// directly keeps each view story to the one state it exercises, including the
+// cached-catalog-with-refetch-error state a seeded query cannot express.
+const buildSettings = (
+	overrides: Partial<AgentChatSettings> = {},
+): AgentChatSettings => ({
+	modelOptions: defaultModelOptions,
+	models: [],
+	hasModelOptions: true,
+	isModelCatalogLoading: false,
+	modelCatalogError: undefined,
+	modelSelectorPlaceholder: "Select a model",
+	modelSelectorHelp: undefined,
+	unavailableModelNotice: undefined,
+	canConfigureAgentSetup: true,
+	providerCount: 1,
+	modelCount: 1,
+	unsupportedProviderNames: [],
+	selectedModel: defaultModelID,
+	onModelChange: fn(),
+	reasoningEffort: undefined,
+	onReasoningEffortChange: fn(),
+	hasPickedReasoningEffort: false,
+	resetPickedReasoningEffort: fn(),
+	mcpServers: [],
+	selectedMCPServerIds: [],
+	onMCPSelectionChange: fn(),
+	onMCPAuthComplete: fn(),
+	...overrides,
+});
+
+const WithSettings: FC<{
+	settings?: Partial<AgentChatSettings>;
+	children: ReactNode;
+}> = ({ settings, children }) => {
+	// Build once so consumers see a stable settings value across rerenders.
+	const [value] = useState(() => buildSettings(settings));
+	return (
+		<AgentChatSettingsValueProvider settings={value}>
+			{children}
+		</AgentChatSettingsValueProvider>
+	);
+};
 
 const oneWeekAgo = new Date(Date.now() - 7 * 24 * 60 * 60 * 1000).toISOString();
 
@@ -169,11 +217,13 @@ type StoryProps = Omit<
 > & {
 	editing?: Partial<ComponentProps<typeof AgentChatPageView>["editing"]>;
 	chat?: Partial<TypesGen.Chat>;
+	settings?: Partial<AgentChatSettings>;
 };
 
 const StoryAgentChatPageView: FC<StoryProps> = ({
 	editing,
 	chat,
+	settings,
 	...overrides
 }) => {
 	const [defaultStore] = useState(() => createChatStore());
@@ -182,12 +232,6 @@ const StoryAgentChatPageView: FC<StoryProps> = ({
 	const props = {
 		chat: buildChat(chat),
 		persistedError: undefined as ChatDetailError | undefined,
-		effectiveSelectedModel: defaultModelID,
-		setSelectedModel: fn(),
-		modelOptions: defaultModelOptions,
-		models: [],
-		modelSelectorPlaceholder: "Select a model",
-		hasModelOptions: true,
 		isInputDisabled: false,
 		isSubmissionPending: false,
 		isInterruptPending: false,
@@ -203,21 +247,16 @@ const StoryAgentChatPageView: FC<StoryProps> = ({
 		isHydratingMessages: false,
 		hasFetchMoreError: false,
 		onFetchMoreMessages: fn(async () => {}),
-		mcpServers: [] as ComponentProps<typeof AgentChatPageView>["mcpServers"],
-		selectedMCPServerIds: [] as ComponentProps<
-			typeof AgentChatPageView
-		>["selectedMCPServerIds"],
-		onMCPSelectionChange: fn(),
-		onMCPAuthComplete: fn(),
-		canConfigureAgentSetup: true,
-		providerCount: 1,
-		modelCount: 1,
 		initialMessages: [],
 		...overrides,
 		store,
 		editing: buildEditing(editing),
 	};
-	return <AgentChatPageView {...props} />;
+	return (
+		<WithSettings settings={settings}>
+			<AgentChatPageView {...props} />
+		</WithSettings>
+	);
 };
 
 // ---------------------------------------------------------------------------
@@ -309,7 +348,9 @@ export const Default: Story = {
 export const CachedModelsWithRefetchError: Story = {
 	render: () => (
 		<StoryAgentChatPageView
-			modelCatalogError={new Error("Failed to refresh available models.")}
+			settings={{
+				modelCatalogError: new Error("Failed to refresh available models."),
+			}}
 		/>
 	),
 };
@@ -726,8 +767,7 @@ export const SidebarCollapsed: Story = {
 export const NoModelOptions: Story = {
 	render: () => (
 		<StoryAgentChatPageView
-			hasModelOptions={false}
-			modelOptions={[]}
+			settings={{ hasModelOptions: false, modelOptions: [] }}
 			isInputDisabled
 		/>
 	),
@@ -736,12 +776,14 @@ export const NoModelOptions: Story = {
 export const MissingProviderAndModelSetup: Story = {
 	render: () => (
 		<StoryAgentChatPageView
-			canConfigureAgentSetup
 			chat={{ organization_id: MockDefaultOrganization.id }}
-			providerCount={0}
-			modelCount={0}
-			hasModelOptions={false}
-			modelOptions={[]}
+			settings={{
+				canConfigureAgentSetup: true,
+				providerCount: 0,
+				modelCount: 0,
+				hasModelOptions: false,
+				modelOptions: [],
+			}}
 			isInputDisabled
 		/>
 	),
@@ -772,12 +814,14 @@ export const MissingProviderAndModelSetup: Story = {
 export const MissingModelSetup: Story = {
 	render: () => (
 		<StoryAgentChatPageView
-			canConfigureAgentSetup
 			chat={{ organization_id: MockDefaultOrganization.id }}
-			providerCount={1}
-			modelCount={0}
-			hasModelOptions={false}
-			modelOptions={[]}
+			settings={{
+				canConfigureAgentSetup: true,
+				providerCount: 1,
+				modelCount: 0,
+				hasModelOptions: false,
+				modelOptions: [],
+			}}
 			isInputDisabled
 		/>
 	),
@@ -804,9 +848,11 @@ export const MissingModelSetup: Story = {
 export const MissingProviderSetup: Story = {
 	render: () => (
 		<StoryAgentChatPageView
-			canConfigureAgentSetup
-			providerCount={0}
-			modelCount={1}
+			settings={{
+				canConfigureAgentSetup: true,
+				providerCount: 0,
+				modelCount: 1,
+			}}
 		/>
 	),
 	play: async ({ canvasElement }) => {
@@ -832,11 +878,13 @@ export const MissingProviderSetup: Story = {
 export const MemberNoModelsAvailable: Story = {
 	render: () => (
 		<StoryAgentChatPageView
-			canConfigureAgentSetup={false}
-			providerCount={0}
-			modelCount={0}
-			hasModelOptions={false}
-			modelOptions={[]}
+			settings={{
+				canConfigureAgentSetup: false,
+				providerCount: 0,
+				modelCount: 0,
+				hasModelOptions: false,
+				modelOptions: [],
+			}}
 			isInputDisabled
 		/>
 	),
@@ -932,59 +980,51 @@ export const WorkspaceNoAgent: Story = {
 /** Default loading state with skeleton placeholders. */
 export const Loading: Story = {
 	render: () => (
-		<AgentChatPageLoadingView
-			inputRef={{ current: null }}
-			initialValue=""
-			initialEditorState={undefined}
-			remountKey={0}
-			onContentChange={fn()}
-			isInputDisabled
-			effectiveSelectedModel={defaultModelID}
-			setSelectedModel={fn()}
-			modelOptions={defaultModelOptions}
-			modelSelectorPlaceholder="Select a model"
-			hasModelOptions
-			showRightPanel={false}
-		/>
+		<WithSettings>
+			<AgentChatPageLoadingView
+				inputRef={{ current: null }}
+				initialValue=""
+				initialEditorState={undefined}
+				remountKey={0}
+				onContentChange={fn()}
+				isInputDisabled
+				showRightPanel={false}
+			/>
+		</WithSettings>
 	),
 };
 
 /** Loading state with the model selector populated. */
 export const LoadingWithModelOptions: Story = {
 	render: () => (
-		<AgentChatPageLoadingView
-			inputRef={{ current: null }}
-			initialValue=""
-			initialEditorState={undefined}
-			remountKey={0}
-			onContentChange={fn()}
-			isInputDisabled={false}
-			effectiveSelectedModel={defaultModelID}
-			setSelectedModel={fn()}
-			modelOptions={defaultModelOptions}
-			modelSelectorPlaceholder="Select a model"
-			hasModelOptions
-			showRightPanel={false}
-		/>
+		<WithSettings>
+			<AgentChatPageLoadingView
+				inputRef={{ current: null }}
+				initialValue=""
+				initialEditorState={undefined}
+				remountKey={0}
+				onContentChange={fn()}
+				isInputDisabled={false}
+				showRightPanel={false}
+			/>
+		</WithSettings>
 	),
 };
+
 /** Loading state with the right panel pre-opened. */
 export const LoadingWithRightPanel: Story = {
 	render: () => (
-		<AgentChatPageLoadingView
-			inputRef={{ current: null }}
-			initialValue=""
-			initialEditorState={undefined}
-			remountKey={0}
-			onContentChange={fn()}
-			isInputDisabled
-			effectiveSelectedModel={defaultModelID}
-			setSelectedModel={fn()}
-			modelOptions={defaultModelOptions}
-			modelSelectorPlaceholder="Select a model"
-			hasModelOptions
-			showRightPanel
-		/>
+		<WithSettings>
+			<AgentChatPageLoadingView
+				inputRef={{ current: null }}
+				initialValue=""
+				initialEditorState={undefined}
+				remountKey={0}
+				onContentChange={fn()}
+				isInputDisabled
+				showRightPanel
+			/>
+		</WithSettings>
 	),
 };
 
@@ -992,20 +1032,17 @@ export const LoadingWithRightPanel: Story = {
 export const LoadingSidebarCollapsed: Story = {
 	parameters: { reactRouter: collapsedSidebarRouter },
 	render: () => (
-		<AgentChatPageLoadingView
-			inputRef={{ current: null }}
-			initialValue=""
-			initialEditorState={undefined}
-			remountKey={0}
-			onContentChange={fn()}
-			isInputDisabled
-			effectiveSelectedModel={defaultModelID}
-			setSelectedModel={fn()}
-			modelOptions={defaultModelOptions}
-			modelSelectorPlaceholder="Select a model"
-			hasModelOptions
-			showRightPanel={false}
-		/>
+		<WithSettings>
+			<AgentChatPageLoadingView
+				inputRef={{ current: null }}
+				initialValue=""
+				initialEditorState={undefined}
+				remountKey={0}
+				onContentChange={fn()}
+				isInputDisabled
+				showRightPanel={false}
+			/>
+		</WithSettings>
 	),
 };
 

--- a/site/src/pages/AgentsPage/AgentChatPageView.tsx
+++ b/site/src/pages/AgentsPage/AgentChatPageView.tsx
@@ -17,7 +17,6 @@ import type { ChatMessagePart } from "#/api/typesGenerated";
 import { ErrorAlert } from "#/components/Alert/ErrorAlert";
 import { useProxy } from "#/contexts/ProxyContext";
 import { useAuthenticated } from "#/hooks/useAuthenticated";
-import type { ModelSelectorOption } from "#/modules/aiModels/ModelSelector";
 import {
 	getAgentBrowserApp,
 	isWorkspaceAppEmbeddable,
@@ -58,6 +57,7 @@ import { RightPanel } from "./components/RightPanel/RightPanel";
 import { RightPanelAddTabControl } from "./components/RightPanel/RightPanelAddTabControl";
 import { getWorkspaceStatus, StatusIcon } from "./components/StatusIcon";
 import { TerminalPanel } from "./components/TerminalPanel";
+import { useAgentChatSettings } from "./context/AgentChatSettingsContext";
 import { ChatWorkspaceContext } from "./context/ChatWorkspaceContext";
 import { TerminalClientSessionContext } from "./context/TerminalClientSessionContext";
 import { chatWidthClass, useChatFullWidth } from "./hooks/useChatFullWidth";
@@ -123,24 +123,8 @@ interface AgentChatPageViewProps {
 	// Editing state.
 	editing: EditingState;
 
-	// Model/input configuration.
-	effectiveSelectedModel: string;
-	setSelectedModel: (model: string) => void;
-	modelOptions: readonly ModelSelectorOption[];
-	models: readonly TypesGen.ChatModel[] | undefined;
-	modelSelectorPlaceholder: string;
-	modelSelectorHelp?: ReactNode;
-	modelCatalogError?: unknown;
-	unavailableModelNotice?: string;
-	reasoningEffort?: string;
-	onReasoningEffortChange?: (value: string) => void;
-	canConfigureAgentSetup: boolean;
-	providerCount?: number;
-	modelCount?: number;
-	unsupportedProviderNames?: readonly string[];
+	// Input configuration.
 	aiGatewayDisabled?: boolean;
-	hasModelOptions: boolean;
-	isModelCatalogLoading?: boolean;
 	onPlanModeToggle?: (enabled: boolean) => void;
 	isInputDisabled: boolean;
 	isSubmissionPending: boolean;
@@ -179,12 +163,6 @@ interface AgentChatPageViewProps {
 	isHydratingMessages: boolean;
 	hasFetchMoreError: boolean;
 	onFetchMoreMessages: () => Promise<unknown>;
-
-	// MCP server state.
-	mcpServers: readonly TypesGen.MCPServerConfig[];
-	selectedMCPServerIds: readonly string[];
-	onMCPSelectionChange: (ids: string[]) => void;
-	onMCPAuthComplete: (serverId: string) => void;
 }
 
 const UnavailableTabMessage: FC<{ message: string }> = ({ message }) => (
@@ -280,23 +258,7 @@ export const AgentChatPageView: FC<AgentChatPageViewProps> = ({
 	store,
 	initialMessages,
 	editing,
-	effectiveSelectedModel,
-	setSelectedModel,
-	modelOptions,
-	models,
-	modelSelectorPlaceholder,
-	modelSelectorHelp,
-	modelCatalogError,
-	unavailableModelNotice,
-	reasoningEffort,
-	onReasoningEffortChange,
-	canConfigureAgentSetup,
-	providerCount,
-	modelCount,
-	unsupportedProviderNames,
 	aiGatewayDisabled,
-	hasModelOptions,
-	isModelCatalogLoading = false,
 	onPlanModeToggle,
 	isInputDisabled,
 	isSubmissionPending,
@@ -317,11 +279,9 @@ export const AgentChatPageView: FC<AgentChatPageViewProps> = ({
 	isHydratingMessages,
 	hasFetchMoreError,
 	onFetchMoreMessages,
-	mcpServers,
-	selectedMCPServerIds,
-	onMCPSelectionChange,
-	onMCPAuthComplete,
 }) => {
+	const { mcpServers, modelCatalogError, unavailableModelNotice } =
+		useAgentChatSettings();
 	const queryClient = useQueryClient();
 	const { proxy } = useProxy();
 	const { entitlements, experiments } = useDashboard();
@@ -953,7 +913,6 @@ export const AgentChatPageView: FC<AgentChatPageViewProps> = ({
 								<ChatPageInput
 									chat={chat}
 									store={store}
-									models={models}
 									onSend={editing.handleSendFromInput}
 									onDeleteQueuedMessage={handleDeleteQueuedMessage}
 									onPromoteQueuedMessage={handlePromoteQueuedMessage}
@@ -961,21 +920,8 @@ export const AgentChatPageView: FC<AgentChatPageViewProps> = ({
 									isInputDisabled={isInputDisabled}
 									isSendPending={isSubmissionPending}
 									isInterruptPending={isInterruptPending}
-									hasModelOptions={hasModelOptions}
-									canConfigureAgentSetup={canConfigureAgentSetup}
-									providerCount={providerCount}
-									modelCount={modelCount}
-									unsupportedProviderNames={unsupportedProviderNames}
 									aiGatewayDisabled={aiGatewayDisabled}
-									selectedModel={effectiveSelectedModel}
-									onModelChange={setSelectedModel}
-									modelOptions={modelOptions}
-									modelSelectorPlaceholder={modelSelectorPlaceholder}
-									modelSelectorHelp={modelSelectorHelp}
-									reasoningEffort={reasoningEffort}
-									onReasoningEffortChange={onReasoningEffortChange}
 									onPlanModeToggle={onPlanModeToggle}
-									isModelCatalogLoading={isModelCatalogLoading}
 									onWorkspaceChange={onWorkspaceChange}
 									isWorkspaceLoading={isWorkspaceLoading}
 									inputRef={editing.chatInputRef}
@@ -986,10 +932,6 @@ export const AgentChatPageView: FC<AgentChatPageViewProps> = ({
 									isEditing={isEditing}
 									onCancelHistoryEdit={editing.handleCancelHistoryEdit}
 									editingFileBlocks={editing.editingFileBlocks}
-									mcpServers={mcpServers}
-									selectedMCPServerIds={selectedMCPServerIds}
-									onMCPSelectionChange={onMCPSelectionChange}
-									onMCPAuthComplete={onMCPAuthComplete}
 									workspace={workspace}
 									workspaceAgent={workspaceAgent}
 									attachedWorkspace={attachedWorkspace}
@@ -1049,12 +991,6 @@ interface AgentChatPageLoadingViewProps {
 		hasFileReferences: boolean,
 	) => void;
 	isInputDisabled: boolean;
-	effectiveSelectedModel: string;
-	setSelectedModel: (model: string) => void;
-	modelOptions: readonly ModelSelectorOption[];
-	modelSelectorPlaceholder: string;
-	hasModelOptions: boolean;
-	isModelCatalogLoading?: boolean;
 	planModeEnabled?: boolean;
 	onPlanModeToggle?: (enabled: boolean) => void;
 	showRightPanel: boolean;
@@ -1067,16 +1003,18 @@ export const AgentChatPageLoadingView: FC<AgentChatPageLoadingViewProps> = ({
 	remountKey,
 	onContentChange,
 	isInputDisabled,
-	effectiveSelectedModel,
-	setSelectedModel,
-	modelOptions,
-	modelSelectorPlaceholder,
-	hasModelOptions,
-	isModelCatalogLoading = false,
 	planModeEnabled,
 	onPlanModeToggle,
 	showRightPanel,
 }) => {
+	const {
+		hasModelOptions,
+		isModelCatalogLoading,
+		modelOptions,
+		modelSelectorPlaceholder,
+		onModelChange,
+		selectedModel,
+	} = useAgentChatSettings();
 	const [chatFullWidth] = useChatFullWidth();
 	return (
 		<div
@@ -1114,8 +1052,8 @@ export const AgentChatPageLoadingView: FC<AgentChatPageLoadingViewProps> = ({
 						onContentChange={onContentChange}
 						isDisabled={isInputDisabled}
 						isLoading={false}
-						selectedModel={effectiveSelectedModel}
-						onModelChange={setSelectedModel}
+						selectedModel={selectedModel}
+						onModelChange={onModelChange}
 						modelOptions={modelOptions}
 						modelSelectorPlaceholder={modelSelectorPlaceholder}
 						planModeEnabled={planModeEnabled}

--- a/site/src/pages/AgentsPage/components/ChatPageContent.stories.tsx
+++ b/site/src/pages/AgentsPage/components/ChatPageContent.stories.tsx
@@ -4,13 +4,18 @@ import type { FC } from "react";
 import { expect, fn, userEvent, waitFor, within } from "storybook/test";
 import {
 	chatPromptsKey,
+	mcpServerConfigsKey,
+	organizationChatModelsKey,
 	userCompactionThresholdsKey,
 } from "#/api/queries/chats";
 import { preferenceSettingsKey } from "#/api/queries/users";
 import { workspacesKey } from "#/api/queries/workspaces";
 import type * as TypesGen from "#/api/typesGenerated";
 import { MockChat, MockChatQueuedMessage } from "#/testHelpers/chatEntities";
-import { MockChatModel } from "#/testHelpers/chatModels";
+import {
+	MockChatModel,
+	MockChatModelProviderDescriptor,
+} from "#/testHelpers/chatModels";
 import {
 	MockUserChatCompactionThresholds,
 	MockUserOwner,
@@ -21,6 +26,7 @@ import {
 	withDashboardProvider,
 	withProxyProvider,
 } from "#/testHelpers/storybook";
+import { AgentChatSettingsProvider } from "../context/AgentChatSettingsContext";
 import { ChatWorkspaceContext } from "../context/ChatWorkspaceContext";
 import { createChatStore } from "./ChatConversation/chatStore";
 import { FIXTURE_NOW } from "./ChatConversation/storyFixtures";
@@ -43,6 +49,27 @@ const StoryChatPageTimeline: FC<{
 		/>
 	</MessageScroller.Provider>
 );
+
+const CHAT_ID = "chat-page-content-stories";
+
+// The composer chat carries no id so the prompt-history and draft attachment
+// scopes stay inert, while its organization drives the settings queries.
+const composerChat: TypesGen.Chat = { ...MockChat, id: "" };
+
+const composerModelCatalog: TypesGen.OrganizationChatModelsResponse = {
+	models: [
+		{
+			...MockChatModel,
+			id: MockChat.last_model_config_id,
+			organization_id: MockChat.organization_id,
+			model: "gpt-4o",
+			display_name: "GPT-4o",
+			is_default: true,
+		},
+	],
+	providers: [MockChatModelProviderDescriptor],
+	unsupported_providers: [],
+};
 
 // ChatPageTimeline builds the transcript URL transform from the proxy
 // context, so every story needs the provider.
@@ -67,14 +94,20 @@ const meta = {
 					count: 0,
 				} satisfies TypesGen.WorkspacesResponse,
 			},
+			{
+				key: organizationChatModelsKey(MockChat.organization_id),
+				data: composerModelCatalog,
+			},
+			{
+				key: mcpServerConfigsKey(MockChat.organization_id),
+				data: [] satisfies TypesGen.MCPServerConfig[],
+			},
 		],
 	},
 } satisfies Meta;
 
 export default meta;
 type Story = StoryObj<typeof meta>;
-
-const CHAT_ID = "chat-page-content-stories";
 
 const mockUserChatCompactionThresholdsWithOverride: TypesGen.UserChatCompactionThresholds =
 	{
@@ -87,48 +120,28 @@ const mockUserChatCompactionThresholdsWithOverride: TypesGen.UserChatCompactionT
 		],
 	};
 
-const mockCompactionModels: readonly TypesGen.ChatModel[] = [
-	{
-		...MockChatModel,
-		id: MockChat.last_model_config_id,
-	},
-];
-
-// Renders only the composer half of the chat page. Empty chat id and
-// organization keep the prompt-history and draft attachment queries disabled.
+// Renders only the composer half of the chat page.
 const StoryChatPageInput: FC<{
 	store: ReturnType<typeof createChatStore>;
 	onInterrupt?: () => void;
 }> = ({ store, onInterrupt }) => (
-	<div className="mx-auto w-full max-w-3xl p-4">
-		<ChatPageInput
-			chat={{ ...MockChat, id: "", organization_id: "" }}
-			store={store}
-			models={[]}
-			onSend={fn()}
-			onDeleteQueuedMessage={fn()}
-			onPromoteQueuedMessage={fn()}
-			onInterrupt={onInterrupt ?? fn()}
-			isInputDisabled={false}
-			isSendPending={false}
-			isInterruptPending={false}
-			hasModelOptions
-			selectedModel="model-config-1"
-			onModelChange={fn()}
-			modelOptions={[
-				{
-					id: "model-config-1",
-					provider: "openai",
-					model: "gpt-4o",
-					displayName: "GPT-4o",
-				},
-			]}
-			modelSelectorPlaceholder="Select model"
-			canConfigureAgentSetup={false}
-			isEditing={false}
-			onCancelHistoryEdit={fn()}
-		/>
-	</div>
+	<AgentChatSettingsProvider chat={composerChat}>
+		<div className="mx-auto w-full max-w-3xl p-4">
+			<ChatPageInput
+				chat={composerChat}
+				store={store}
+				onSend={fn()}
+				onDeleteQueuedMessage={fn()}
+				onPromoteQueuedMessage={fn()}
+				onInterrupt={onInterrupt ?? fn()}
+				isInputDisabled={false}
+				isSendPending={false}
+				isInterruptPending={false}
+				isEditing={false}
+				onCancelHistoryEdit={fn()}
+			/>
+		</div>
+	</AgentChatSettingsProvider>
 );
 
 const buildMessage = (
@@ -378,28 +391,23 @@ const CompactionChatPageInput: FC = () => {
 	]);
 
 	return (
-		<div className="mx-auto w-full max-w-3xl p-4">
-			<ChatPageInput
-				chat={MockChat}
-				store={store}
-				models={mockCompactionModels}
-				onSend={fn()}
-				onDeleteQueuedMessage={fn()}
-				onPromoteQueuedMessage={fn()}
-				onInterrupt={fn()}
-				isInputDisabled={false}
-				isSendPending={false}
-				isInterruptPending={false}
-				hasModelOptions={false}
-				selectedModel={MockChat.last_model_config_id}
-				onModelChange={fn()}
-				modelOptions={[]}
-				modelSelectorPlaceholder="Select model"
-				canConfigureAgentSetup={false}
-				isEditing={false}
-				onCancelHistoryEdit={fn()}
-			/>
-		</div>
+		<AgentChatSettingsProvider chat={MockChat}>
+			<div className="mx-auto w-full max-w-3xl p-4">
+				<ChatPageInput
+					chat={MockChat}
+					store={store}
+					onSend={fn()}
+					onDeleteQueuedMessage={fn()}
+					onPromoteQueuedMessage={fn()}
+					onInterrupt={fn()}
+					isInputDisabled={false}
+					isSendPending={false}
+					isInterruptPending={false}
+					isEditing={false}
+					onCancelHistoryEdit={fn()}
+				/>
+			</div>
+		</AgentChatSettingsProvider>
 	);
 };
 
@@ -432,6 +440,14 @@ export const CompactsAtUserOverride: Story = {
 					workspaces: [],
 					count: 0,
 				} satisfies TypesGen.WorkspacesResponse,
+			},
+			{
+				key: organizationChatModelsKey(MockChat.organization_id),
+				data: composerModelCatalog,
+			},
+			{
+				key: mcpServerConfigsKey(MockChat.organization_id),
+				data: [] satisfies TypesGen.MCPServerConfig[],
 			},
 		],
 	},
@@ -467,6 +483,14 @@ export const CompactsAtHistoricalModelDefault: Story = {
 					workspaces: [],
 					count: 0,
 				} satisfies TypesGen.WorkspacesResponse,
+			},
+			{
+				key: organizationChatModelsKey(MockChat.organization_id),
+				data: composerModelCatalog,
+			},
+			{
+				key: mcpServerConfigsKey(MockChat.organization_id),
+				data: [] satisfies TypesGen.MCPServerConfig[],
 			},
 		],
 	},

--- a/site/src/pages/AgentsPage/components/ChatPageContent.tsx
+++ b/site/src/pages/AgentsPage/components/ChatPageContent.tsx
@@ -12,8 +12,8 @@ import { workspaces } from "#/api/queries/workspaces";
 import type * as TypesGen from "#/api/typesGenerated";
 import { useProxy } from "#/contexts/ProxyContext";
 import { useAuthenticated } from "#/hooks/useAuthenticated";
-import type { ModelSelectorOption } from "#/modules/aiModels/ModelSelector";
 import { rewriteLocalhostURL } from "#/utils/portForward";
+import { useAgentChatSettings } from "../context/AgentChatSettingsContext";
 import { useChatDraftAttachments } from "../hooks/useChatDraftAttachments";
 import { chatWidthClass, useChatFullWidth } from "../hooks/useChatFullWidth";
 import { useFileAttachments } from "../hooks/useFileAttachments";
@@ -270,7 +270,6 @@ export type PendingAttachment = {
 interface ChatPageInputProps {
 	chat: TypesGen.Chat;
 	store: ChatStoreHandle;
-	models: readonly TypesGen.ChatModel[] | undefined;
 	onSend: (
 		message: string,
 		attachments?: readonly PendingAttachment[],
@@ -281,21 +280,8 @@ interface ChatPageInputProps {
 	isInputDisabled: boolean;
 	isSendPending: boolean;
 	isInterruptPending: boolean;
-	hasModelOptions: boolean;
-	selectedModel: string;
-	onModelChange: (modelID: string) => void;
-	modelOptions: readonly ModelSelectorOption[];
-	modelSelectorPlaceholder: string;
-	modelSelectorHelp?: ReactNode;
-	reasoningEffort?: string;
-	onReasoningEffortChange?: (value: string) => void;
-	canConfigureAgentSetup: boolean;
-	providerCount?: number;
-	modelCount?: number;
-	unsupportedProviderNames?: readonly string[];
 	aiGatewayDisabled?: boolean;
 	onPlanModeToggle?: (enabled: boolean) => void;
-	isModelCatalogLoading?: boolean;
 	// Imperative editor handle plus the one-time initial draft,
 	// owned by the conversation component.
 	inputRef?: React.Ref<ChatMessageInputRef>;
@@ -312,11 +298,6 @@ interface ChatPageInputProps {
 	// File parts from the message being edited, converted to
 	// File objects and pre-populated into attachments.
 	editingFileBlocks?: readonly TypesGen.ChatMessagePart[];
-	// MCP server picker state.
-	mcpServers?: readonly TypesGen.MCPServerConfig[];
-	selectedMCPServerIds?: readonly string[];
-	onMCPSelectionChange?: (ids: string[]) => void;
-	onMCPAuthComplete?: (serverId: string) => void;
 	onWorkspaceChange?: (workspaceId: string | null) => void;
 	isWorkspaceLoading?: boolean;
 	workspace?: TypesGen.Workspace;
@@ -328,7 +309,6 @@ interface ChatPageInputProps {
 export const ChatPageInput: FC<ChatPageInputProps> = ({
 	chat,
 	store,
-	models,
 	onSend,
 	onDeleteQueuedMessage,
 	onPromoteQueuedMessage,
@@ -336,21 +316,8 @@ export const ChatPageInput: FC<ChatPageInputProps> = ({
 	isInputDisabled,
 	isSendPending,
 	isInterruptPending,
-	hasModelOptions,
-	selectedModel,
-	onModelChange,
-	modelOptions,
-	modelSelectorPlaceholder,
-	modelSelectorHelp,
-	reasoningEffort,
-	onReasoningEffortChange,
-	canConfigureAgentSetup,
-	providerCount,
-	modelCount,
-	unsupportedProviderNames,
 	aiGatewayDisabled,
 	onPlanModeToggle,
-	isModelCatalogLoading = false,
 	inputRef,
 	initialValue,
 	initialEditorState,
@@ -359,10 +326,6 @@ export const ChatPageInput: FC<ChatPageInputProps> = ({
 	isEditing,
 	onCancelHistoryEdit,
 	editingFileBlocks,
-	mcpServers,
-	selectedMCPServerIds,
-	onMCPSelectionChange,
-	onMCPAuthComplete,
 	onWorkspaceChange,
 	isWorkspaceLoading = false,
 	workspace,
@@ -370,6 +333,26 @@ export const ChatPageInput: FC<ChatPageInputProps> = ({
 	attachedWorkspace,
 	folder,
 }) => {
+	const {
+		canConfigureAgentSetup,
+		hasModelOptions,
+		isModelCatalogLoading,
+		mcpServers,
+		modelCount,
+		modelOptions,
+		modelSelectorHelp,
+		modelSelectorPlaceholder,
+		models,
+		onMCPAuthComplete,
+		onMCPSelectionChange,
+		onModelChange,
+		onReasoningEffortChange,
+		providerCount,
+		reasoningEffort,
+		selectedMCPServerIds,
+		selectedModel,
+		unsupportedProviderNames,
+	} = useAgentChatSettings();
 	const { user: currentUser } = useAuthenticated();
 	const organizationId = chat.organization_id;
 	const chatId = chat.id;

--- a/site/src/pages/AgentsPage/context/AgentChatSettingsContext.test.tsx
+++ b/site/src/pages/AgentsPage/context/AgentChatSettingsContext.test.tsx
@@ -1,0 +1,440 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import type { FC, PropsWithChildren } from "react";
+import { QueryClientProvider } from "react-query";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { API } from "#/api/api";
+import {
+	mcpServerConfigsKey,
+	organizationChatModelsKey,
+} from "#/api/queries/chats";
+import type * as TypesGen from "#/api/typesGenerated";
+import {
+	DashboardContext,
+	type DashboardValue,
+} from "#/modules/dashboard/DashboardProvider";
+import type { Permissions } from "#/modules/permissions";
+import { MockChat, MockMCPServerConfig } from "#/testHelpers/chatEntities";
+import {
+	MockChatModel,
+	MockChatModelProviderDescriptor,
+} from "#/testHelpers/chatModels";
+import {
+	MockAIProviderOpenAI,
+	MockAppearanceConfig,
+	MockBuildInfo,
+	MockDefaultOrganization,
+	MockEntitlements,
+	MockNoPermissions,
+	MockUserOwner,
+} from "#/testHelpers/entities";
+import { createTestQueryClient } from "#/testHelpers/renderHelpers";
+import { mcpSelectionStorageKey } from "../components/MCPServerPicker";
+import {
+	type AgentChatSettings,
+	AgentChatSettingsProvider,
+	useAgentChatSettings,
+} from "./AgentChatSettingsContext";
+
+// The provider only reads permissions from the auth context.
+let permissions: Permissions = MockNoPermissions;
+
+vi.mock("#/hooks/useAuthenticated", () => ({
+	useAuthenticated: () => ({
+		user: MockUserOwner,
+		permissions,
+		signOut: vi.fn(),
+	}),
+}));
+
+const ORGANIZATION_ID = "settings-organization";
+
+const HISTORICAL_MODEL_ID = "model-historical";
+const DEFAULT_MODEL_ID = "model-default";
+const ALTERNATE_MODEL_ID = "model-alternate";
+
+const buildModel = (
+	id: string,
+	overrides: Partial<TypesGen.ChatModel> = {},
+): TypesGen.ChatModel => ({
+	...MockChatModel,
+	id,
+	organization_id: ORGANIZATION_ID,
+	ai_provider_id: MockChatModelProviderDescriptor.id,
+	model: id,
+	display_name: id,
+	is_default: false,
+	...overrides,
+});
+
+const buildCatalog = (
+	models: readonly TypesGen.ChatModel[],
+): TypesGen.OrganizationChatModelsResponse => ({
+	models: [...models],
+	providers: [MockChatModelProviderDescriptor],
+	unsupported_providers: [],
+});
+
+const DEFAULT_ON_SERVER: TypesGen.MCPServerConfig = {
+	...MockMCPServerConfig,
+	id: "mcp-default-on",
+	organization_id: ORGANIZATION_ID,
+	slug: "mcp-default-on",
+	availability: "default_on",
+};
+
+const OPT_IN_SERVER: TypesGen.MCPServerConfig = {
+	...MockMCPServerConfig,
+	id: "mcp-opt-in",
+	organization_id: ORGANIZATION_ID,
+	slug: "mcp-opt-in",
+	availability: "default_off",
+};
+
+const MCP_SERVERS = [DEFAULT_ON_SERVER, OPT_IN_SERVER];
+
+const DEFAULT_CATALOG = buildCatalog([buildModel(HISTORICAL_MODEL_ID)]);
+
+// A provider the catalog reports as available, so it counts as configured.
+const CONFIGURED_PROVIDER: TypesGen.AIProvider = {
+	...MockAIProviderOpenAI,
+	id: MockChatModelProviderDescriptor.id,
+	enabled: true,
+};
+
+const LATE_SERVER: TypesGen.MCPServerConfig = {
+	...MockMCPServerConfig,
+	id: "mcp-authorized",
+	organization_id: ORGANIZATION_ID,
+	slug: "mcp-authorized",
+	availability: "default_off",
+};
+
+const buildChat = (overrides: Partial<TypesGen.Chat> = {}): TypesGen.Chat => ({
+	...MockChat,
+	organization_id: ORGANIZATION_ID,
+	last_model_config_id: HISTORICAL_MODEL_ID,
+	...overrides,
+});
+
+const dashboardValue: DashboardValue = {
+	entitlements: MockEntitlements,
+	experiments: [],
+	appearance: MockAppearanceConfig,
+	buildInfo: MockBuildInfo,
+	// The chat organization is not the default one, so the legacy unscoped MCP
+	// selection stays out of these cases.
+	organizations: [
+		MockDefaultOrganization,
+		{
+			...MockDefaultOrganization,
+			id: ORGANIZATION_ID,
+			name: "settings-org",
+			display_name: "Settings Org",
+			is_default: false,
+		},
+	],
+	showOrganizations: true,
+	canViewOrganizationSettings: false,
+};
+
+/** The settings a consumer observed when the user asked it to report. */
+type SettingsReport = {
+	selectedModel: string;
+	selectedMCPServerIds: readonly string[];
+	mcpServerIds: readonly string[];
+	hasPickedReasoningEffort: boolean;
+	canConfigureAgentSetup: boolean;
+	providerCount: number | undefined;
+};
+
+const toReport = (settings: AgentChatSettings): SettingsReport => ({
+	selectedModel: settings.selectedModel,
+	selectedMCPServerIds: settings.selectedMCPServerIds,
+	mcpServerIds: settings.mcpServers.map((server) => server.id),
+	hasPickedReasoningEffort: settings.hasPickedReasoningEffort,
+	canConfigureAgentSetup: settings.canConfigureAgentSetup,
+	providerCount: settings.providerCount,
+});
+
+/**
+ * A consumer that reports what it currently reads from the context, so a
+ * change another consumer made is observable without inspecting the provider.
+ */
+const SettingsReporter: FC<{ onReport: (report: SettingsReport) => void }> = ({
+	onReport,
+}) => {
+	const settings = useAgentChatSettings();
+	return (
+		<button type="button" onClick={() => onReport(toReport(settings))}>
+			Report settings
+		</button>
+	);
+};
+
+/** A separate consumer that changes the settings the reporter reads. */
+const SettingsEditor: FC = () => {
+	const settings = useAgentChatSettings();
+	return (
+		<>
+			<button
+				type="button"
+				onClick={() => settings.onModelChange(ALTERNATE_MODEL_ID)}
+			>
+				Use alternate model
+			</button>
+			<button
+				type="button"
+				onClick={() => settings.onReasoningEffortChange("high")}
+			>
+				Use high reasoning effort
+			</button>
+			<button type="button" onClick={settings.resetPickedReasoningEffort}>
+				Reset reasoning effort pick
+			</button>
+			<button type="button" onClick={() => settings.onMCPSelectionChange([])}>
+				Clear MCP servers
+			</button>
+			<button
+				type="button"
+				onClick={() => settings.onMCPSelectionChange([OPT_IN_SERVER.id])}
+			>
+				Use opt-in MCP server
+			</button>
+			<button
+				type="button"
+				onClick={() => settings.onMCPAuthComplete(OPT_IN_SERVER.id)}
+			>
+				Finish MCP auth
+			</button>
+		</>
+	);
+};
+
+const renderSettings = ({
+	chat,
+	catalog = DEFAULT_CATALOG,
+}: {
+	chat: TypesGen.Chat | undefined;
+	catalog?: TypesGen.OrganizationChatModelsResponse;
+}) => {
+	const queryClient = createTestQueryClient();
+	// Seed the real query cache so the provider resolves its settings on the
+	// first render, the way it does from a warm cache in the app.
+	queryClient.setQueryData(organizationChatModelsKey(ORGANIZATION_ID), catalog);
+	queryClient.setQueryData(mcpServerConfigsKey(ORGANIZATION_ID), MCP_SERVERS);
+
+	const onReport = vi.fn<(report: SettingsReport) => void>();
+	const Wrapper: FC<PropsWithChildren> = ({ children }) => (
+		<QueryClientProvider client={queryClient}>
+			<DashboardContext.Provider value={dashboardValue}>
+				{children}
+			</DashboardContext.Provider>
+		</QueryClientProvider>
+	);
+
+	render(
+		<Wrapper>
+			<AgentChatSettingsProvider chat={chat}>
+				<SettingsEditor />
+				<SettingsReporter onReport={onReport} />
+			</AgentChatSettingsProvider>
+		</Wrapper>,
+	);
+
+	const clickButton = async (name: string) => {
+		await userEvent.click(screen.getByRole("button", { name }));
+	};
+
+	const readReport = async (): Promise<SettingsReport> => {
+		onReport.mockClear();
+		await clickButton("Report settings");
+		expect(onReport).toHaveBeenCalledTimes(1);
+		return onReport.mock.calls[0][0];
+	};
+
+	return { clickButton, readReport };
+};
+
+describe("AgentChatSettingsProvider", () => {
+	beforeEach(() => {
+		localStorage.clear();
+		permissions = MockNoPermissions;
+		vi.spyOn(API.experimental, "getChatModels").mockResolvedValue(
+			DEFAULT_CATALOG,
+		);
+		vi.spyOn(API.experimental, "getMCPServerConfigs").mockResolvedValue([
+			...MCP_SERVERS,
+		]);
+		vi.spyOn(API, "getAIProviders").mockResolvedValue([CONFIGURED_PROVIDER]);
+	});
+
+	afterEach(() => {
+		vi.restoreAllMocks();
+		localStorage.clear();
+	});
+
+	it("prefers the chat's historical model over the organization default", async () => {
+		const { readReport } = renderSettings({
+			chat: buildChat(),
+			catalog: buildCatalog([
+				buildModel(DEFAULT_MODEL_ID, { is_default: true }),
+				buildModel(HISTORICAL_MODEL_ID),
+			]),
+		});
+
+		await expect(readReport()).resolves.toMatchObject({
+			selectedModel: HISTORICAL_MODEL_ID,
+		});
+	});
+
+	it("falls back to the organization default when the historical model is gone", async () => {
+		const { readReport } = renderSettings({
+			chat: buildChat({ last_model_config_id: "model-deleted" }),
+			catalog: buildCatalog([
+				buildModel(ALTERNATE_MODEL_ID),
+				buildModel(DEFAULT_MODEL_ID, { is_default: true }),
+			]),
+		});
+
+		await expect(readReport()).resolves.toMatchObject({
+			selectedModel: DEFAULT_MODEL_ID,
+		});
+	});
+
+	it("applies a user's model choice to other consumers immediately", async () => {
+		const { clickButton, readReport } = renderSettings({
+			chat: buildChat(),
+			catalog: buildCatalog([
+				buildModel(HISTORICAL_MODEL_ID),
+				buildModel(ALTERNATE_MODEL_ID),
+			]),
+		});
+
+		await expect(readReport()).resolves.toMatchObject({
+			selectedModel: HISTORICAL_MODEL_ID,
+		});
+
+		await clickButton("Use alternate model");
+
+		await expect(readReport()).resolves.toMatchObject({
+			selectedModel: ALTERNATE_MODEL_ID,
+		});
+	});
+
+	it("tracks a deliberate reasoning effort pick until it is reset", async () => {
+		const { clickButton, readReport } = renderSettings({
+			chat: buildChat(),
+		});
+
+		await expect(readReport()).resolves.toMatchObject({
+			hasPickedReasoningEffort: false,
+		});
+
+		await clickButton("Use high reasoning effort");
+		await expect(readReport()).resolves.toMatchObject({
+			hasPickedReasoningEffort: true,
+		});
+
+		await clickButton("Reset reasoning effort pick");
+		await expect(readReport()).resolves.toMatchObject({
+			hasPickedReasoningEffort: false,
+		});
+	});
+
+	it("keeps a chat's empty MCP selection over the saved organization one", async () => {
+		localStorage.setItem(
+			mcpSelectionStorageKey(ORGANIZATION_ID),
+			JSON.stringify([OPT_IN_SERVER.id]),
+		);
+
+		const { readReport } = renderSettings({
+			chat: buildChat({ mcp_server_ids: [] }),
+		});
+
+		await expect(readReport()).resolves.toMatchObject({
+			selectedMCPServerIds: [],
+		});
+	});
+
+	it("prefers a user's MCP selection over the chat's", async () => {
+		const { clickButton, readReport } = renderSettings({
+			chat: buildChat({ mcp_server_ids: [DEFAULT_ON_SERVER.id] }),
+		});
+
+		await clickButton("Use opt-in MCP server");
+
+		await expect(readReport()).resolves.toMatchObject({
+			selectedMCPServerIds: [OPT_IN_SERVER.id],
+		});
+	});
+
+	it("persists an empty MCP selection so the opt-out survives a reload", async () => {
+		const { clickButton, readReport } = renderSettings({
+			chat: buildChat({ mcp_server_ids: [DEFAULT_ON_SERVER.id] }),
+		});
+
+		await clickButton("Clear MCP servers");
+
+		await expect(readReport()).resolves.toMatchObject({
+			selectedMCPServerIds: [],
+		});
+		expect(localStorage.getItem(mcpSelectionStorageKey(ORGANIZATION_ID))).toBe(
+			"[]",
+		);
+	});
+
+	it("refetches the MCP servers after an auth flow completes", async () => {
+		const { clickButton, readReport } = renderSettings({ chat: buildChat() });
+		const getMCPServerConfigs = vi.mocked(API.experimental.getMCPServerConfigs);
+		// The server the user just authorized only appears once the provider
+		// refetches, so an unchanged report would mean the refetch never ran.
+		getMCPServerConfigs.mockResolvedValue([...MCP_SERVERS, LATE_SERVER]);
+
+		await expect(readReport()).resolves.toMatchObject({
+			mcpServerIds: MCP_SERVERS.map((server) => server.id),
+		});
+
+		await clickButton("Finish MCP auth");
+
+		await vi.waitFor(async () => {
+			await expect(readReport()).resolves.toMatchObject({
+				mcpServerIds: [...MCP_SERVERS, LATE_SERVER].map((server) => server.id),
+			});
+		});
+	});
+
+	it("leaves the provider catalog query disabled without deployment permission", async () => {
+		const { readReport } = renderSettings({ chat: buildChat() });
+
+		await expect(readReport()).resolves.toMatchObject({
+			canConfigureAgentSetup: false,
+			providerCount: undefined,
+		});
+		expect(API.getAIProviders).not.toHaveBeenCalled();
+	});
+
+	it("counts configured providers for a deployment administrator", async () => {
+		permissions = { ...MockNoPermissions, editDeploymentConfig: true };
+		const { readReport } = renderSettings({ chat: buildChat() });
+
+		await vi.waitFor(async () => {
+			await expect(readReport()).resolves.toMatchObject({
+				canConfigureAgentSetup: true,
+				providerCount: 1,
+			});
+		});
+	});
+
+	it("rejects consumers rendered outside the provider", () => {
+		const consoleError = vi
+			.spyOn(console, "error")
+			.mockImplementation(() => {});
+
+		expect(() => render(<SettingsReporter onReport={vi.fn()} />)).toThrow(
+			"useAgentChatSettings must be used within an AgentChatSettingsProvider",
+		);
+
+		consoleError.mockRestore();
+	});
+});

--- a/site/src/pages/AgentsPage/context/AgentChatSettingsContext.tsx
+++ b/site/src/pages/AgentsPage/context/AgentChatSettingsContext.tsx
@@ -1,0 +1,284 @@
+import {
+	createContext,
+	type FC,
+	type ReactNode,
+	useContext,
+	useState,
+} from "react";
+import { useQuery } from "react-query";
+import { chatProviderConfigs } from "#/api/queries/aiProviders";
+import { chatModels, mcpServerConfigs } from "#/api/queries/chats";
+import type * as TypesGen from "#/api/typesGenerated";
+import { useAuthenticated } from "#/hooks/useAuthenticated";
+import type { ModelSelectorOption } from "#/modules/aiModels/ModelSelector";
+import { useDashboard } from "#/modules/dashboard/useDashboard";
+import {
+	resolveMCPSelection,
+	saveMCPSelection,
+} from "../components/MCPServerPicker";
+import { getModelSelectorHelp } from "../components/ModelSelectorHelp";
+import {
+	countConfiguredProviderConfigs,
+	getModelSelectorPlaceholder,
+	getUnavailableModelNotice,
+	getUnsupportedProviderNames,
+	getUsableDefaultModelIDForOrganization,
+	hasUserFixableProviders,
+	resolveModelOptionId,
+	resolveModelSelector,
+} from "../utils/modelOptions";
+import { pickReasoningEffort } from "../utils/reasoningEffort";
+
+/**
+ * Model and MCP settings that decide what a chat submits. Sends, edits, plan
+ * implementation, and ask-user responses read the same resolved values as the
+ * composer, so changing a selector applies to the very next submission.
+ */
+export interface AgentChatSettings {
+	/** Selectable models for the chat organization. */
+	readonly modelOptions: readonly ModelSelectorOption[];
+	/** Catalog entries behind the options, used for compaction thresholds. */
+	readonly models: readonly TypesGen.ChatModel[] | undefined;
+	readonly hasModelOptions: boolean;
+	/**
+	 * True while the catalog is unresolved, including before the chat record
+	 * names an organization. Keeps the selector from flashing "No Models".
+	 */
+	readonly isModelCatalogLoading: boolean;
+	readonly modelCatalogError: unknown;
+	readonly modelSelectorPlaceholder: string;
+	readonly modelSelectorHelp: ReactNode | undefined;
+	readonly unavailableModelNotice: string | undefined;
+	readonly canConfigureAgentSetup: boolean;
+	readonly providerCount: number | undefined;
+	readonly modelCount: number | undefined;
+	readonly unsupportedProviderNames: readonly string[];
+	/** The model every submission uses, validated against the options. */
+	readonly selectedModel: string;
+	readonly onModelChange: (modelID: string) => void;
+	readonly reasoningEffort: string | undefined;
+	/** Records a deliberate effort pick, which an in-progress edit sends. */
+	readonly onReasoningEffortChange: (reasoningEffort: string) => void;
+	/**
+	 * Whether the user picked an effort since the last reset. An edit sends
+	 * `reasoning_effort` only when the user picked one for that edit, so the
+	 * backend keeps the original effort otherwise.
+	 */
+	readonly hasPickedReasoningEffort: boolean;
+	/** Clears {@link hasPickedReasoningEffort}. Call when an edit begins. */
+	readonly resetPickedReasoningEffort: () => void;
+	readonly mcpServers: readonly TypesGen.MCPServerConfig[];
+	/** The MCP servers every submission uses. */
+	readonly selectedMCPServerIds: readonly string[];
+	readonly onMCPSelectionChange: (ids: string[]) => void;
+	readonly onMCPAuthComplete: (serverId: string) => void;
+}
+
+const AgentChatSettingsContext = createContext<AgentChatSettings | undefined>(
+	undefined,
+);
+
+/**
+ * Returns the canonical submission settings for the current chat. Must be used
+ * within an `AgentChatSettingsProvider`.
+ */
+export const useAgentChatSettings = (): AgentChatSettings => {
+	const settings = useContext(AgentChatSettingsContext);
+	if (settings === undefined) {
+		throw new Error(
+			"useAgentChatSettings must be used within an AgentChatSettingsProvider",
+		);
+	}
+	return settings;
+};
+
+interface AgentChatSettingsProviderProps {
+	/** The open chat, or undefined while it loads. */
+	chat: TypesGen.Chat | undefined;
+	children: ReactNode;
+}
+
+interface AgentChatSettingsValueProviderProps {
+	settings: AgentChatSettings;
+	children: ReactNode;
+}
+
+/**
+ * Provides settings from an explicit value instead of the queries.
+ *
+ * @internal Intended for tests and stories that render one isolated settings
+ * state, including states the query cache cannot represent, such as a cached
+ * catalog whose refetch failed. It exists so the context itself stays private:
+ * a narrow seam that only accepts a complete {@link AgentChatSettings} is safer
+ * than exporting the raw context. Production code uses
+ * {@link AgentChatSettingsProvider}.
+ */
+export const AgentChatSettingsValueProvider: FC<
+	AgentChatSettingsValueProviderProps
+> = ({ settings, children }) => (
+	<AgentChatSettingsContext value={settings}>
+		{children}
+	</AgentChatSettingsContext>
+);
+
+export const AgentChatSettingsProvider: FC<AgentChatSettingsProviderProps> = ({
+	chat,
+	children,
+}) => {
+	const { permissions } = useAuthenticated();
+	const { organizations } = useDashboard();
+	const organizationId = chat?.organization_id ?? "";
+
+	const [userSelectedModel, setUserSelectedModel] = useState("");
+	const [userSelectedReasoningEffort, setUserSelectedReasoningEffort] =
+		useState("");
+	const [hasPickedReasoningEffort, setHasPickedReasoningEffort] =
+		useState(false);
+	const [userSelectedMCPServerIds, setUserSelectedMCPServerIds] = useState<
+		string[] | null
+	>(null);
+
+	const modelsQuery = useQuery(chatModels(organizationId));
+	const chatProviderConfigsQuery = useQuery({
+		...chatProviderConfigs(),
+		enabled: permissions.editDeploymentConfig,
+	});
+	const mcpServersQuery = useQuery({
+		...mcpServerConfigs(organizationId),
+		enabled: Boolean(organizationId),
+	});
+
+	const models = modelsQuery.data?.models;
+	const {
+		options: modelOptions,
+		isModelCatalogLoading,
+		modelCatalog,
+		hasConfiguredModels,
+	} = resolveModelSelector(organizationId, modelsQuery);
+	const isModelDataPending = organizationId === "" || isModelCatalogLoading;
+	const hasModelOptions = modelOptions.length > 0;
+	const providerCount =
+		permissions.editDeploymentConfig &&
+		chatProviderConfigsQuery.data &&
+		modelsQuery.data
+			? countConfiguredProviderConfigs(
+					chatProviderConfigsQuery.data,
+					modelsQuery.data,
+				)
+			: undefined;
+
+	// Validate explicit and historical choices against organization options.
+	// Prefer the usable organization default before another organization model.
+	const selectedModel = (() => {
+		const resolvedUserSelection = resolveModelOptionId(
+			userSelectedModel,
+			modelOptions,
+		);
+		if (resolvedUserSelection) {
+			return resolvedUserSelection;
+		}
+
+		const resolvedChatModel = resolveModelOptionId(
+			chat?.last_model_config_id,
+			modelOptions,
+		);
+		if (resolvedChatModel) {
+			return resolvedChatModel;
+		}
+
+		return (
+			getUsableDefaultModelIDForOrganization(
+				models,
+				modelOptions,
+				organizationId,
+			) ||
+			modelOptions[0]?.id ||
+			""
+		);
+	})();
+
+	const selectedModelOption = modelOptions.find(
+		(option) => option.id === selectedModel,
+	);
+	const reasoningEffort = selectedModelOption
+		? pickReasoningEffort(
+				userSelectedReasoningEffort || chat?.last_reasoning_effort,
+				selectedModelOption.reasoningEfforts ?? [],
+				selectedModelOption.reasoningEffortDefault,
+			)
+		: undefined;
+
+	const modelSelectorPlaceholder = getModelSelectorPlaceholder(
+		modelOptions,
+		isModelDataPending,
+		hasConfiguredModels,
+		modelCatalog,
+	);
+	const modelSelectorHelp = getModelSelectorHelp({
+		isModelCatalogLoading: isModelDataPending,
+		hasModelOptions,
+		hasConfiguredModels,
+		hasUserFixableModelProviders: hasUserFixableProviders(modelCatalog),
+	});
+	const unavailableModelNotice = getUnavailableModelNotice({
+		hasResolvedModelData:
+			!isModelDataPending && Boolean(modelsQuery.data) && !modelsQuery.error,
+		storedModelRef: chat?.last_model_config_id,
+		modelOptions,
+		catalog: modelCatalog,
+	});
+
+	const mcpServers = mcpServersQuery.data ?? [];
+	const isDefaultChatOrganization = organizations.some(
+		(organization) =>
+			organization.id === organizationId && organization.is_default,
+	);
+	const selectedMCPServerIds = resolveMCPSelection({
+		userSelection: userSelectedMCPServerIds,
+		chatSelection: chat?.mcp_server_ids,
+		organizationId,
+		servers: mcpServers,
+		isDefaultOrganization: isDefaultChatOrganization,
+	});
+
+	const settings: AgentChatSettings = {
+		modelOptions,
+		models,
+		hasModelOptions,
+		isModelCatalogLoading: isModelDataPending,
+		modelCatalogError: modelsQuery.error,
+		modelSelectorPlaceholder,
+		modelSelectorHelp,
+		unavailableModelNotice,
+		canConfigureAgentSetup: permissions.editDeploymentConfig,
+		providerCount,
+		modelCount: modelsQuery.data ? modelOptions.length : undefined,
+		unsupportedProviderNames: getUnsupportedProviderNames(modelsQuery.data),
+		selectedModel,
+		onModelChange: setUserSelectedModel,
+		reasoningEffort,
+		onReasoningEffortChange: (nextReasoningEffort: string) => {
+			setUserSelectedReasoningEffort(nextReasoningEffort);
+			setHasPickedReasoningEffort(true);
+		},
+		hasPickedReasoningEffort,
+		resetPickedReasoningEffort: () => setHasPickedReasoningEffort(false),
+		mcpServers,
+		selectedMCPServerIds,
+		onMCPSelectionChange: (ids: string[]) => {
+			setUserSelectedMCPServerIds(ids);
+			if (organizationId) {
+				saveMCPSelection(organizationId, ids);
+			}
+		},
+		onMCPAuthComplete: () => {
+			void mcpServersQuery.refetch();
+		},
+	};
+
+	return (
+		<AgentChatSettingsContext value={settings}>
+			{children}
+		</AgentChatSettingsContext>
+	);
+};


### PR DESCRIPTION
> 🤖 This PR was written by Coder Agents on behalf of Jake Howell.

Introduces one canonical owner for the model and MCP settings used by chat submissions.

`AgentChatSettingsProvider` now loads model and MCP data, resolves selector presentation and fallback choices, persists MCP changes, and exposes the same current settings to both the composer and every send path. `AgentChatPage` retains chat opening, message hydration, mutations, watchers, branching, and the keyed scroller while dropping the model and MCP prop chains through the view.

The narrow `AgentChatSettingsValueProvider` is an internal story seam for isolated states that cannot be represented by query-cache data, such as cached model data with a failed refetch. Production code always uses the query-backed provider.

Depends on #29166

<details>
<summary>Implementation plan</summary>

This is the final PR in the AgentChatPage data-ownership stack. The provider sits inside the agent-keyed remount boundary and above the controller and composer, so selection state resets between chats while composer sends, edits, plan implementation, and ask-user responses always read one canonical value without effect- or ref-based synchronization.

The page continues to own `openChat` and its binding-repair polling, infinite message hydration, `useChatStore`, `useGitWatcher`, `useChatToolInvalidations`, loading/error/not-found branching, and the keyed `MessageScroller` wrapper.

</details>
