### PR TITLE
feat: add exp launch claude command

### DIFF
--- a/enterprise/cli/exp_launch.go
+++ b/enterprise/cli/exp_launch.go
@@ -1,0 +1,106 @@
+package cli
+
+import (
+	"os"
+	"os/exec"
+	"strings"
+
+	"golang.org/x/xerrors"
+
+	agplcli "github.com/coder/coder/v2/cli"
+	"github.com/coder/serpent"
+)
+
+func (r *RootCmd) expLaunch() *serpent.Command {
+	var gatewayURL, provider, model string
+
+	return &serpent.Command{
+		Use:   "launch <client> [-- <client args>]",
+		Short: "Launch a coding agent configured to use AI Gateway (experimental)",
+		Long: "Launches the client with its API pointed at this deployment's AI Gateway,\n" +
+			"authenticated with your Coder session token.\n\n" +
+			"Supported clients: claude.\n\n" +
+			"Flags belonging to the client must come after `--`; flags before it are\n" +
+			"parsed by Coder and rejected if unknown.",
+		Middleware: serpent.RequireRangeArgs(1, -1),
+		Options: serpent.OptionSet{
+			{
+				Flag:        "gateway-url",
+				Env:         "CODER_AI_GATEWAY_URL",
+				Description: "AI Gateway URL. Defaults to this deployment's gateway.",
+				Value:       serpent.StringOf(&gatewayURL),
+			},
+			{
+				Flag:        "provider",
+				Default:     "anthropic",
+				Description: "AI Gateway provider to route through.",
+				Value:       serpent.StringOf(&provider),
+			},
+			{
+				Flag:        "model",
+				Description: "Model to pass to the client.",
+				Value:       serpent.StringOf(&model),
+			},
+		},
+		Handler: func(inv *serpent.Invocation) error {
+			if inv.Args[0] != "claude" {
+				return xerrors.Errorf("unknown client %q; supported: claude", inv.Args[0])
+			}
+
+			client, err := r.InitClient(inv)
+			if err != nil {
+				return err
+			}
+			token := client.SessionToken()
+			if token == "" {
+				return xerrors.New("not logged in; run 'coder login'")
+			}
+			if gatewayURL == "" {
+				gatewayURL = client.URL.JoinPath("/api/v2/ai-gateway").String()
+			}
+			gatewayURL = strings.TrimRight(gatewayURL, "/")
+
+			bin, err := exec.LookPath("claude")
+			if err != nil {
+				return xerrors.Errorf("claude not found in PATH; install: https://docs.claude.com/en/docs/claude-code/setup")
+			}
+
+			var args []string
+			if model != "" {
+				args = append(args, "--model", model)
+			}
+			args = append(args, inv.Args[1:]...)
+
+			//nolint:gosec // The binary is resolved from PATH by design.
+			cmd := exec.CommandContext(inv.Context(), bin, args...)
+			cmd.Env = append(scrubbedEnv(),
+				"ANTHROPIC_BASE_URL="+gatewayURL+"/"+provider,
+				"ANTHROPIC_AUTH_TOKEN="+token,
+			)
+			cmd.Stdin, cmd.Stdout, cmd.Stderr = inv.Stdin, inv.Stdout, inv.Stderr
+
+			if err := cmd.Run(); err != nil {
+				exitErr := &exec.ExitError{}
+				if xerrors.As(err, &exitErr) {
+					return agplcli.ExitError(exitErr.ExitCode(), nil)
+				}
+				return err
+			}
+			return nil
+		},
+	}
+}
+
+// scrubbedEnv returns the environment without the variables that would
+// re-route the client away from the gateway.
+func scrubbedEnv() []string {
+	all := os.Environ()
+	env := make([]string, 0, len(all))
+	for _, kv := range all {
+		if strings.HasPrefix(kv, "ANTHROPIC_") || strings.HasPrefix(kv, "CLAUDE_CODE_USE_") {
+			continue
+		}
+		env = append(env, kv)
+	}
+	return env
+}

