### PR TITLE
docs: add Agent Relay for Claude Code

### DIFF
--- a/docs/ai-coder/agent-relay/claude-code.md
+++ b/docs/ai-coder/agent-relay/claude-code.md
@@ -1,0 +1,46 @@
+---
+title: Agent Relay for Claude Code
+---
+
+> [!NOTE]
+> Agent Relay for Claude Code is in [early access](../../install/releases/feature-stages.md#early-access-features)
+> and is currently in closed preview with select customers.
+
+[Agent Relay](./index.md) connects [Claude Code](https://claude.ai/code) sessions to self-hosted Coder workspaces.
+Anthropic calls this self-hosted worker model bring-your-own-compute (BYOC),
+and also refers to it as [self-hosted environments](https://code.claude.com/docs/en/self-hosted-environments).
+Developers keep using the claude.ai/code or Claude Desktop client and workflow they already know.
+The Claude Code runner's tool calls run inside a Coder workspace on infrastructure you control
+instead of an Anthropic-managed environment.
+
+Anthropic's agent orchestration and AI inference remain cloud-hosted.
+Coder doesn't proxy or observe model inference.
+Coder provides the workspace where the runner executes,
+and logs that correlate the Claude Code session and user to that workspace.
+
+## How it works
+
+1. A developer starts a Claude Code session at claude.ai/code or in Claude Desktop,
+   targeting a self-hosted runner pool mapped to a Coder organization and workspace template.
+1. Agent Relay claims the pending work order for that session
+   and asks the Coder control plane to provision a workspace from the mapped template for that user.
+1. A Claude Code self-hosted runner inside the workspace registers with the corresponding Claude Code session
+   and executes the agent's tool calls.
+1. When the session ends,
+   Agent Relay manages workspace teardown.
+
+Each Claude Code session gets its own ephemeral workspace.
+
+## Requirements
+
+- A licensed Coder deployment
+- An Anthropic plan with self-hosted runner (BYOC) support
+
+## Get started
+
+Talk to your [Coder account team](https://coder.com/contact) or email [sales@coder.com](mailto:sales@coder.com) to get access to Agent Relay for Claude Code.
+
+## Learn more
+
+- [Agent Relay](./index.md)
+- [Architecture](../../admin/infrastructure/architecture.md)

--- a/docs/ai-coder/agent-relay/claude-code.md
+++ b/docs/ai-coder/agent-relay/claude-code.md
@@ -20,8 +20,7 @@ and logs that correlate the Claude Code session and user to that workspace.
 ## How it works
 
 1. A developer starts a Claude Code session at claude.ai/code or in Claude Desktop, targeting a self-hosted runner pool mapped to a Coder organization and workspace template.
-1. Agent Relay claims the pending work order for that session
-   and asks the Coder control plane to provision a workspace from the mapped template for that user.
+1. Agent Relay claims the pending work order for that session and asks the Coder control plane to provision a workspace from the mapped template for that user.
 1. A Claude Code self-hosted runner inside the workspace registers with the corresponding Claude Code session
    and executes the agent's tool calls.
 1. When the session ends,

--- a/docs/ai-coder/agent-relay/claude-code.md
+++ b/docs/ai-coder/agent-relay/claude-code.md
@@ -30,9 +30,10 @@ Each Claude Code session gets its own ephemeral workspace.
 ## Requirements
 
 - A licensed Coder deployment
-- An Anthropic Team or Enterprise plan.
-  Self-hosted environments are in public beta on these plans;
-  refer to Anthropic's [self-hosted environment documentation](https://code.claude.com/docs/en/self-hosted-environments) for details.
+- An Anthropic Team or Enterprise plan
+
+Self-hosted environments are in public beta on these plans.
+Refer to Anthropic's [self-hosted environment documentation](https://code.claude.com/docs/en/self-hosted-environments) for details.
 
 ## Get started
 

--- a/docs/ai-coder/agent-relay/claude-code.md
+++ b/docs/ai-coder/agent-relay/claude-code.md
@@ -7,8 +7,7 @@ title: Agent Relay for Claude Code
 > and is currently in closed preview with select customers.
 
 [Agent Relay](./index.md) connects [Claude Code](https://claude.ai/code) sessions to self-hosted Coder workspaces.
-Anthropic calls this self-hosted worker model bring-your-own-compute (BYOC),
-and also refers to it as [self-hosted environments](https://code.claude.com/docs/en/self-hosted-environments).
+Anthropic calls this self-hosted worker model [self-hosted environments](https://code.claude.com/docs/en/self-hosted-environments).
 Developers keep using the claude.ai/code or Claude Desktop client and workflow they already know.
 The Claude Code runner's tool calls run inside a Coder workspace on infrastructure you control
 instead of an Anthropic-managed environment.
@@ -34,7 +33,9 @@ Each Claude Code session gets its own ephemeral workspace.
 ## Requirements
 
 - A licensed Coder deployment
-- An Anthropic plan with self-hosted runner (BYOC) support
+- An Anthropic Team or Enterprise plan.
+  Self-hosted environments are in public beta on these plans;
+  refer to Anthropic's [self-hosted environment documentation](https://code.claude.com/docs/en/self-hosted-environments) for details.
 
 ## Get started
 

--- a/docs/ai-coder/agent-relay/claude-code.md
+++ b/docs/ai-coder/agent-relay/claude-code.md
@@ -23,8 +23,7 @@ and logs that correlate the Claude Code session and user to that workspace.
 1. Agent Relay claims the pending work order for that session and asks the Coder control plane to provision a workspace from the mapped template for that user.
 1. A Claude Code self-hosted runner inside the workspace registers with the corresponding Claude Code session
    and executes the agent's tool calls.
-1. When the session ends,
-   Agent Relay manages workspace teardown.
+1. When the session ends, Agent Relay manages workspace teardown.
 
 Each Claude Code session gets its own ephemeral workspace.
 

--- a/docs/ai-coder/agent-relay/claude-code.md
+++ b/docs/ai-coder/agent-relay/claude-code.md
@@ -3,8 +3,7 @@ title: Agent Relay for Claude Code
 ---
 
 > [!NOTE]
-> Agent Relay for Claude Code is in [early access](../../install/releases/feature-stages.md#early-access-features)
-> and is currently in closed preview with select customers.
+> Agent Relay for Claude Code is in [early access](../../install/releases/feature-stages.md#early-access-features) and is currently in closed preview with select customers.
 
 [Agent Relay](./index.md) connects [Claude Code](https://claude.ai/code) sessions to self-hosted Coder workspaces.
 Anthropic calls this self-hosted worker model [self-hosted environments](https://code.claude.com/docs/en/self-hosted-environments).

--- a/docs/ai-coder/agent-relay/claude-code.md
+++ b/docs/ai-coder/agent-relay/claude-code.md
@@ -8,8 +8,7 @@ title: Agent Relay for Claude Code
 [Agent Relay](./index.md) connects [Claude Code](https://claude.ai/code) sessions to self-hosted Coder workspaces.
 Anthropic calls this self-hosted worker model [self-hosted environments](https://code.claude.com/docs/en/self-hosted-environments).
 Developers keep using the claude.ai/code or Claude Desktop client and workflow they already know.
-The Claude Code runner's tool calls run inside a Coder workspace on infrastructure you control
-instead of an Anthropic-managed environment.
+The Claude Code runner's tool calls run inside a Coder workspace on infrastructure you control instead of an Anthropic-managed environment.
 
 Anthropic's agent orchestration and AI inference remain cloud-hosted.
 Coder doesn't proxy or observe model inference.

--- a/docs/ai-coder/agent-relay/claude-code.md
+++ b/docs/ai-coder/agent-relay/claude-code.md
@@ -18,8 +18,7 @@ Coder provides the workspace where the runner executes and logs that correlate t
 
 1. A developer starts a Claude Code session at claude.ai/code or in Claude Desktop, targeting a self-hosted runner pool mapped to a Coder organization and workspace template.
 1. Agent Relay claims the pending work order for that session and asks the Coder control plane to provision a workspace from the mapped template for that user.
-1. A Claude Code self-hosted runner inside the workspace registers with the corresponding Claude Code session
-   and executes the agent's tool calls.
+1. A Claude Code self-hosted runner inside the workspace registers with the corresponding Claude Code session and executes the agent's tool calls.
 1. When the session ends, Agent Relay manages workspace teardown.
 
 Each Claude Code session gets its own ephemeral workspace.

--- a/docs/ai-coder/agent-relay/claude-code.md
+++ b/docs/ai-coder/agent-relay/claude-code.md
@@ -12,8 +12,7 @@ The Claude Code runner's tool calls run inside a Coder workspace on infrastructu
 
 Anthropic's agent orchestration and AI inference remain cloud-hosted.
 Coder doesn't proxy or observe model inference.
-Coder provides the workspace where the runner executes,
-and logs that correlate the Claude Code session and user to that workspace.
+Coder provides the workspace where the runner executes and logs that correlate the Claude Code session and user to that workspace.
 
 ## How it works
 

--- a/docs/ai-coder/agent-relay/claude-code.md
+++ b/docs/ai-coder/agent-relay/claude-code.md
@@ -19,8 +19,7 @@ and logs that correlate the Claude Code session and user to that workspace.
 
 ## How it works
 
-1. A developer starts a Claude Code session at claude.ai/code or in Claude Desktop,
-   targeting a self-hosted runner pool mapped to a Coder organization and workspace template.
+1. A developer starts a Claude Code session at claude.ai/code or in Claude Desktop, targeting a self-hosted runner pool mapped to a Coder organization and workspace template.
 1. Agent Relay claims the pending work order for that session
    and asks the Coder control plane to provision a workspace from the mapped template for that user.
 1. A Claude Code self-hosted runner inside the workspace registers with the corresponding Claude Code session

--- a/docs/ai-coder/agent-relay/index.md
+++ b/docs/ai-coder/agent-relay/index.md
@@ -42,7 +42,7 @@ Agent Relay is in [early access](../../install/releases/feature-stages.md#early-
 
 ## Supported providers
 
-[Cursor](./cursor.md) is the first provider Agent Relay supports.
+[Cursor](./cursor.md) and [Claude Code](./claude-code.md) are the providers Agent Relay supports.
 Coder built Agent Relay to support additional cloud-hosted agent providers as they add support for self-hosted execution.
 
 ## Get started
@@ -52,5 +52,6 @@ If you want access to Agent Relay or want updates on the support status for your
 ## Learn more
 
 - [Agent Relay for Cursor](./cursor.md)
+- [Agent Relay for Claude Code](./claude-code.md)
 - [Coder Agents](../agents/index.md)
 - [Architecture](../../admin/infrastructure/architecture.md)

--- a/docs/ai-coder/index.md
+++ b/docs/ai-coder/index.md
@@ -27,7 +27,7 @@ Developers interact with agents through the web UI or the REST API.
 
 [Agent Relay](./agent-relay/index.md) connects a supported cloud-hosted AI agent provider's hosted sessions to self-hosted Coder workspaces.
 The provider's orchestration and AI inference stay cloud-hosted; a worker process inside the workspace executes the agent's tool calls.
-[Cursor Cloud Agents](https://cursor.com/cloud) is the first supported provider.
+[Cursor Cloud Agents](https://cursor.com/cloud) and [Claude Code](https://claude.ai/code) are the supported providers.
 
 Agent Relay is in [early access](../install/releases/feature-stages.md#early-access-features) and is in closed preview with select customers.
 

--- a/docs/manifest.json
+++ b/docs/manifest.json
@@ -1146,6 +1146,12 @@
 							"description": "Run Cursor's cloud agent sessions inside self-hosted Coder workspaces with Agent Relay.",
 							"path": "./ai-coder/agent-relay/cursor.md",
 							"state": ["early access"]
+						},
+						{
+							"title": "Agent Relay for Claude Code",
+							"description": "Run Claude Code's cloud sessions inside self-hosted Coder workspaces with Agent Relay.",
+							"path": "./ai-coder/agent-relay/claude-code.md",
+							"state": ["early access"]
 						}
 					]
 				},


### PR DESCRIPTION
**Do not merge before Sept 14**

Adds a peer page to docs/ai-coder/agent-relay/cursor.md documenting Agent Relay support for Claude Code (Anthropic's self-hosted environments model for claude.ai/code and Claude Desktop sessions).

---
This PR was created by Coder Agents on behalf of @mattvollmer.