### PR TITLE
fix: unblock AI price book refresh for gpt-6-astra and qwen3.8-max

### DIFF
--- a/coderd/aibridge/prices/data/prices.json
+++ b/coderd/aibridge/prices/data/prices.json
@@ -553,6 +553,14 @@
   },
   {
     "provider": "azure",
+    "model": "gpt-6-astra",
+    "input_price": 10000000,
+    "output_price": 50000000,
+    "cache_read_price": 1000000,
+    "cache_write_price": 12500000
+  },
+  {
+    "provider": "azure",
     "model": "gpt-chat-latest",
     "input_price": 5000000,
     "output_price": 30000000,
@@ -929,6 +937,30 @@
   },
   {
     "provider": "bedrock",
+    "model": "apac.amazon.nova-lite-v1:0",
+    "input_price": 63000,
+    "output_price": 252000,
+    "cache_read_price": 15750,
+    "cache_write_price": null
+  },
+  {
+    "provider": "bedrock",
+    "model": "apac.amazon.nova-micro-v1:0",
+    "input_price": 37000,
+    "output_price": 148000,
+    "cache_read_price": 9250,
+    "cache_write_price": null
+  },
+  {
+    "provider": "bedrock",
+    "model": "apac.amazon.nova-pro-v1:0",
+    "input_price": 840000,
+    "output_price": 3360000,
+    "cache_read_price": 210000,
+    "cache_write_price": null
+  },
+  {
+    "provider": "bedrock",
     "model": "au.anthropic.claude-haiku-4-5-20251001-v1:0",
     "input_price": 1000000,
     "output_price": 5000000,
@@ -942,6 +974,14 @@
     "output_price": 82500000,
     "cache_read_price": 1650000,
     "cache_write_price": 20625000
+  },
+  {
+    "provider": "bedrock",
+    "model": "au.anthropic.claude-opus-4-7",
+    "input_price": 5500000,
+    "output_price": 27500000,
+    "cache_read_price": 550000,
+    "cache_write_price": 6875000
   },
   {
     "provider": "bedrock",
@@ -985,6 +1025,14 @@
   },
   {
     "provider": "bedrock",
+    "model": "ca.amazon.nova-lite-v1:0",
+    "input_price": 64000,
+    "output_price": 256000,
+    "cache_read_price": 16000,
+    "cache_write_price": null
+  },
+  {
+    "provider": "bedrock",
     "model": "deepseek.r1-v1:0",
     "input_price": 1350000,
     "output_price": 5400000,
@@ -1005,6 +1053,38 @@
     "input_price": 620000,
     "output_price": 1850000,
     "cache_read_price": null,
+    "cache_write_price": null
+  },
+  {
+    "provider": "bedrock",
+    "model": "eu.amazon.nova-2-lite-v1:0",
+    "input_price": 374000,
+    "output_price": 3157000,
+    "cache_read_price": 93500,
+    "cache_write_price": null
+  },
+  {
+    "provider": "bedrock",
+    "model": "eu.amazon.nova-lite-v1:0",
+    "input_price": 69000,
+    "output_price": 276000,
+    "cache_read_price": 17250,
+    "cache_write_price": null
+  },
+  {
+    "provider": "bedrock",
+    "model": "eu.amazon.nova-micro-v1:0",
+    "input_price": 40000,
+    "output_price": 160000,
+    "cache_read_price": 10000,
+    "cache_write_price": null
+  },
+  {
+    "provider": "bedrock",
+    "model": "eu.amazon.nova-pro-v1:0",
+    "input_price": 920000,
+    "output_price": 3680000,
+    "cache_read_price": 230000,
     "cache_write_price": null
   },
   {
@@ -1086,6 +1166,22 @@
     "output_price": 11000000,
     "cache_read_price": 220000,
     "cache_write_price": 2750000
+  },
+  {
+    "provider": "bedrock",
+    "model": "eu.mistral.pixtral-large-2502-v1:0",
+    "input_price": 2000000,
+    "output_price": 6000000,
+    "cache_read_price": null,
+    "cache_write_price": null
+  },
+  {
+    "provider": "bedrock",
+    "model": "global.amazon.nova-2-lite-v1:0",
+    "input_price": 300000,
+    "output_price": 2500000,
+    "cache_read_price": 75000,
+    "cache_write_price": null
   },
   {
     "provider": "bedrock",
@@ -1201,6 +1297,22 @@
   },
   {
     "provider": "bedrock",
+    "model": "global.openai.gpt-6-astra",
+    "input_price": 10000000,
+    "output_price": 50000000,
+    "cache_read_price": 1000000,
+    "cache_write_price": 12500000
+  },
+  {
+    "provider": "bedrock",
+    "model": "global.xai.grok-4.6",
+    "input_price": 2000000,
+    "output_price": 6000000,
+    "cache_read_price": 500000,
+    "cache_write_price": null
+  },
+  {
+    "provider": "bedrock",
     "model": "google.gemma-3-12b-it",
     "input_price": 50000,
     "output_price": 100000,
@@ -1221,6 +1333,14 @@
     "input_price": 40000,
     "output_price": 80000,
     "cache_read_price": null,
+    "cache_write_price": null
+  },
+  {
+    "provider": "bedrock",
+    "model": "jp.amazon.nova-2-lite-v1:0",
+    "input_price": 396000,
+    "output_price": 3311000,
+    "cache_read_price": 99000,
     "cache_write_price": null
   },
   {
@@ -1505,6 +1625,14 @@
   },
   {
     "provider": "bedrock",
+    "model": "openai.gpt-6-astra",
+    "input_price": 11000000,
+    "output_price": 55000000,
+    "cache_read_price": 1100000,
+    "cache_write_price": 13750000
+  },
+  {
+    "provider": "bedrock",
     "model": "openai.gpt-oss-120b",
     "input_price": 150000,
     "output_price": 600000,
@@ -1605,6 +1733,38 @@
     "input_price": 300000,
     "output_price": 1500000,
     "cache_read_price": null,
+    "cache_write_price": null
+  },
+  {
+    "provider": "bedrock",
+    "model": "us.amazon.nova-2-lite-v1:0",
+    "input_price": 330000,
+    "output_price": 2750000,
+    "cache_read_price": 82500,
+    "cache_write_price": null
+  },
+  {
+    "provider": "bedrock",
+    "model": "us.amazon.nova-lite-v1:0",
+    "input_price": 60000,
+    "output_price": 240000,
+    "cache_read_price": 15000,
+    "cache_write_price": null
+  },
+  {
+    "provider": "bedrock",
+    "model": "us.amazon.nova-micro-v1:0",
+    "input_price": 35000,
+    "output_price": 140000,
+    "cache_read_price": 8750,
+    "cache_write_price": null
+  },
+  {
+    "provider": "bedrock",
+    "model": "us.amazon.nova-pro-v1:0",
+    "input_price": 800000,
+    "output_price": 3200000,
+    "cache_read_price": 200000,
     "cache_write_price": null
   },
   {
@@ -1713,6 +1873,30 @@
   },
   {
     "provider": "bedrock",
+    "model": "us.meta.llama3-1-70b-instruct-v1:0",
+    "input_price": 720000,
+    "output_price": 720000,
+    "cache_read_price": null,
+    "cache_write_price": null
+  },
+  {
+    "provider": "bedrock",
+    "model": "us.meta.llama3-1-8b-instruct-v1:0",
+    "input_price": 220000,
+    "output_price": 220000,
+    "cache_read_price": null,
+    "cache_write_price": null
+  },
+  {
+    "provider": "bedrock",
+    "model": "us.meta.llama3-3-70b-instruct-v1:0",
+    "input_price": 720000,
+    "output_price": 720000,
+    "cache_read_price": null,
+    "cache_write_price": null
+  },
+  {
+    "provider": "bedrock",
     "model": "us.meta.llama4-maverick-17b-instruct-v1:0",
     "input_price": 240000,
     "output_price": 970000,
@@ -1725,6 +1909,70 @@
     "input_price": 170000,
     "output_price": 660000,
     "cache_read_price": null,
+    "cache_write_price": null
+  },
+  {
+    "provider": "bedrock",
+    "model": "us.mistral.pixtral-large-2502-v1:0",
+    "input_price": 2000000,
+    "output_price": 6000000,
+    "cache_read_price": null,
+    "cache_write_price": null
+  },
+  {
+    "provider": "bedrock",
+    "model": "us.openai.gpt-5.6-luna",
+    "input_price": 220000,
+    "output_price": 1320000,
+    "cache_read_price": 22000,
+    "cache_write_price": 275000
+  },
+  {
+    "provider": "bedrock",
+    "model": "us.openai.gpt-5.6-sol",
+    "input_price": 4400000,
+    "output_price": 22000000,
+    "cache_read_price": 440000,
+    "cache_write_price": 5500000
+  },
+  {
+    "provider": "bedrock",
+    "model": "us.openai.gpt-5.6-terra",
+    "input_price": 2200000,
+    "output_price": 13200000,
+    "cache_read_price": 220000,
+    "cache_write_price": 2750000
+  },
+  {
+    "provider": "bedrock",
+    "model": "us.openai.gpt-6-astra",
+    "input_price": 11000000,
+    "output_price": 55000000,
+    "cache_read_price": 1100000,
+    "cache_write_price": 13750000
+  },
+  {
+    "provider": "bedrock",
+    "model": "us.writer.palmyra-x4-v1:0",
+    "input_price": 2500000,
+    "output_price": 10000000,
+    "cache_read_price": null,
+    "cache_write_price": null
+  },
+  {
+    "provider": "bedrock",
+    "model": "us.writer.palmyra-x5-v1:0",
+    "input_price": 600000,
+    "output_price": 6000000,
+    "cache_read_price": null,
+    "cache_write_price": null
+  },
+  {
+    "provider": "bedrock",
+    "model": "us.xai.grok-4.6",
+    "input_price": 2200000,
+    "output_price": 6600000,
+    "cache_read_price": 550000,
     "cache_write_price": null
   },
   {
@@ -1793,27 +2041,19 @@
   },
   {
     "provider": "copilot",
+    "model": "claude-fable-5.1",
+    "input_price": 10000000,
+    "output_price": 50000000,
+    "cache_read_price": 250000,
+    "cache_write_price": 12500000
+  },
+  {
+    "provider": "copilot",
     "model": "claude-haiku-4.5",
     "input_price": 1000000,
     "output_price": 5000000,
     "cache_read_price": 100000,
     "cache_write_price": 1250000
-  },
-  {
-    "provider": "copilot",
-    "model": "claude-opus-4.5",
-    "input_price": 5000000,
-    "output_price": 25000000,
-    "cache_read_price": 500000,
-    "cache_write_price": 6250000
-  },
-  {
-    "provider": "copilot",
-    "model": "claude-opus-4.6",
-    "input_price": 5000000,
-    "output_price": 25000000,
-    "cache_read_price": 500000,
-    "cache_write_price": 6250000
   },
   {
     "provider": "copilot",
@@ -1841,22 +2081,6 @@
   },
   {
     "provider": "copilot",
-    "model": "claude-sonnet-4",
-    "input_price": 3000000,
-    "output_price": 15000000,
-    "cache_read_price": 300000,
-    "cache_write_price": 3750000
-  },
-  {
-    "provider": "copilot",
-    "model": "claude-sonnet-4.5",
-    "input_price": 3000000,
-    "output_price": 15000000,
-    "cache_read_price": 300000,
-    "cache_write_price": 3750000
-  },
-  {
-    "provider": "copilot",
     "model": "claude-sonnet-4.6",
     "input_price": 3000000,
     "output_price": 15000000,
@@ -1870,14 +2094,6 @@
     "output_price": 10000000,
     "cache_read_price": 200000,
     "cache_write_price": 2500000
-  },
-  {
-    "provider": "copilot",
-    "model": "gemini-3.1-pro-preview",
-    "input_price": 2000000,
-    "output_price": 12000000,
-    "cache_read_price": 200000,
-    "cache_write_price": null
   },
   {
     "provider": "copilot",
@@ -1905,10 +2121,10 @@
   },
   {
     "provider": "copilot",
-    "model": "gpt-4.1",
-    "input_price": 2000000,
-    "output_price": 8000000,
-    "cache_read_price": 500000,
+    "model": "gemini-3.8-flash",
+    "input_price": 750000,
+    "output_price": 3750000,
+    "cache_read_price": 75000,
     "cache_write_price": null
   },
   {
@@ -1917,22 +2133,6 @@
     "input_price": 250000,
     "output_price": 2000000,
     "cache_read_price": 25000,
-    "cache_write_price": null
-  },
-  {
-    "provider": "copilot",
-    "model": "gpt-5.2",
-    "input_price": 1750000,
-    "output_price": 14000000,
-    "cache_read_price": 175000,
-    "cache_write_price": null
-  },
-  {
-    "provider": "copilot",
-    "model": "gpt-5.2-codex",
-    "input_price": 1750000,
-    "output_price": 14000000,
-    "cache_read_price": 175000,
     "cache_write_price": null
   },
   {
@@ -1986,10 +2186,10 @@
   {
     "provider": "copilot",
     "model": "gpt-5.6-sol",
-    "input_price": 2000000,
-    "output_price": 10000000,
-    "cache_read_price": 200000,
-    "cache_write_price": 2500000
+    "input_price": 4000000,
+    "output_price": 20000000,
+    "cache_read_price": 400000,
+    "cache_write_price": 5000000
   },
   {
     "provider": "copilot",
@@ -1998,6 +2198,14 @@
     "output_price": 12000000,
     "cache_read_price": 200000,
     "cache_write_price": 2500000
+  },
+  {
+    "provider": "copilot",
+    "model": "gpt-6-astra",
+    "input_price": 10000000,
+    "output_price": 50000000,
+    "cache_read_price": 1000000,
+    "cache_write_price": 12500000
   },
   {
     "provider": "copilot",
@@ -2994,25 +3202,25 @@
   {
     "provider": "openrouter",
     "model": "deepseek/deepseek-chat",
-    "input_price": 320000,
-    "output_price": 890000,
+    "input_price": 257400,
+    "output_price": 1028700,
     "cache_read_price": null,
     "cache_write_price": null
   },
   {
     "provider": "openrouter",
     "model": "deepseek/deepseek-chat-v3-0324",
-    "input_price": 250000,
-    "output_price": 1000000,
-    "cache_read_price": null,
+    "input_price": 290000,
+    "output_price": 1140000,
+    "cache_read_price": 110000,
     "cache_write_price": null
   },
   {
     "provider": "openrouter",
     "model": "deepseek/deepseek-chat-v3.1",
-    "input_price": 550000,
-    "output_price": 1650000,
-    "cache_read_price": 550000,
+    "input_price": 250000,
+    "output_price": 950000,
+    "cache_read_price": 130000,
     "cache_write_price": null
   },
   {
@@ -3066,9 +3274,9 @@
   {
     "provider": "openrouter",
     "model": "deepseek/deepseek-v4-flash",
-    "input_price": 79380,
-    "output_price": 158760,
-    "cache_read_price": 15876,
+    "input_price": 88606,
+    "output_price": 177212,
+    "cache_read_price": 17721,
     "cache_write_price": null
   },
   {
@@ -3090,17 +3298,25 @@
   {
     "provider": "openrouter",
     "model": "deepseek/deepseek-v4-pro",
-    "input_price": 1030776,
-    "output_price": 2061552,
-    "cache_read_price": 85898,
+    "input_price": 955260,
+    "output_price": 1910520,
+    "cache_read_price": 79605,
     "cache_write_price": null
   },
   {
     "provider": "openrouter",
     "model": "deepseek/deepseek-v4-pro-0813",
-    "input_price": 660000,
-    "output_price": 1980000,
-    "cache_read_price": 22000,
+    "input_price": 1049400,
+    "output_price": 3148200,
+    "cache_read_price": 34980,
+    "cache_write_price": null
+  },
+  {
+    "provider": "openrouter",
+    "model": "deepseek/deepseek-v4.1-flash",
+    "input_price": 300000,
+    "output_price": 1200000,
+    "cache_read_price": 6000,
     "cache_write_price": null
   },
   {
@@ -3377,18 +3593,10 @@
   },
   {
     "provider": "openrouter",
-    "model": "ibm-granite/granite-4.1-8b",
-    "input_price": 50000,
-    "output_price": 100000,
-    "cache_read_price": 50000,
-    "cache_write_price": null
-  },
-  {
-    "provider": "openrouter",
     "model": "ibm-granite/granite-4.2-8b",
-    "input_price": 100000,
-    "output_price": 150000,
-    "cache_read_price": 50000,
+    "input_price": 60000,
+    "output_price": 250000,
+    "cache_read_price": 15000,
     "cache_write_price": null
   },
   {
@@ -3401,7 +3609,7 @@
   },
   {
     "provider": "openrouter",
-    "model": "inception/mercury-2.5-preview",
+    "model": "inception/mercury-2.5",
     "input_price": 40000,
     "output_price": 150000,
     "cache_read_price": 4000,
@@ -3426,6 +3634,14 @@
   {
     "provider": "openrouter",
     "model": "inclusionai/ling-3.0-flash-fin:free",
+    "input_price": 0,
+    "output_price": 0,
+    "cache_read_price": null,
+    "cache_write_price": null
+  },
+  {
+    "provider": "openrouter",
+    "model": "inclusionai/ling-3.0-flash-sante:free",
     "input_price": 0,
     "output_price": 0,
     "cache_read_price": null,
@@ -3642,9 +3858,9 @@
   {
     "provider": "openrouter",
     "model": "minimax/minimax-m2.5",
-    "input_price": 270000,
-    "output_price": 1080000,
-    "cache_read_price": 27000,
+    "input_price": 300000,
+    "output_price": 1200000,
+    "cache_read_price": 30000,
     "cache_write_price": null
   },
   {
@@ -3657,26 +3873,10 @@
   },
   {
     "provider": "openrouter",
-    "model": "minimax/minimax-m2.7:free",
-    "input_price": 0,
-    "output_price": 0,
-    "cache_read_price": null,
-    "cache_write_price": null
-  },
-  {
-    "provider": "openrouter",
     "model": "minimax/minimax-m3",
     "input_price": 300000,
     "output_price": 1200000,
     "cache_read_price": 60000,
-    "cache_write_price": null
-  },
-  {
-    "provider": "openrouter",
-    "model": "minimax/minimax-m3:free",
-    "input_price": 0,
-    "output_price": 0,
-    "cache_read_price": null,
     "cache_write_price": null
   },
   {
@@ -3874,9 +4074,9 @@
   {
     "provider": "openrouter",
     "model": "moonshotai/kimi-k2.7-code",
-    "input_price": 660000,
-    "output_price": 3400000,
-    "cache_read_price": 180000,
+    "input_price": 710000,
+    "output_price": 3500000,
+    "cache_read_price": 150000,
     "cache_write_price": null
   },
   {
@@ -3905,18 +4105,18 @@
   },
   {
     "provider": "openrouter",
-    "model": "nex-agi/nex-n2-mini",
-    "input_price": 25000,
-    "output_price": 100000,
-    "cache_read_price": 2500,
+    "model": "nex-agi/nex-n2.5-mini:free",
+    "input_price": 0,
+    "output_price": 0,
+    "cache_read_price": null,
     "cache_write_price": null
   },
   {
     "provider": "openrouter",
-    "model": "nex-agi/nex-n2-pro",
-    "input_price": 250000,
-    "output_price": 1000000,
-    "cache_read_price": 25000,
+    "model": "nex-agi/nex-n2.5-pro:free",
+    "input_price": 0,
+    "output_price": 0,
+    "cache_read_price": null,
     "cache_write_price": null
   },
   {
@@ -3940,14 +4140,6 @@
     "model": "nousresearch/hermes-4-405b",
     "input_price": 1000000,
     "output_price": 3000000,
-    "cache_read_price": null,
-    "cache_write_price": null
-  },
-  {
-    "provider": "openrouter",
-    "model": "nousresearch/hermes-4-70b",
-    "input_price": 130000,
-    "output_price": 400000,
     "cache_read_price": null,
     "cache_write_price": null
   },
@@ -3986,9 +4178,9 @@
   {
     "provider": "openrouter",
     "model": "nvidia/nemotron-3-ultra-550b-a55b",
-    "input_price": 600000,
-    "output_price": 2400000,
-    "cache_read_price": 120000,
+    "input_price": 625000,
+    "output_price": 3125000,
+    "cache_read_price": 187500,
     "cache_write_price": null
   },
   {
@@ -3996,6 +4188,14 @@
     "model": "nvidia/nemotron-3-ultra-550b-a55b:free",
     "input_price": 0,
     "output_price": 0,
+    "cache_read_price": null,
+    "cache_write_price": null
+  },
+  {
+    "provider": "openrouter",
+    "model": "nvidia/nemotron-3.5-content-safety",
+    "input_price": 200000,
+    "output_price": 200000,
     "cache_read_price": null,
     "cache_write_price": null
   },
@@ -4377,6 +4577,22 @@
   },
   {
     "provider": "openrouter",
+    "model": "openai/gpt-6-astra",
+    "input_price": 10000000,
+    "output_price": 50000000,
+    "cache_read_price": 1000000,
+    "cache_write_price": 12500000
+  },
+  {
+    "provider": "openrouter",
+    "model": "openai/gpt-6-astra-pro",
+    "input_price": 10000000,
+    "output_price": 50000000,
+    "cache_read_price": 1000000,
+    "cache_write_price": 12500000
+  },
+  {
+    "provider": "openrouter",
     "model": "openai/gpt-audio",
     "input_price": 2500000,
     "output_price": 10000000,
@@ -4626,8 +4842,8 @@
   {
     "provider": "openrouter",
     "model": "qwen/qwen3-14b",
-    "input_price": 120000,
-    "output_price": 240000,
+    "input_price": 227500,
+    "output_price": 910000,
     "cache_read_price": null,
     "cache_write_price": null
   },
@@ -4642,9 +4858,9 @@
   {
     "provider": "openrouter",
     "model": "qwen/qwen3-235b-a22b-2507",
-    "input_price": 87500,
-    "output_price": 350000,
-    "cache_read_price": 17500,
+    "input_price": 220000,
+    "output_price": 880000,
+    "cache_read_price": null,
     "cache_write_price": null
   },
   {
@@ -4666,8 +4882,8 @@
   {
     "provider": "openrouter",
     "model": "qwen/qwen3-30b-a3b-instruct-2507",
-    "input_price": 48150,
-    "output_price": 193050,
+    "input_price": 90000,
+    "output_price": 300000,
     "cache_read_price": null,
     "cache_write_price": null
   },
@@ -4754,9 +4970,9 @@
   {
     "provider": "openrouter",
     "model": "qwen/qwen3-next-80b-a3b-instruct",
-    "input_price": 100000,
+    "input_price": 90000,
     "output_price": 1100000,
-    "cache_read_price": 70000,
+    "cache_read_price": null,
     "cache_write_price": null
   },
   {
@@ -4826,8 +5042,8 @@
   {
     "provider": "openrouter",
     "model": "qwen/qwen3.5-122b-a10b",
-    "input_price": 290000,
-    "output_price": 2400000,
+    "input_price": 260000,
+    "output_price": 2080000,
     "cache_read_price": null,
     "cache_write_price": null
   },
@@ -4842,9 +5058,9 @@
   {
     "provider": "openrouter",
     "model": "qwen/qwen3.5-35b-a3b",
-    "input_price": 250000,
+    "input_price": 312500,
     "output_price": 1250000,
-    "cache_read_price": 250000,
+    "cache_read_price": 156250,
     "cache_write_price": null
   },
   {
@@ -4890,9 +5106,9 @@
   {
     "provider": "openrouter",
     "model": "qwen/qwen3.6-27b",
-    "input_price": 600000,
-    "output_price": 3600000,
-    "cache_read_price": 120000,
+    "input_price": 300000,
+    "output_price": 2000000,
+    "cache_read_price": 30000,
     "cache_write_price": null
   },
   {
@@ -4977,7 +5193,7 @@
   },
   {
     "provider": "openrouter",
-    "model": "qwen/qwen3.8-max",
+    "model": "qwen/qwen3.8-max-0902",
     "input_price": 2000000,
     "output_price": 6000000,
     "cache_read_price": 250000,
@@ -5106,9 +5322,9 @@
   {
     "provider": "openrouter",
     "model": "tencent/hy3",
-    "input_price": 82500,
-    "output_price": 330000,
-    "cache_read_price": 20625,
+    "input_price": 132000,
+    "output_price": 528000,
+    "cache_read_price": 33000,
     "cache_write_price": null
   },
   {
@@ -5186,7 +5402,7 @@
   {
     "provider": "openrouter",
     "model": "undi95/remm-slerp-l2-13b",
-    "input_price": 450000,
+    "input_price": 350000,
     "output_price": 650000,
     "cache_read_price": null,
     "cache_write_price": null
@@ -5306,9 +5522,9 @@
   {
     "provider": "openrouter",
     "model": "z-ai/glm-4.6",
-    "input_price": 550000,
-    "output_price": 2200000,
-    "cache_read_price": 110000,
+    "input_price": 430000,
+    "output_price": 1750000,
+    "cache_read_price": 80000,
     "cache_write_price": null
   },
   {
@@ -5330,9 +5546,9 @@
   {
     "provider": "openrouter",
     "model": "z-ai/glm-4.7-flash",
-    "input_price": 60000,
+    "input_price": 60500,
     "output_price": 400000,
-    "cache_read_price": 10000,
+    "cache_read_price": null,
     "cache_write_price": null
   },
   {
@@ -5369,18 +5585,10 @@
   },
   {
     "provider": "openrouter",
-    "model": "z-ai/glm-5.2:free",
-    "input_price": 0,
-    "output_price": 0,
-    "cache_read_price": null,
-    "cache_write_price": null
-  },
-  {
-    "provider": "openrouter",
     "model": "z-ai/glm-5.3",
     "input_price": 1400000,
     "output_price": 4400000,
-    "cache_read_price": 140000,
+    "cache_read_price": 260000,
     "cache_write_price": null
   },
   {
@@ -5458,9 +5666,9 @@
   {
     "provider": "openrouter",
     "model": "~moonshotai/kimi-latest",
-    "input_price": 2500000,
-    "output_price": 14000000,
-    "cache_read_price": 290000,
+    "input_price": 2400000,
+    "output_price": 12000000,
+    "cache_read_price": 240000,
     "cache_write_price": null
   },
   {
@@ -5490,17 +5698,17 @@
   {
     "provider": "openrouter",
     "model": "~z-ai/glm-flash-latest",
-    "input_price": 71250,
-    "output_price": 237500,
-    "cache_read_price": 14250,
+    "input_price": 75000,
+    "output_price": 250000,
+    "cache_read_price": 15000,
     "cache_write_price": null
   },
   {
     "provider": "openrouter",
     "model": "~z-ai/glm-latest",
-    "input_price": 1148000,
-    "output_price": 3608000,
-    "cache_read_price": 188600,
+    "input_price": 1085000,
+    "output_price": 3410000,
+    "cache_read_price": 201500,
     "cache_write_price": null
   },
   {
@@ -6025,6 +6233,14 @@
   },
   {
     "provider": "vercel",
+    "model": "deepseek/deepseek-v4.1-flash-beta",
+    "input_price": 220000,
+    "output_price": 660000,
+    "cache_read_price": 7000,
+    "cache_write_price": null
+  },
+  {
+    "provider": "vercel",
     "model": "google/gemini-2.5-flash",
     "input_price": 300000,
     "output_price": 2500000,
@@ -6193,6 +6409,14 @@
   },
   {
     "provider": "vercel",
+    "model": "inception/mercury-2.5",
+    "input_price": 40000,
+    "output_price": 150000,
+    "cache_read_price": 4000,
+    "cache_write_price": null
+  },
+  {
+    "provider": "vercel",
     "model": "inception/mercury-coder-small",
     "input_price": 250000,
     "output_price": 1000000,
@@ -6218,6 +6442,22 @@
   {
     "provider": "vercel",
     "model": "inclusionai/ling-3.0-flash-fin-free",
+    "input_price": 0,
+    "output_price": 0,
+    "cache_read_price": null,
+    "cache_write_price": null
+  },
+  {
+    "provider": "vercel",
+    "model": "inclusionai/ling-3.0-flash-sante",
+    "input_price": 0,
+    "output_price": 0,
+    "cache_read_price": null,
+    "cache_write_price": null
+  },
+  {
+    "provider": "vercel",
+    "model": "inclusionai/ling-3.0-flash-sante-free",
     "input_price": 0,
     "output_price": 0,
     "cache_read_price": null,
@@ -6401,14 +6641,6 @@
   },
   {
     "provider": "vercel",
-    "model": "minimax/minimax-m2.7-free",
-    "input_price": 0,
-    "output_price": 0,
-    "cache_read_price": null,
-    "cache_write_price": null
-  },
-  {
-    "provider": "vercel",
     "model": "minimax/minimax-m2.7-highspeed",
     "input_price": 600000,
     "output_price": 2400000,
@@ -6421,14 +6653,6 @@
     "input_price": 300000,
     "output_price": 1200000,
     "cache_read_price": 60000,
-    "cache_write_price": null
-  },
-  {
-    "provider": "vercel",
-    "model": "minimax/minimax-m3-free",
-    "input_price": 0,
-    "output_price": 0,
-    "cache_read_price": 0,
     "cache_write_price": null
   },
   {
@@ -6997,7 +7221,7 @@
     "input_price": 400000,
     "output_price": 2400000,
     "cache_read_price": 40000,
-    "cache_write_price": 250000
+    "cache_write_price": 500000
   },
   {
     "provider": "vercel",
@@ -7013,7 +7237,7 @@
     "input_price": 4000000,
     "output_price": 20000000,
     "cache_read_price": 400000,
-    "cache_write_price": 2500000
+    "cache_write_price": 5000000
   },
   {
     "provider": "vercel",
@@ -7029,7 +7253,23 @@
     "input_price": 4000000,
     "output_price": 24000000,
     "cache_read_price": 400000,
-    "cache_write_price": 2500000
+    "cache_write_price": 5000000
+  },
+  {
+    "provider": "vercel",
+    "model": "openai/gpt-6-astra",
+    "input_price": 10000000,
+    "output_price": 50000000,
+    "cache_read_price": 1000000,
+    "cache_write_price": 12500000
+  },
+  {
+    "provider": "vercel",
+    "model": "openai/gpt-6-astra-fast",
+    "input_price": 20000000,
+    "output_price": 100000000,
+    "cache_read_price": 2000000,
+    "cache_write_price": 25000000
   },
   {
     "provider": "vercel",
@@ -7058,6 +7298,22 @@
   {
     "provider": "vercel",
     "model": "openai/gpt-image-2",
+    "input_price": 5000000,
+    "output_price": 30000000,
+    "cache_read_price": 1250000,
+    "cache_write_price": null
+  },
+  {
+    "provider": "vercel",
+    "model": "openai/gpt-image-2.5-flare",
+    "input_price": 5000000,
+    "output_price": 30000000,
+    "cache_read_price": 1250000,
+    "cache_write_price": null
+  },
+  {
+    "provider": "vercel",
+    "model": "openai/gpt-image-2.5-sunburst",
     "input_price": 5000000,
     "output_price": 30000000,
     "cache_read_price": 1250000,
@@ -7401,14 +7657,6 @@
   },
   {
     "provider": "vercel",
-    "model": "xiaomi/mimo-v2.5-pro-ultraspeed",
-    "input_price": 1305000,
-    "output_price": 2610000,
-    "cache_read_price": 10800,
-    "cache_write_price": null
-  },
-  {
-    "provider": "vercel",
     "model": "zai/glm-4.5",
     "input_price": 600000,
     "output_price": 2200000,
@@ -7506,9 +7754,9 @@
   {
     "provider": "vercel",
     "model": "zai/glm-5.3",
-    "input_price": 700000,
-    "output_price": 2200000,
-    "cache_read_price": 130000,
+    "input_price": 1400000,
+    "output_price": 4400000,
+    "cache_read_price": 140000,
     "cache_write_price": null
   },
   {
@@ -7525,14 +7773,6 @@
     "input_price": 150000,
     "output_price": 500000,
     "cache_read_price": 30000,
-    "cache_write_price": null
-  },
-  {
-    "provider": "vercel",
-    "model": "zai/glm-5.3-promo-50",
-    "input_price": 700000,
-    "output_price": 2200000,
-    "cache_read_price": 130000,
     "cache_write_price": null
   },
   {

--- a/scripts/aibridgepricesgen/curation.json
+++ b/scripts/aibridgepricesgen/curation.json
@@ -222,7 +222,8 @@
 			"modelIdentifier": "deepseek/deepseek-v4-pro"
 		},
 		{
-			"modelIdentifier": "qwen/qwen3.8-max"
+			"modelIdentifier": "qwen/qwen3.8-max-0902",
+			"displayName": "Qwen3.8 Max"
 		},
 		{
 			"modelIdentifier": "qwen/qwen3-coder-next"

--- a/scripts/aibridgepricesgen/overrides.jq
+++ b/scripts/aibridgepricesgen/overrides.jq
@@ -31,39 +31,6 @@ end
     )
   end
 
-# gpt-6-astra: released 2026-09-03 and not listed on models.dev yet. Inject it
-# from OpenAI's published model page and pricing table so the price book and
-# the known-models catalog can carry it; drop this block once upstream lists it.
-# Ref: https://developers.openai.com/api/docs/models/gpt-6-astra
-# Ref: https://developers.openai.com/api/docs/pricing
-| if (.openai.models | has("gpt-6-astra")) then
-    error("overrides.jq: gpt-6-astra now present upstream; drop the injection")
-  else
-    .openai.models."gpt-6-astra" = {
-      id: "gpt-6-astra",
-      name: "GPT-6 Astra",
-      attachment: true,
-      reasoning: true,
-      reasoning_options: [{type: "effort", values: ["low", "medium", "high", "xhigh", "max"]}],
-      tool_call: true,
-      structured_output: true,
-      temperature: false,
-      knowledge: "2026-04-30",
-      release_date: "2026-09-03",
-      last_updated: "2026-09-03",
-      modalities: {input: ["text", "image"], output: ["text"]},
-      open_weights: false,
-      limit: {context: 1050000, input: 922000, output: 128000},
-      cost: {
-        input: 10,
-        output: 50,
-        cache_read: 1,
-        cache_write: 12.5,
-        tiers: [{input: 20, output: 75, cache_read: 2, cache_write: 25, tier: {type: "context", size: 272000}}]
-      }
-    }
-  end
-
 # Mapping of provider names on models.dev to our own names
 # Ref. table definition for ai_provider_type
 # amazon-bedrock -> bedrock

--- a/site/src/modules/aiModels/knownModels/knownModelsGenerated.json
+++ b/site/src/modules/aiModels/knownModels/knownModelsGenerated.json
@@ -606,10 +606,10 @@
 			"displayName": "GLM-5.3",
 			"aliases": [],
 			"contextLimit": 1310720,
-			"maxOutputTokens": 262144,
+			"maxOutputTokens": 943718,
 			"inputCost": 1.4,
 			"outputCost": 4.4,
-			"cacheReadCost": 0.14
+			"cacheReadCost": 0.26
 		},
 		{
 			"provider": "openrouter",
@@ -713,9 +713,9 @@
 			"aliases": [],
 			"contextLimit": 1048576,
 			"maxOutputTokens": 384000,
-			"inputCost": 0.07938,
-			"outputCost": 0.15876,
-			"cacheReadCost": 0.015876
+			"inputCost": 0.088606,
+			"outputCost": 0.177212,
+			"cacheReadCost": 0.017721
 		},
 		{
 			"provider": "openrouter",
@@ -724,13 +724,13 @@
 			"aliases": [],
 			"contextLimit": 1048576,
 			"maxOutputTokens": 384000,
-			"inputCost": 1.030776,
-			"outputCost": 2.061552,
-			"cacheReadCost": 0.085898
+			"inputCost": 0.95526,
+			"outputCost": 1.91052,
+			"cacheReadCost": 0.079605
 		},
 		{
 			"provider": "openrouter",
-			"modelIdentifier": "qwen/qwen3.8-max",
+			"modelIdentifier": "qwen/qwen3.8-max-0902",
 			"displayName": "Qwen3.8 Max",
 			"aliases": [],
 			"contextLimit": 1000000,
@@ -817,9 +817,9 @@
 			"aliases": [],
 			"contextLimit": 1000000,
 			"maxOutputTokens": 1000000,
-			"inputCost": 0.7,
-			"outputCost": 2.2,
-			"cacheReadCost": 0.13
+			"inputCost": 1.4,
+			"outputCost": 4.4,
+			"cacheReadCost": 0.14
 		},
 		{
 			"provider": "vercel",


### PR DESCRIPTION
The weekly `aigateway-prices-refresh` job [failed](https://github.com/coder/coder/actions/runs/34458761592) because two upstream-guard assertions in the generator tripped: models.dev now lists OpenAI's `gpt-6-astra` (so its `overrides.jq` injection must be dropped), and the curated OpenRouter `qwen/qwen3.8-max` identifier was renamed upstream to `qwen/qwen3.8-max-0902`.

This removes the `gpt-6-astra` injection, repoints the qwen curation entry to `qwen/qwen3.8-max-0902` (with a `displayName` override to keep the clean "Qwen3.8 Max" label in the UI), and regenerates `prices.json` and `knownModelsGenerated.json`.

Note: because the artifacts regenerate from live models.dev, this diff also carries unrelated upstream drift, the same content the scheduled refresh PR would produce.

> [!NOTE]
> Generated with Coder Agents on behalf of @ssncferreira.