--- a/enterprise/cli/exp_launch.go
+++ b/enterprise/cli/exp_launch.go
@@ -62,7 +62,7 @@ func (r *RootCmd) expLaunch() *serpent.Command {
 
 			bin, err := exec.LookPath("claude")
 			if err != nil {
-				return xerrors.Errorf("claude not found in PATH; install: https://docs.claude.com/en/docs/claude-code/setup")
+				return xerrors.Errorf("claude not found in PATH; install: https://code.claude.com/docs/en/setup")
 			}
 
 			var args []string

--- a/enterprise/cli/exp_launch_test.go
+++ b/enterprise/cli/exp_launch_test.go
@@ -1,0 +1,133 @@
+package cli_test
+
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// fakeClaude puts a stub `claude` on PATH that dumps its environment and args
+// to a file, then exits with $EXIT. It returns the dump's path.
+func fakeClaude(t *testing.T) string {
+	t.Helper()
+
+	bin := t.TempDir()
+	script := "#!/bin/sh\nenv > \"$OUT\"\necho \"$@\" >> \"$OUT\"\nexit \"${EXIT:-0}\"\n"
+	require.NoError(t, os.WriteFile(filepath.Join(bin, "claude"), []byte(script), 0o755)) //nolint:gosec
+
+	out := filepath.Join(t.TempDir(), "dump")
+	t.Setenv("PATH", bin+string(os.PathListSeparator)+os.Getenv("PATH"))
+	t.Setenv("OUT", out)
+	return out
+}
+
+// TestExpLaunch exercises `coder exp launch` against a stub client binary. It
+// cannot be parallel because it uses t.Setenv.
+//
+//nolint:paralleltest,tparallel
+func TestExpLaunch(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("The stub client is a /bin/sh script.")
+	}
+
+	t.Run("LaunchesClaudeWithGatewayEnvAndPassthroughArgs", func(t *testing.T) {
+		// Given: inherited vars that would re-route Claude Code off the gateway.
+		t.Setenv("CLAUDE_CODE_USE_BEDROCK", "1")
+		t.Setenv("ANTHROPIC_API_KEY", "stale")
+		out := fakeClaude(t)
+
+		inv, _ := newCLI(t, "exp", "launch", "claude",
+			"--url", "https://c.example.com", "--token", "tok",
+			"--provider", "bedrock", "--model", "m",
+			"--", "--dangerously-skip-permissions")
+
+		// When: the client is launched.
+		require.NoError(t, inv.Run())
+
+		// Then: it is pointed at the deployment's gateway with the Coder
+		// session token, the stale vars are gone, and the args pass through.
+		dump, err := os.ReadFile(out)
+		require.NoError(t, err)
+		lines := strings.Split(strings.TrimRight(string(dump), "\n"), "\n")
+		require.Contains(t, lines, "ANTHROPIC_BASE_URL=https://c.example.com/api/v2/ai-gateway/bedrock")
+		require.Contains(t, lines, "ANTHROPIC_AUTH_TOKEN=tok")
+		require.NotContains(t, lines, "CLAUDE_CODE_USE_BEDROCK=1")
+		require.NotContains(t, lines, "ANTHROPIC_API_KEY=stale")
+		require.Equal(t, "--model m --dangerously-skip-permissions", lines[len(lines)-1])
+	})
+
+	t.Run("PrefersTheGatewayURLFlag", func(t *testing.T) {
+		out := fakeClaude(t)
+
+		inv, _ := newCLI(t, "exp", "launch", "claude",
+			"--url", "https://c.example.com", "--token", "tok",
+			"--gateway-url", "https://gw.example.com/")
+
+		// When: an explicit gateway is given with a trailing slash.
+		require.NoError(t, inv.Run())
+
+		// Then: it replaces the derived URL, without a doubled slash.
+		dump, err := os.ReadFile(out)
+		require.NoError(t, err)
+		require.Contains(t, strings.Split(string(dump), "\n"), "ANTHROPIC_BASE_URL=https://gw.example.com/anthropic")
+	})
+
+	t.Run("RejectsAnUnknownClient", func(t *testing.T) {
+		fakeClaude(t)
+
+		inv, _ := newCLI(t, "exp", "launch", "nope",
+			"--url", "https://c.example.com", "--token", "tok")
+
+		// When: a client we do not support is named.
+		err := inv.Run()
+
+		// Then: the error names it and lists what is supported.
+		require.Error(t, err)
+		require.Contains(t, err.Error(), `unknown client "nope"`)
+		require.Contains(t, err.Error(), "claude")
+	})
+
+	t.Run("SaysWhenTheClientIsNotInstalled", func(t *testing.T) {
+		t.Setenv("PATH", t.TempDir())
+
+		inv, _ := newCLI(t, "exp", "launch", "claude",
+			"--url", "https://c.example.com", "--token", "tok")
+
+		// When: claude is not on PATH. Then: the error says how to install it.
+		err := inv.Run()
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "claude not found in PATH")
+	})
+
+	t.Run("RequiresALogin", func(t *testing.T) {
+		fakeClaude(t)
+
+		inv, _ := newCLI(t, "exp", "launch", "claude", "--url", "https://c.example.com")
+
+		// When: there is no session token. Then: the error says how to get one.
+		err := inv.Run()
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "coder login")
+	})
+
+	t.Run("PropagatesTheClientExitCode", func(t *testing.T) {
+		fakeClaude(t)
+		t.Setenv("EXIT", "3")
+
+		inv, _ := newCLI(t, "exp", "launch", "claude",
+			"--url", "https://c.example.com", "--token", "tok")
+
+		// When: the client exits non-zero.
+		err := inv.Run()
+
+		// Then: the CLI exits with the same code.
+		require.Error(t, err)
+		var exitErr interface{ ExitCode() int }
+		require.ErrorAs(t, err, &exitErr)
+		require.Equal(t, 3, exitErr.ExitCode())
+	})
+}

