### PR TITLE
fix(site/src/pages/AgentsPage): lead find_tools header with the match count

### DIFF
--- a/site/src/pages/AgentsPage/components/ChatConversation/ConversationTimeline.stories.tsx
+++ b/site/src/pages/AgentsPage/components/ChatConversation/ConversationTimeline.stories.tsx
@@ -606,7 +606,7 @@ export const FindToolsSearchResult: Story = {
 	play: async ({ canvasElement }) => {
 		const canvas = within(canvasElement);
 		const summary = canvas.getByRole("button", {
-			name: "Searched tools: github issues, pull requests, name:github__list_issues -> 2 matched",
+			name: "Matched 2 tools: github issues, pull requests, github__list_issues",
 		});
 		expect(summary).toBeVisible();
 		expect(canvas.queryByText("github__list_issues")).not.toBeInTheDocument();

--- a/site/src/pages/AgentsPage/components/ChatConversation/ConversationTimeline.stories.tsx
+++ b/site/src/pages/AgentsPage/components/ChatConversation/ConversationTimeline.stories.tsx
@@ -606,7 +606,7 @@ export const FindToolsSearchResult: Story = {
 	play: async ({ canvasElement }) => {
 		const canvas = within(canvasElement);
 		const summary = canvas.getByRole("button", {
-			name: "Matched 2 tools: github issues, pull requests, github__list_issues",
+			name: "Matched 2 tools: github__list_issues, github__list_pull_requests",
 		});
 		expect(summary).toBeVisible();
 		expect(canvas.queryByText("github__list_issues")).not.toBeInTheDocument();

--- a/site/src/pages/AgentsPage/components/ChatElements/tools/FindToolsTool.stories.tsx
+++ b/site/src/pages/AgentsPage/components/ChatElements/tools/FindToolsTool.stories.tsx
@@ -1,0 +1,89 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { FindToolsTool } from "./FindToolsTool";
+
+const githubMatches = [
+	{
+		name: "github__list_issues",
+		description: "List issues in a GitHub repository.",
+	},
+	{
+		name: "github__list_pull_requests",
+		description: "List pull requests in a GitHub repository.",
+	},
+];
+
+const meta: Meta<typeof FindToolsTool> = {
+	title: "pages/AgentsPage/ChatElements/tools/FindToolsTool",
+	component: FindToolsTool,
+	args: {
+		queries: ["github issues", "pull requests"],
+		names: ["github__list_issues"],
+		matches: githubMatches,
+		status: "completed",
+		isError: false,
+	},
+	decorators: [
+		(Story) => (
+			<div className="mx-auto w-full max-w-3xl py-6 font-sans text-xs">
+				<Story />
+			</div>
+		),
+	],
+};
+export default meta;
+type Story = StoryObj<typeof FindToolsTool>;
+
+export const Running: Story = {
+	args: { status: "running", matches: [] },
+};
+
+export const ManyMatches: Story = {};
+
+export const SingleMatch: Story = {
+	args: {
+		queries: ["github issues"],
+		names: [],
+		matches: githubMatches.slice(0, 1),
+	},
+};
+
+export const NoMatches: Story = {
+	args: {
+		queries: ["nonexistent capability"],
+		names: [],
+		matches: [],
+	},
+};
+
+// A long query list overflows the header, so the match count leads the
+// label and only the query list is truncated.
+export const LongQueryListTruncates: Story = {
+	decorators: [
+		(Story) => (
+			<div className="w-80">
+				<Story />
+			</div>
+		),
+	],
+	args: {
+		queries: [
+			"list github issues for a repository",
+			"open pull requests assigned to me",
+			"create a new branch from main",
+			"comment on a pull request review thread",
+		],
+		names: ["github__list_issues", "github__list_pull_requests"],
+	},
+};
+
+export const Failed: Story = {
+	args: {
+		queries: ["github issues"],
+		names: [],
+		matches: [],
+		status: "error",
+		isError: true,
+		errorMessage:
+			"The schema budget for this step is exhausted; call the tools already activated or retry next step.",
+	},
+};

--- a/site/src/pages/AgentsPage/components/ChatElements/tools/FindToolsTool.stories.tsx
+++ b/site/src/pages/AgentsPage/components/ChatElements/tools/FindToolsTool.stories.tsx
@@ -55,9 +55,30 @@ export const NoMatches: Story = {
 	},
 };
 
-// A long query list overflows the header, so the match count leads the
-// label and only the query list is truncated.
-export const LongQueryListTruncates: Story = {
+// A long match list overflows the header, so the match count leads the
+// label and only the tool names are truncated.
+export const LongMatchListTruncates: Story = {
+	decorators: [
+		(Story) => (
+			<div className="w-80">
+				<Story />
+			</div>
+		),
+	],
+	args: {
+		queries: ["microsoft documentation", "code samples"],
+		names: [],
+		matches: [
+			"mslearn__microsoft_docs_search",
+			"mslearn__microsoft_docs_fetch",
+			"mslearn__microsoft_code_sample_search",
+			"mslearn__microsoft_learn_catalog",
+		].map((name) => ({ name, description: `${name} description` })),
+	},
+};
+
+// A long search with no results falls back to showing the search terms.
+export const LongSearchNoMatchesTruncates: Story = {
 	decorators: [
 		(Story) => (
 			<div className="w-80">
@@ -69,10 +90,10 @@ export const LongQueryListTruncates: Story = {
 		queries: [
 			"list github issues for a repository",
 			"open pull requests assigned to me",
-			"create a new branch from main",
 			"comment on a pull request review thread",
 		],
-		names: ["github__list_issues", "github__list_pull_requests"],
+		names: ["github__list_issues"],
+		matches: [],
 	},
 };
 

--- a/site/src/pages/AgentsPage/components/ChatElements/tools/FindToolsTool.tsx
+++ b/site/src/pages/AgentsPage/components/ChatElements/tools/FindToolsTool.tsx
@@ -24,16 +24,23 @@ export const FindToolsTool: FC<FindToolsToolProps> = ({
 	isError,
 	errorMessage,
 }) => {
-	// The header label truncates from the end, so the match count leads
-	// and the query list absorbs any overflow.
-	const queryLabel = [...queries, ...names].join(", ");
-	const querySuffix = queryLabel ? `: ${queryLabel}` : "";
-	const label =
-		status === "running"
-			? `Searching tools${querySuffix}`
-			: isError
-				? `Failed to search tools${querySuffix}`
-				: `Matched ${matches.length} ${matches.length === 1 ? "tool" : "tools"}${querySuffix}`;
+	// The header label truncates from the end, so the outcome leads and
+	// the list absorbs any overflow. Search terms only appear when there
+	// are no matched tool names to show instead.
+	const searchTerms = [...queries, ...names].join(", ");
+	const searchSuffix = searchTerms ? `: ${searchTerms}` : "";
+	let label: string;
+	if (status === "running") {
+		label = `Searching tools${searchSuffix}`;
+	} else if (isError) {
+		label = `Failed to search tools${searchSuffix}`;
+	} else if (matches.length === 0) {
+		label = `No tools matched${searchSuffix}`;
+	} else {
+		const noun = matches.length === 1 ? "tool" : "tools";
+		const matchedNames = matches.map((match) => match.name).join(", ");
+		label = `Matched ${matches.length} ${noun}: ${matchedNames}`;
+	}
 
 	return (
 		<ToolCall.Root

--- a/site/src/pages/AgentsPage/components/ChatElements/tools/FindToolsTool.tsx
+++ b/site/src/pages/AgentsPage/components/ChatElements/tools/FindToolsTool.tsx
@@ -24,12 +24,16 @@ export const FindToolsTool: FC<FindToolsToolProps> = ({
 	isError,
 	errorMessage,
 }) => {
-	const queryLabel =
-		[...queries, ...names.map((name) => `name:${name}`)].join(", ") || "tools";
+	// The header label truncates from the end, so the match count leads
+	// and the query list absorbs any overflow.
+	const queryLabel = [...queries, ...names].join(", ");
+	const querySuffix = queryLabel ? `: ${queryLabel}` : "";
 	const label =
 		status === "running"
-			? `Searching tools: ${queryLabel}`
-			: `Searched tools: ${queryLabel} -> ${matches.length} matched`;
+			? `Searching tools${querySuffix}`
+			: isError
+				? `Failed to search tools${querySuffix}`
+				: `Matched ${matches.length} ${matches.length === 1 ? "tool" : "tools"}${querySuffix}`;
 
 	return (
 		<ToolCall.Root


### PR DESCRIPTION
The collapsed `find_tools` header rendered `Searched tools: <queries> -> N matched`. The label truncates from the end, so with more than a couple of queries the match count was the first thing cut off, and name lookups carried a noisy `name:` prefix.

The header now leads with the outcome and shows the matched tool names instead of the search terms, which read as one ambiguous list once the prefix was gone: `Matched 3 tools: mslearn__microsoft_docs_fetch, mslearn__microsoft_docs_search, …`. Zero results fall back to the search terms (`No tools matched: quantum llama grooming`), the running state keeps `Searching tools: …`, and a failed call reads `Failed to search tools: …` instead of `0 matched`.

Adds `FindToolsTool` stories for the running, single, many, empty, error, and two narrow-width truncation states. The `FindToolsSearchResult` story in `ConversationTimeline.stories.tsx` keeps the click-only `play` from #29127 (no assertions) so the expanded match list is still captured; this PR only relabels its header lookup to the new `Matched 2 tools: …` text.

Dogfood UAT ran remotely against 153cde71863 across matches, singular, zero, running, error, reload, narrow viewport, and mixed-row regression scenarios and passed. The later commits (8197f90aaaf and the merge of main, 7a0fc7d52fd) only touch that story `play` and were not re-run through UAT.

## Delivery record

- Human review (DanielleMaywood) on 153cde71863: one thread asking to remove the story `play` assertions; addressed in 8197f90aaaf.
- Codex review on 8197f90aaaf: one P1 thread asking to keep one story expanded through a click-only `play`. Addressed in 7a0fc7d52fd by merging main, where #29127 keeps exactly that click-only `play` on `FindToolsSearchResult`, and relabeling its lookup to the new header.
- Codex re-review on 7a0fc7d52fd (manual `@codex review`): no findings (`Didn't find any major issues`, reviewed commit `7a0fc7d52f`), zero unresolved threads. CI on this head: `required` and all test jobs pass; `Analyze PR for Documentation Updates Needed` fails because its `doc-check-pr-29178` review workspace is dormant (CODAGT-1025), unrelated to this change.
- 8197f90aaaf and 7a0fc7d52fd were pushed with `git push --no-verify`, authorized by Mike. The opted-in pre-push hook (`make pre-push`) fails on this host for reasons unrelated to this change: `TestGetModulesArchive` hashes a `testdata/` tar whose directory modes are `0700` in this umask-`0077` checkout, and `OrganizationMembersPage.test.tsx` / `TemplateSchedulePage.test.tsx` crash inside `NotificationsInbox.tsx` under jsdom. Local validation for 7a0fc7d52fd: pre-commit hook passed (gen, fmt, lint, typos, build), `biome` clean, `tsc` exit 0, Storybook browser test run 61/61 across both story files (the click-only `play` exercises the new label).

Refs https://linear.app/codercom/issue/CODAGT-1022/fix-truncated-match-count-in-collapsed-find-search-render

> Opened by Xum on behalf of @ibetitsmike.
