### PR TITLE
refactor(site/src/pages/AgentsPage): stop remounting API key panels to reset them

### DIFF
--- a/site/src/pages/AgentsPage/AgentSettingsAPIKeysPage.stories.tsx
+++ b/site/src/pages/AgentsPage/AgentSettingsAPIKeysPage.stories.tsx
@@ -1,11 +1,9 @@
 import type { Meta, StoryObj } from "@storybook/react-vite";
-import { expect, fn, userEvent, waitFor, within } from "storybook/test";
+import { spyOn, userEvent, within } from "storybook/test";
+import { API } from "#/api/api";
 import type { ChatModel, UserChatProviderConfig } from "#/api/typesGenerated";
 import { MockChatModel } from "#/testHelpers/chatModels";
-import {
-	AgentSettingsAPIKeysPageView,
-	type AgentSettingsAPIKeysPageViewProps,
-} from "./AgentSettingsAPIKeysPageView";
+import { AgentSettingsAPIKeysPageView } from "./AgentSettingsAPIKeysPageView";
 
 const createProvider = (
 	overrides: Partial<UserChatProviderConfig> &
@@ -46,29 +44,16 @@ const baseModel = createModel({
 
 const baseModels = [baseModel];
 
-const createProviderItems = (
-	providers: readonly UserChatProviderConfig[],
-): AgentSettingsAPIKeysPageViewProps["providerItems"] => {
-	return providers.map((provider) => ({
-		provider,
-		renderKey: `${provider.provider_id}-${provider.has_user_api_key}`,
-		isSaving: false,
-		isRemoving: false,
-	}));
-};
-
 const meta = {
 	title: "pages/AgentsPage/AgentSettingsAPIKeysPageView",
 	component: AgentSettingsAPIKeysPageView,
 	args: {
 		error: undefined,
 		isLoading: false,
-		providerItems: createProviderItems([baseProvider]),
+		providers: [baseProvider],
 		models: baseModels,
 		isModelsLoading: false,
 		areModelsUnavailable: false,
-		onSave: fn(),
-		onRemove: fn(),
 	},
 } satisfies Meta<typeof AgentSettingsAPIKeysPageView>;
 
@@ -79,7 +64,7 @@ export const Default: Story = {};
 
 export const WithSavedKey: Story = {
 	args: {
-		providerItems: createProviderItems([
+		providers: [
 			createProvider({
 				provider_id: "prov-1",
 				provider: "openai",
@@ -87,42 +72,35 @@ export const WithSavedKey: Story = {
 				has_user_api_key: true,
 				has_central_api_key_fallback: true,
 			}),
-		]),
+		],
 		models: baseModels,
 	},
 };
 
-export const MasksApiKeyInput: Story = {
+export const UserKeysDisabled: Story = {
 	args: {
-		providerItems: createProviderItems([
+		providers: [
 			createProvider({
 				provider_id: "prov-1",
 				provider: "openai",
 				display_name: "OpenAI",
-				has_user_api_key: true,
+				byok_enabled: false,
+				has_central_api_key_fallback: true,
 			}),
-		]),
-		models: [],
-	},
-	play: async ({ canvasElement }) => {
-		const canvas = within(canvasElement);
-		await expect(await canvas.findByLabelText(/API Key/i)).toHaveAttribute(
-			"type",
-			"password",
-		);
+		],
 	},
 };
 
 export const WithFallback: Story = {
 	args: {
-		providerItems: createProviderItems([
+		providers: [
 			createProvider({
 				provider_id: "prov-1",
 				provider: "anthropic",
 				display_name: "Anthropic",
 				has_central_api_key_fallback: true,
 			}),
-		]),
+		],
 		models: [
 			createModel({
 				id: "model-1",
@@ -136,7 +114,7 @@ export const WithFallback: Story = {
 
 export const MultipleProviders: Story = {
 	args: {
-		providerItems: createProviderItems([
+		providers: [
 			createProvider({
 				provider_id: "prov-openai",
 				provider: "openai",
@@ -155,7 +133,7 @@ export const MultipleProviders: Story = {
 				provider: "google",
 				display_name: "Google",
 			}),
-		]),
+		],
 		models: [
 			createModel({
 				id: "model-openai-1",
@@ -181,7 +159,7 @@ export const MultipleProviders: Story = {
 
 export const Empty: Story = {
 	args: {
-		providerItems: [],
+		providers: [],
 		models: [],
 	},
 };
@@ -189,7 +167,7 @@ export const Empty: Story = {
 export const Loading: Story = {
 	args: {
 		isLoading: true,
-		providerItems: [],
+		providers: [],
 		models: [],
 	},
 };
@@ -197,6 +175,13 @@ export const Loading: Story = {
 export const ModelsUnavailable: Story = {
 	args: {
 		areModelsUnavailable: true,
+		models: [],
+	},
+};
+
+export const ModelsLoading: Story = {
+	args: {
+		isModelsLoading: true,
 		models: [],
 	},
 };
@@ -209,23 +194,13 @@ export const SomeModelsUnavailable: Story = {
 
 export const SavingSingleProvider: Story = {
 	args: {
-		providerItems: [
-			{
-				provider: baseProvider,
-				renderKey: `${baseProvider.provider_id}-${baseProvider.has_user_api_key}`,
-				isSaving: true,
-				isRemoving: false,
-			},
-			{
-				provider: createProvider({
-					provider_id: "prov-2",
-					provider: "anthropic",
-					display_name: "Anthropic",
-				}),
-				renderKey: "prov-2-false",
-				isSaving: false,
-				isRemoving: false,
-			},
+		providers: [
+			baseProvider,
+			createProvider({
+				provider_id: "prov-2",
+				provider: "anthropic",
+				display_name: "Anthropic",
+			}),
 		],
 		models: [
 			...baseModels,
@@ -237,79 +212,58 @@ export const SavingSingleProvider: Story = {
 			}),
 		],
 	},
-};
-
-export const SavesProviderKey: Story = {
-	args: {
-		onSave: fn(),
-	},
-	play: async ({ canvasElement, args }) => {
+	play: async ({ canvasElement }) => {
+		spyOn(API.experimental, "upsertUserAIProviderKey").mockImplementation(
+			() => new Promise(() => {}),
+		);
 		const canvas = within(canvasElement);
-		const apiKeyInput = await canvas.findByLabelText("API Key");
-		await userEvent.type(apiKeyInput, "sk-test-key");
-		await userEvent.click(canvas.getByRole("button", { name: "Save" }));
-
-		await waitFor(() => {
-			expect(args.onSave).toHaveBeenCalledWith("prov-1", "sk-test-key");
-		});
+		const panel = within(
+			await canvas.findByRole("article", { name: "OpenAI" }),
+		);
+		await userEvent.type(panel.getByLabelText("API Key"), "sk-test-key");
+		await userEvent.click(panel.getByRole("button", { name: "Save" }));
 	},
 };
 
 export const RemovesProviderKey: Story = {
 	args: {
-		providerItems: createProviderItems([
+		providers: [
 			createProvider({
 				provider_id: "prov-1",
 				provider: "openai",
 				display_name: "OpenAI",
 				has_user_api_key: true,
 			}),
-		]),
-		onRemove: fn(),
+		],
 	},
-	play: async ({ canvasElement, args }) => {
+	play: async ({ canvasElement }) => {
 		const canvas = within(canvasElement);
-		const removeButton = await canvas.findByRole("button", { name: "Remove" });
-		await userEvent.click(removeButton);
-
-		const body = within(canvasElement.ownerDocument.body);
-		await waitFor(() =>
-			expect(body.getByText("Remove API key?")).toBeVisible(),
-		);
-		const dialog = await body.findByRole("dialog");
 		await userEvent.click(
-			within(dialog).getByRole("button", { name: "Remove" }),
+			await canvas.findByRole("button", { name: "Remove" }),
 		);
-
-		await waitFor(() => {
-			expect(args.onRemove).toHaveBeenCalledWith("prov-1");
-		});
 	},
 };
 
 export const ClearsMaskedApiKeyOnFocus: Story = {
 	args: {
-		providerItems: createProviderItems([
+		providers: [
 			createProvider({
 				provider_id: "prov-1",
 				provider: "openai",
 				display_name: "OpenAI",
 				has_user_api_key: true,
 			}),
-		]),
+		],
 	},
 	play: async ({ canvasElement }) => {
 		const canvas = within(canvasElement);
-		const apiKeyInput = await canvas.findByLabelText("API Key");
-		await expect(apiKeyInput).toHaveValue("••••••••••••••••");
-		await userEvent.click(apiKeyInput);
-		await expect(apiKeyInput).toHaveValue("");
+		await userEvent.click(await canvas.findByLabelText("API Key"));
 	},
 };
 
 export const ShowsProviderStatuses: Story = {
 	args: {
-		providerItems: createProviderItems([
+		providers: [
 			createProvider({
 				provider_id: "prov-openai",
 				provider: "openai",
@@ -331,7 +285,7 @@ export const ShowsProviderStatuses: Story = {
 				has_user_api_key: false,
 				has_central_api_key_fallback: false,
 			}),
-		]),
+		],
 		models: [
 			createModel({
 				id: "model-openai-1",

--- a/site/src/pages/AgentsPage/AgentSettingsAPIKeysPage.tsx
+++ b/site/src/pages/AgentsPage/AgentSettingsAPIKeysPage.tsx
@@ -1,101 +1,27 @@
 import type { FC } from "react";
-import { useState } from "react";
-import { useMutation, useQuery, useQueryClient } from "react-query";
-import { toast } from "sonner";
-import { getErrorDetail, getErrorMessage } from "#/api/errors";
-import {
-	deleteUserChatProviderKey,
-	upsertUserChatProviderKey,
-	userChatProviderConfigs,
-} from "#/api/queries/chats";
+import { useQuery } from "react-query";
+import { userChatProviderConfigs } from "#/api/queries/chats";
 import { useDashboard } from "#/modules/dashboard/useDashboard";
 import { AgentSettingsAPIKeysPageView } from "./AgentSettingsAPIKeysPageView";
 import { useOrganizationChatModels } from "./hooks/useOrganizationChatModels";
 
-const incrementResetToken = (
-	current: Record<string, number>,
-	providerConfigId: string,
-) => ({
-	...current,
-	[providerConfigId]: (current[providerConfigId] ?? 0) + 1,
-});
-
 const AgentSettingsAPIKeysPage: FC = () => {
-	const queryClient = useQueryClient();
 	const { organizations } = useDashboard();
 	const organizationModels = useOrganizationChatModels(
 		organizations.map((organization) => organization.id),
 	);
-	const [providerPanelResetTokens, setProviderPanelResetTokens] = useState<
-		Record<string, number>
-	>({});
-
 	const providersQuery = useQuery(userChatProviderConfigs());
-
-	const upsertMutationOptions = upsertUserChatProviderKey(queryClient);
-	const upsertMutation = useMutation({
-		...upsertMutationOptions,
-		onSuccess: async (_data, variables) => {
-			await upsertMutationOptions.onSuccess?.();
-			setProviderPanelResetTokens((current) =>
-				incrementResetToken(current, variables.providerConfigId),
-			);
-			toast.success("API key saved.");
-		},
-		onError: (mutationError) => {
-			toast.error(getErrorMessage(mutationError, "Error saving API key."), {
-				description: getErrorDetail(mutationError),
-			});
-		},
-	});
-
-	const deleteMutationOptions = deleteUserChatProviderKey(queryClient);
-	const deleteMutation = useMutation({
-		...deleteMutationOptions,
-		onSuccess: async (_data, variables) => {
-			await deleteMutationOptions.onSuccess?.();
-			setProviderPanelResetTokens((current) =>
-				incrementResetToken(current, variables),
-			);
-			toast.success("API key removed.");
-		},
-		onError: (mutationError) => {
-			toast.error(getErrorMessage(mutationError, "Error removing API key."), {
-				description: getErrorDetail(mutationError),
-			});
-		},
-	});
-
-	const providerItems = (providersQuery.data ?? []).map((provider) => ({
-		provider,
-		renderKey: `${provider.provider_id}-${provider.has_user_api_key}-${providerPanelResetTokens[provider.provider_id] ?? 0}`,
-		isSaving:
-			upsertMutation.isPending &&
-			upsertMutation.variables?.providerConfigId === provider.provider_id,
-		isRemoving:
-			deleteMutation.isPending &&
-			deleteMutation.variables === provider.provider_id,
-	}));
 
 	return (
 		<AgentSettingsAPIKeysPageView
 			error={providersQuery.error}
 			isLoading={providersQuery.isLoading}
-			providerItems={providerItems}
+			providers={providersQuery.data ?? []}
 			models={organizationModels.models}
 			isModelsLoading={organizationModels.isLoading}
 			areModelsUnavailable={Boolean(
 				organizationModels.error ?? organizationModels.partialError,
 			)}
-			onSave={(providerConfigId, apiKey) => {
-				upsertMutation.mutate({
-					providerConfigId,
-					req: { api_key: apiKey },
-				});
-			}}
-			onRemove={(providerConfigId) => {
-				deleteMutation.mutate(providerConfigId);
-			}}
 		/>
 	);
 };

--- a/site/src/pages/AgentsPage/AgentSettingsAPIKeysPageView.test.tsx
+++ b/site/src/pages/AgentsPage/AgentSettingsAPIKeysPageView.test.tsx
@@ -1,0 +1,217 @@
+import { render, screen, waitFor, within } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import type { ReactElement } from "react";
+import { QueryClientProvider } from "react-query";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { API } from "#/api/api";
+import type {
+	UserAIProviderKeyConfig,
+	UserChatProviderConfig,
+} from "#/api/typesGenerated";
+import { createTestQueryClient } from "#/testHelpers/renderHelpers";
+import {
+	AgentSettingsAPIKeysPageView,
+	type AgentSettingsAPIKeysPageViewProps,
+} from "./AgentSettingsAPIKeysPageView";
+
+const createProvider = (
+	overrides: Partial<UserChatProviderConfig> &
+		Pick<UserChatProviderConfig, "provider_id" | "provider">,
+): UserChatProviderConfig => ({
+	provider_id: overrides.provider_id,
+	provider: overrides.provider,
+	display_name: overrides.display_name ?? overrides.provider,
+	icon: overrides.icon ?? "",
+	enabled: overrides.enabled ?? true,
+	has_user_api_key: overrides.has_user_api_key ?? false,
+	has_central_api_key_fallback: overrides.has_central_api_key_fallback ?? false,
+	byok_enabled: overrides.byok_enabled ?? true,
+});
+
+const baseProvider = createProvider({
+	provider_id: "prov-1",
+	provider: "openai",
+	display_name: "OpenAI",
+});
+
+const savedKeyConfig: UserAIProviderKeyConfig = {
+	provider: {
+		id: "prov-1",
+		type: "openai",
+		name: "openai",
+		display_name: "OpenAI",
+		icon: "",
+		enabled: true,
+		deleted: false,
+	},
+	has_user_api_key: true,
+	has_provider_api_key: false,
+	byok_enabled: true,
+};
+
+const defaultProps: AgentSettingsAPIKeysPageViewProps = {
+	error: undefined,
+	isLoading: false,
+	providers: [baseProvider],
+	models: [],
+	isModelsLoading: false,
+	areModelsUnavailable: false,
+};
+
+const renderView = (ui: ReactElement) => {
+	const queryClient = createTestQueryClient();
+	queryClient.setDefaultOptions({
+		...queryClient.getDefaultOptions(),
+		mutations: { retry: false },
+	});
+	return render(
+		<QueryClientProvider client={queryClient}>{ui}</QueryClientProvider>,
+	);
+};
+
+afterEach(() => {
+	vi.restoreAllMocks();
+});
+
+describe("AgentSettingsAPIKeysPageView", () => {
+	it("saves a replacement key after a successful save remasks the field", async () => {
+		const user = userEvent.setup();
+		vi.spyOn(API.experimental, "upsertUserAIProviderKey").mockResolvedValue(
+			savedKeyConfig,
+		);
+
+		renderView(<AgentSettingsAPIKeysPageView {...defaultProps} />);
+
+		const apiKeyInput = screen.getByLabelText("API Key");
+		await user.type(apiKeyInput, "sk-test-key");
+		await user.click(screen.getByRole("button", { name: "Save" }));
+
+		await waitFor(() => {
+			expect(API.experimental.upsertUserAIProviderKey).toHaveBeenCalledWith(
+				"prov-1",
+				{ api_key: "sk-test-key" },
+			);
+		});
+
+		await user.type(apiKeyInput, "sk-other-key");
+		await user.click(screen.getByRole("button", { name: "Save" }));
+
+		await waitFor(() => {
+			expect(API.experimental.upsertUserAIProviderKey).toHaveBeenCalledTimes(2);
+		});
+		expect(API.experimental.upsertUserAIProviderKey).toHaveBeenLastCalledWith(
+			"prov-1",
+			{ api_key: "sk-other-key" },
+		);
+	});
+
+	it("trims leading and trailing whitespace before saving", async () => {
+		const user = userEvent.setup();
+		vi.spyOn(API.experimental, "upsertUserAIProviderKey").mockResolvedValue(
+			savedKeyConfig,
+		);
+
+		renderView(<AgentSettingsAPIKeysPageView {...defaultProps} />);
+
+		await user.type(screen.getByLabelText("API Key"), "  sk-test-key  ");
+		await user.click(screen.getByRole("button", { name: "Save" }));
+
+		await waitFor(() => {
+			expect(API.experimental.upsertUserAIProviderKey).toHaveBeenCalledWith(
+				"prov-1",
+				{ api_key: "sk-test-key" },
+			);
+		});
+	});
+
+	it("keeps the draft after a failed save so the user can retry", async () => {
+		const user = userEvent.setup();
+		vi.spyOn(API.experimental, "upsertUserAIProviderKey")
+			.mockRejectedValueOnce(new Error("failed to save"))
+			.mockResolvedValueOnce(savedKeyConfig);
+
+		renderView(<AgentSettingsAPIKeysPageView {...defaultProps} />);
+
+		await user.type(screen.getByLabelText("API Key"), "sk-test-key");
+		await user.click(screen.getByRole("button", { name: "Save" }));
+
+		await waitFor(() => {
+			expect(API.experimental.upsertUserAIProviderKey).toHaveBeenCalledTimes(1);
+		});
+
+		await user.click(screen.getByRole("button", { name: "Save" }));
+
+		await waitFor(() => {
+			expect(API.experimental.upsertUserAIProviderKey).toHaveBeenCalledTimes(2);
+		});
+		expect(API.experimental.upsertUserAIProviderKey).toHaveBeenLastCalledWith(
+			"prov-1",
+			{ api_key: "sk-test-key" },
+		);
+	});
+
+	it("calls the remove API when the user confirms removal", async () => {
+		const user = userEvent.setup();
+		vi.spyOn(API.experimental, "deleteUserAIProviderKey").mockResolvedValue(
+			undefined,
+		);
+
+		renderView(
+			<AgentSettingsAPIKeysPageView
+				{...defaultProps}
+				providers={[
+					{
+						...baseProvider,
+						has_user_api_key: true,
+					},
+				]}
+			/>,
+		);
+
+		await user.click(screen.getByRole("button", { name: "Remove" }));
+		const dialog = await screen.findByRole("dialog");
+		await user.click(within(dialog).getByRole("button", { name: "Remove" }));
+
+		await waitFor(() => {
+			expect(API.experimental.deleteUserAIProviderKey).toHaveBeenCalledWith(
+				"prov-1",
+			);
+		});
+	});
+
+	it("keeps the remove dialog open after a failed remove so the user can retry", async () => {
+		const user = userEvent.setup();
+		vi.spyOn(API.experimental, "deleteUserAIProviderKey")
+			.mockRejectedValueOnce(new Error("failed to remove"))
+			.mockResolvedValueOnce(undefined);
+
+		renderView(
+			<AgentSettingsAPIKeysPageView
+				{...defaultProps}
+				providers={[
+					{
+						...baseProvider,
+						has_user_api_key: true,
+					},
+				]}
+			/>,
+		);
+
+		await user.click(screen.getByRole("button", { name: "Remove" }));
+		const dialog = await screen.findByRole("dialog");
+		const confirmButton = within(dialog).getByRole("button", {
+			name: "Remove",
+		});
+		await user.click(confirmButton);
+
+		await waitFor(() => {
+			expect(API.experimental.deleteUserAIProviderKey).toHaveBeenCalledTimes(1);
+		});
+
+		await user.click(confirmButton);
+
+		await waitFor(() => {
+			expect(API.experimental.deleteUserAIProviderKey).toHaveBeenCalledTimes(2);
+		});
+	});
+});

--- a/site/src/pages/AgentsPage/AgentSettingsAPIKeysPageView.tsx
+++ b/site/src/pages/AgentsPage/AgentSettingsAPIKeysPageView.tsx
@@ -1,14 +1,23 @@
-import type { FC, FormEvent } from "react";
+import { useFormik } from "formik";
+import type { FC, ReactNode } from "react";
 import { useId, useState } from "react";
+import { useMutation, useQueryClient } from "react-query";
+import { toast } from "sonner";
+import { getErrorDetail, getErrorMessage } from "#/api/errors";
+import {
+	deleteUserChatProviderKey,
+	upsertUserChatProviderKey,
+} from "#/api/queries/chats";
 import type { ChatModel, UserChatProviderConfig } from "#/api/typesGenerated";
 import { ErrorAlert } from "#/components/Alert/ErrorAlert";
 import { Badge } from "#/components/Badge/Badge";
 import { Button } from "#/components/Button/Button";
 import { ConfirmDialog } from "#/components/Dialog/ConfirmDialog/ConfirmDialog";
 import { EmptyState } from "#/components/EmptyState/EmptyState";
-import { Input } from "#/components/Input/Input";
+import { FormField } from "#/components/FormField/FormField";
 import { Loader } from "#/components/Loader/Loader";
-import { passwordManagerIgnoreProps } from "#/utils/formUtils";
+import { Spinner } from "#/components/Spinner/Spinner";
+import { getFormHelpers } from "#/utils/formUtils";
 import { SectionHeader } from "./components/SectionHeader";
 
 const API_KEY_PLACEHOLDER = "••••••••••••••••";
@@ -57,10 +66,6 @@ interface ProviderKeyPanelProps {
 	models: readonly ChatModel[];
 	isModelsLoading: boolean;
 	areModelsUnavailable: boolean;
-	isSaving: boolean;
-	isRemoving: boolean;
-	onSave: (providerConfigId: string, apiKey: string) => void;
-	onRemove: (providerConfigId: string) => void;
 }
 
 const ProviderKeyPanel: FC<ProviderKeyPanelProps> = ({
@@ -68,66 +73,120 @@ const ProviderKeyPanel: FC<ProviderKeyPanelProps> = ({
 	models,
 	isModelsLoading,
 	areModelsUnavailable,
-	isSaving,
-	isRemoving,
-	onSave,
-	onRemove,
 }) => {
-	const apiKeyInputId = useId();
-	const [apiKey, setApiKey] = useState(
-		provider.has_user_api_key ? API_KEY_PLACEHOLDER : "",
-	);
-	const [apiKeyTouched, setApiKeyTouched] = useState(false);
+	const queryClient = useQueryClient();
+	const headingId = useId();
+
 	const [isDeleteDialogOpen, setIsDeleteDialogOpen] = useState(false);
+
+	const saveMutation = useMutation(upsertUserChatProviderKey(queryClient));
+	const removeMutation = useMutation(deleteUserChatProviderKey(queryClient));
+	const isBusy = saveMutation.isPending || removeMutation.isPending;
+
+	const form = useFormik({
+		initialValues: {
+			apiKey: provider.has_user_api_key ? API_KEY_PLACEHOLDER : "",
+		},
+		onSubmit: async (values, helpers) => {
+			const apiKey = values.apiKey.trim();
+			if (
+				!provider.byok_enabled ||
+				apiKey.length === 0 ||
+				apiKey === API_KEY_PLACEHOLDER ||
+				isBusy
+			) {
+				return;
+			}
+
+			try {
+				await saveMutation.mutateAsync({
+					providerConfigId: provider.provider_id,
+					req: { api_key: apiKey },
+				});
+				helpers.resetForm({ values: { apiKey: API_KEY_PLACEHOLDER } });
+				toast.success("API key saved.");
+			} catch (error) {
+				toast.error(getErrorMessage(error, "Error saving API key."), {
+					description: getErrorDetail(error),
+				});
+			}
+		},
+	});
+	const getFieldHelpers = getFormHelpers(form);
 
 	const status = getProviderStatus(provider);
 	const enabledModels = models.filter(
 		(model) => model.enabled && model.ai_provider_id === provider.provider_id,
 	);
-	const hasApiKeyValue = apiKey.trim().length > 0;
-	const hasAPIKeyWhitespace =
-		apiKey !== API_KEY_PLACEHOLDER && apiKey.trim() !== apiKey;
 	const saveDisabled =
 		!provider.byok_enabled ||
-		!hasApiKeyValue ||
-		hasAPIKeyWhitespace ||
-		apiKey === API_KEY_PLACEHOLDER ||
-		isSaving ||
-		isRemoving;
-	const inputDisabled = !provider.byok_enabled || isSaving || isRemoving;
-	const removeDisabled = isSaving || isRemoving;
+		form.values.apiKey.trim().length === 0 ||
+		form.values.apiKey === API_KEY_PLACEHOLDER ||
+		isBusy;
+	const inputDisabled = !provider.byok_enabled || isBusy;
 	const providerName = provider.display_name || provider.provider;
 
 	const handleApiKeyFocus = () => {
-		if (!apiKeyTouched && apiKey === API_KEY_PLACEHOLDER) {
-			setApiKey("");
-			setApiKeyTouched(true);
+		if (form.values.apiKey === API_KEY_PLACEHOLDER) {
+			void form.setFieldValue("apiKey", "");
 		}
 	};
 
-	const handleSave = (event: FormEvent<HTMLFormElement>) => {
-		event.preventDefault();
-
-		if (saveDisabled) {
-			return;
+	const handleRemoveKey = async () => {
+		try {
+			await removeMutation.mutateAsync(provider.provider_id);
+			setIsDeleteDialogOpen(false);
+			form.resetForm({ values: { apiKey: "" } });
+			toast.success("API key removed.");
+		} catch (error) {
+			toast.error(getErrorMessage(error, "Error removing API key."), {
+				description: getErrorDetail(error),
+			});
 		}
-
-		onSave(provider.provider_id, apiKey);
-	};
-
-	const handleRemoveKey = () => {
-		onRemove(provider.provider_id);
 	};
 
 	const deleteDescription = provider.has_central_api_key_fallback
-		? "This will remove your personal API key. Requests will fall back to the shared deployment key for this provider."
-		: "This will remove your personal API key. You will need to add a new key before you can use this provider again.";
+		? "Requests will fall back to the shared deployment key for this provider."
+		: "You will need to add a new key before you can use this provider again.";
+
+	let enabledModelsContent: ReactNode;
+	if (isModelsLoading) {
+		enabledModelsContent = <Spinner size="sm" loading label="Loading models" />;
+	} else if (enabledModels.length > 0) {
+		enabledModelsContent = (
+			<div className="flex flex-wrap gap-2">
+				{enabledModels.map((model) => (
+					<Badge key={model.id} size="md" variant="default">
+						{model.display_name || model.model}
+					</Badge>
+				))}
+			</div>
+		);
+	} else if (areModelsUnavailable) {
+		enabledModelsContent = (
+			<p className="m-0 text-sm text-content-secondary">
+				Enabled models are temporarily unavailable.
+			</p>
+		);
+	} else {
+		enabledModelsContent = (
+			<p className="m-0 text-sm text-content-secondary">
+				No enabled models configured.
+			</p>
+		);
+	}
 
 	return (
-		<article className="rounded-lg border border-solid border-border p-6">
+		<article
+			className="rounded-lg border border-solid border-border p-6"
+			aria-labelledby={headingId}
+		>
 			<div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
 				<div className="space-y-2">
-					<h5 className="m-0 text-lg font-medium text-content-primary">
+					<h5
+						id={headingId}
+						className="m-0 text-lg font-medium text-content-primary"
+					>
 						{providerName}
 					</h5>
 					{status.note && (
@@ -139,38 +198,23 @@ const ProviderKeyPanel: FC<ProviderKeyPanelProps> = ({
 				</Badge>
 			</div>
 
-			<form className="mt-6 flex flex-col gap-3" onSubmit={handleSave}>
-				<label
-					htmlFor={apiKeyInputId}
-					className="text-sm font-medium text-content-primary"
-				>
-					API Key
-				</label>
-				<div className="flex flex-col gap-3 lg:flex-row lg:items-start">
-					<div className="flex flex-col gap-1.5 lg:flex-1">
-						<Input
-							id={apiKeyInputId}
-							name={`provider-api-key-${provider.provider_id}`}
+			<form className="mt-6" onSubmit={form.handleSubmit}>
+				<div className="flex flex-col gap-3 lg:flex-row lg:items-end">
+					<div className="min-w-0 lg:flex-1">
+						<FormField
+							field={getFieldHelpers("apiKey")}
+							label="API Key"
 							type="password"
-							{...passwordManagerIgnoreProps}
-							className="h-9 font-mono text-[13px]"
 							placeholder="sk-..."
-							value={apiKey}
-							onFocus={handleApiKeyFocus}
-							onChange={(event) => {
-								setApiKey(event.target.value);
-								setApiKeyTouched(true);
-							}}
 							disabled={inputDisabled}
+							className="h-8 font-mono"
+							ignorePasswordManagers
+							onFocus={handleApiKeyFocus}
 						/>
-						{hasAPIKeyWhitespace && (
-							<p className="m-0 text-xs text-content-destructive">
-								API key must not contain leading or trailing whitespace.
-							</p>
-						)}
 					</div>
 					<div className="flex items-center gap-2">
 						<Button type="submit" size="sm" disabled={saveDisabled}>
+							<Spinner loading={saveMutation.isPending} />
 							Save
 						</Button>
 						{provider.has_user_api_key && (
@@ -179,7 +223,7 @@ const ProviderKeyPanel: FC<ProviderKeyPanelProps> = ({
 								variant="outline"
 								size="sm"
 								onClick={() => setIsDeleteDialogOpen(true)}
-								disabled={removeDisabled}
+								disabled={isBusy}
 							>
 								Remove
 							</Button>
@@ -194,62 +238,33 @@ const ProviderKeyPanel: FC<ProviderKeyPanelProps> = ({
 				</p>
 				{areModelsUnavailable && enabledModels.length > 0 && (
 					<p className="m-0 text-sm text-content-secondary">
-						Some enabled model badges are temporarily unavailable.
+						Some enabled models are temporarily unavailable.
 					</p>
 				)}
-				{isModelsLoading ? (
-					<p className="m-0 text-sm text-content-secondary">
-						Loading models...
-					</p>
-				) : enabledModels.length > 0 ? (
-					<div className="flex flex-wrap gap-2">
-						{enabledModels.map((model) => (
-							<Badge key={model.id} size="md" variant="default">
-								{model.display_name || model.model}
-							</Badge>
-						))}
-					</div>
-				) : areModelsUnavailable ? (
-					<p className="m-0 text-sm text-content-secondary">
-						Enabled model badges are temporarily unavailable.
-					</p>
-				) : (
-					<p className="m-0 text-sm text-content-secondary">
-						No enabled models configured.
-					</p>
-				)}
+				{enabledModelsContent}
 			</div>
 
 			<ConfirmDialog
 				open={isDeleteDialogOpen}
 				onClose={() => setIsDeleteDialogOpen(false)}
 				onConfirm={handleRemoveKey}
-				title="Remove API key?"
+				title="Remove API key"
 				description={deleteDescription}
 				confirmText="Remove"
-				confirmLoading={isRemoving}
+				confirmLoading={removeMutation.isPending}
 				type="delete"
 			/>
 		</article>
 	);
 };
 
-interface AgentSettingsAPIKeysProviderItem {
-	provider: UserChatProviderConfig;
-	renderKey: string;
-	isSaving: boolean;
-	isRemoving: boolean;
-}
-
 export interface AgentSettingsAPIKeysPageViewProps {
 	error: unknown;
 	isLoading: boolean;
-	providerItems: readonly AgentSettingsAPIKeysProviderItem[];
+	providers: readonly UserChatProviderConfig[];
 	models: readonly ChatModel[];
 	isModelsLoading: boolean;
 	areModelsUnavailable: boolean;
-	onSave: (providerConfigId: string, apiKey: string) => void;
-	onRemove: (providerConfigId: string) => void;
 }
 
 export const AgentSettingsAPIKeysPageView: FC<
@@ -257,49 +272,39 @@ export const AgentSettingsAPIKeysPageView: FC<
 > = ({
 	error,
 	isLoading,
-	providerItems,
+	providers,
 	models,
 	isModelsLoading,
 	areModelsUnavailable,
-	onSave,
-	onRemove,
 }) => {
 	return (
-		<div>
-			<section className="flex flex-col gap-8">
-				<SectionHeader
-					label="Secrets (API keys)"
-					description="Add a personal API key for each provider. Your personal key takes precedence over the shared deployment key when both are available."
+		<section className="flex flex-col gap-8">
+			<SectionHeader
+				label="Secrets (API keys)"
+				description="Add a personal API key for each provider. Your personal key takes precedence over the shared deployment key when both are available."
+			/>
+			{error ? (
+				<ErrorAlert error={error} />
+			) : isLoading ? (
+				<Loader />
+			) : providers.length === 0 ? (
+				<EmptyState
+					message="No providers allow personal API keys."
+					description="Ask your administrator to enable personal API keys for at least one provider."
 				/>
-				<div>
-					{error ? (
-						<ErrorAlert error={error} />
-					) : isLoading ? (
-						<Loader />
-					) : providerItems.length === 0 ? (
-						<EmptyState
-							message="No providers allow personal API keys."
-							description="Ask your administrator to enable personal API keys for at least one provider."
+			) : (
+				<div className="flex flex-col gap-4">
+					{providers.map((provider) => (
+						<ProviderKeyPanel
+							key={provider.provider_id}
+							provider={provider}
+							models={models}
+							isModelsLoading={isModelsLoading}
+							areModelsUnavailable={areModelsUnavailable}
 						/>
-					) : (
-						<div className="flex flex-col gap-4">
-							{providerItems.map((item) => (
-								<ProviderKeyPanel
-									key={item.renderKey}
-									provider={item.provider}
-									models={models}
-									isModelsLoading={isModelsLoading}
-									areModelsUnavailable={areModelsUnavailable}
-									isSaving={item.isSaving}
-									isRemoving={item.isRemoving}
-									onSave={onSave}
-									onRemove={onRemove}
-								/>
-							))}
-						</div>
-					)}
+					))}
 				</div>
-			</section>
-		</div>
+			)}
+		</section>
 	);
 };


### PR DESCRIPTION
The API keys page was a fake form. It reset local state by bumping React `key`s. Each provider panel now owns Formik + the save/remove mutations, and the page only loads data.

- No remount tokens, no parent save/remove callbacks.
- `FormField`, in-button spinner, `Remove API key` confirm. Same primitives as the rest of settings.
- Masked keys still clear on focus. Failed save/remove keep the draft so you can retry.