--- a/enterprise/cli/root.go
+++ b/enterprise/cli/root.go
@@ -34,6 +34,7 @@ func (r *RootCmd) enterpriseOnly() []*serpent.Command {
 func (r *RootCmd) enterpriseExperimental() []*serpent.Command {
 	return []*serpent.Command{
 		r.aiModelPricesCommand(),
+		r.expLaunch(),
 	}
 }
 


### PR DESCRIPTION
Adds `coder exp launch claude [--provider p] [--model m] [--gateway-url u] [-- <claude args>]`, an experimental command that runs Claude Code pointed at this deployment's AI Gateway using the CLI's session token. Inspired by `ollama launch`.

- Env only (`ANTHROPIC_BASE_URL`, `ANTHROPIC_AUTH_TOKEN`); nothing written to disk.
- Inherited `ANTHROPIC_*` / `CLAUDE_CODE_USE_*` are scrubbed so template-set BYOK vars can't bypass the gateway.
- Child exit code is propagated.
- No server calls; test uses a stub `claude` on `PATH`, no coderd.

Follow-ups: `opencode` (inline `OPENCODE_CONFIG_CONTENT`), `codex` (sidecar profile).

<details>
<summary>Implementation plan</summary>

# Plan: `coder exp launch claude`

## Context

Configuring coding agents to talk to AI Gateway means hand-setting base URLs,
tokens and (for some clients) config files. `ollama launch` solves the same
problem for Ollama. We add an experimental Coder CLI command that launches a
coding agent pre-configured for the AI Gateway of the deployment the CLI is
logged into.

Inspiration taken from `ollama launch` (ollama/ollama `cmd/launch/*`):

- Claude Code is configured purely via env vars; nothing is written to disk.
- Child is run with `os/exec`, inherited stdio, `os.Environ()` + overrides.
- Args after `--` are passed through to the child.
- Not installed: error with an install hint.
- Tests: table tests on generated env/args; fake `#!/bin/sh` binary on `PATH`.

Deliberately *not* copied in v1: model picker, install prompt, state file,
config-file merging/backups, cloud/local logic.

## Scope (PR 1 of 3)

| PR | Client   | Mechanism                                             |
|----|----------|-------------------------------------------------------|
| 1  | claude   | env vars only                                          |
| 2  | opencode | env var `OPENCODE_CONFIG_CONTENT=<json>` only          |
| 3  | codex    | sidecar profile file + `--profile` + `-c` overrides    |

This plan covers PR 1 only, but the shape must let 2 and 3 be additive.

## Decisions (recommended defaults; flagged ones need confirmation)

| # | Decision | Choice |
|---|----------|--------|
| D1 | Command path | `coder exp launch <client> [flags] [-- <client args>]`. Flat child of `exp`, registered via `enterpriseExperimental()`. Naming bikeshed deferred to graduation. |
| D2 | Gateway URL | `--gateway-url` / `CODER_AI_GATEWAY_URL`; default derived from the CLI's Coder URL: `<client.URL>/api/v2/ai-gateway`. |
| D3 | Provider | `--provider` (default per client; `anthropic` for claude). Not validated against `client.AIProviders()` (permission-gated, extra round trip). Wrong name → gateway returns 404 at first request. |
| D4 | Auth | Centralized mode only: Coder session token from `client.SessionToken()`. Empty token → error `not logged in; run 'coder login'`. BYOK out of scope. |
| D5 | Model | `--model` optional. When set, appended as `--model <m>` to the child args. No `ANTHROPIC_DEFAULT_*_MODEL` env in v1. |
| D6 | Exec | `exec.CommandContext`, stdio = `inv.Stdin/Stdout/Stderr`, `Env = filtered os.Environ() + overrides`. Child `*exec.ExitError` → `agplcli.ExitError(code, nil)` (precedent `cli/ssh.go:725`) so the exit code propagates. |
| D9 | Inherited env | Strip inherited vars that would silently re-route Claude Code away from the gateway: any `ANTHROPIC_*` and `CLAUDE_CODE_USE_*` (covers `CLAUDE_CODE_USE_BEDROCK/VERTEX`, `ANTHROPIC_CUSTOM_HEADERS`, `ANTHROPIC_API_KEY`, `ANTHROPIC_MODEL`). Workspace templates commonly set these for BYOK. |
| D7 | Not installed | `exec.LookPath` fails → `xerrors.Errorf("claude not found in PATH; install: https://docs.claude.com/en/docs/claude-code/setup")`. No auto-install. |
| D8 | Server contact | None. `InitClient` reads URL/token from disk only, so no API calls and no coderd needed in tests. |

## Claude env contract

```
ANTHROPIC_BASE_URL   = <gateway-url>/<provider>          e.g. https://dogfood.cdr.dev/api/v2/ai-gateway/anthropic
ANTHROPIC_AUTH_TOKEN = <coder session token>
```

Exactly what `docs/ai-coder/ai-gateway/clients/claude-code.md` documents for
centralized mode. No `ANTHROPIC_API_KEY=""` (set-but-empty is not unset;
D9 removes it instead).

Args: `[--model <m>]` + everything after `--`.

## Files

- `enterprise/cli/exp_launch.go` — new. Command + `claudeEnv()`.
- `enterprise/cli/exp_launch_test.go` — new. Fake-binary integration test (single test file).
- `enterprise/cli/root.go` — one line in `enterpriseExperimental()`.

No docs (exp commands are hidden from `clidocgen`). No codersdk changes.

## Shape

```go
switch client {
case "claude":
    bin, env, args = "claude", claudeEnv(gatewayURL, provider, token), modelArgs
default:
    return xerrors.Errorf("unknown client %q; supported: claude", client)
}
```

No struct, no map, no interface. PR 2/3 add a `case`.

## TDD

### Red

One test, `TestExpLaunch`, external package, one fake binary, zero
coderd. Skipped on Windows (precedent `cli/configssh_internal_test.go:161-171`;
CI does run Go tests on Windows, so exec has no Windows coverage — accepted).
`//nolint:paralleltest,tparallel` because of `t.Setenv` (precedent
`enterprise/cli/boundary_test.go:256`).

Setup: `bin := t.TempDir()`; write `bin/claude` (`0o755 //nolint:gosec`) as
`#!/bin/sh\nenv > "$OUT"\necho "$@" >> "$OUT"\nexit "${EXIT:-0}"`;
`t.Setenv("PATH", bin)`; `t.Setenv("OUT", outfile)`. Invoke via
`newCLI(t, "exp", "launch", ...)` with
`--url https://c.example.com --token tok` (dummy token; the env dump lands in
a temp file). `--gateway-url` env source (`CODER_AI_GATEWAY_URL`) is not
testable via `clitest` (no `Environ`); flag only.

| case | setup / args | expect |
|------|--------------|--------|
| happy + passthrough + env scrub | `t.Setenv("CLAUDE_CODE_USE_BEDROCK","1")`, `t.Setenv("ANTHROPIC_API_KEY","stale")`; `claude --provider bedrock --model m -- --dangerously-skip-permissions` | dump has `ANTHROPIC_BASE_URL=https://c.example.com/api/v2/ai-gateway/bedrock`, `ANTHROPIC_AUTH_TOKEN=tok`; has no `CLAUDE_CODE_USE_BEDROCK=` or `ANTHROPIC_API_KEY=` line; last line == `--model m --dangerously-skip-permissions` |
| gateway-url override, trailing slash | `claude --gateway-url https://gw.example.com/` | `ANTHROPIC_BASE_URL=https://gw.example.com/anthropic` |
| unknown client | `nope` | error contains `unknown client "nope"` and `claude` |
| not installed | `PATH` = empty dir; `claude` | error contains `claude not found in PATH` |
| no token | `claude` without `--token` | error contains `coder login` |
| exit code propagates | `t.Setenv("EXIT","3")`; `claude` | `errors.As(err, *agplcli.ExitError)`... assert code 3 via `agplcli.ExitError` type |

Six cases. Serpent `--` semantics verified: pflag drops `--`, `inv.Args` =
`["claude", "--dangerously-skip-permissions"]`; flags *before* `--` that
Claude owns will error at our leaf — document in `Long` help.

### Green

1. Add `exp_launch.go`: `expLaunch()` with options `--gateway-url` (env
   `CODER_AI_GATEWAY_URL`), `--provider` (default `anthropic`), `--model`;
   `Middleware: serpent.RequireRangeArgs(1, -1)`.
2. Handler: `switch` on client → `r.InitClient(inv)` → token check → gateway
   URL (`strings.TrimRight(url, "/")`) → `exec.LookPath` → filtered env +
   `claudeEnv()` → `exec.CommandContext` → `Run()` → map `ExitError`.
3. Register in `root.go`.
4. `go test ./enterprise/cli -run TestExpLaunch`.

### Refactor

- Delete anything with one caller that does not aid readability.
- Confirm `make lint/go` and `make fmt` pass.
- Ponytail check: no interface, no registry, no state file, no struct for one client.

## Verification

- `go test ./enterprise/cli -run 'Launch' -race`
- `make lint/go`
- Manual on dogfood: `coder exp launch claude -- -p "say hi"` from a
  workspace logged into dogfood.cdr.dev; confirm a session appears under
  AI Gateway sessions in the dashboard.
- Manual negative: `--provider bedrock` (exists on dogfood) works; `--provider
  nope` fails at first request with a gateway 404.
- Manual: on a machine with an existing Claude subscription login /
  `apiKeyHelper`, confirm the request still lands in AI Gateway sessions
  (env-var precedence is not unit-testable).

## Commit / PR

- Branch `cj/exp-launch` (off `main`).
- Commit: `feat(cli): add exp launch claude`.
- Draft PR only; body includes this plan collapsed and the Coder Agents
  disclosure.

## Resolved with user

- D1 flat `exp launch`; D2 include override, default from Coder URL; D9 scrub; D5 `--model` only.

</details>

---
*Generated by Coder Agents on behalf of @johnstcn.*