### PR TITLE
docs(.claude/docs/FRONTEND_PATTERNS.md): document language server tools

### DIFF
--- a/.claude/docs/FRONTEND_PATTERNS.md
+++ b/.claude/docs/FRONTEND_PATTERNS.md
@@ -14,6 +14,21 @@ How to use this document:
 `site/AGENTS.md` holds the one-line summary of each rule plus general frontend
 workflow guidance. This file is the authoritative version with examples.
 
+## Language server tools
+
+When a `typescript-language-server` MCP is available, prefer it over text search
+for navigating and understanding `site/src/` TypeScript. It resolves symbols
+semantically, so it stays accurate across re-exports, overloads, and renames.
+
+| Tool | When to use |
+|------|-------------|
+| `definition` | Jump to where a symbol (function, type, constant, component) is defined to read its implementation. |
+| `references` | Find every usage of a symbol across the codebase before changing or removing it. |
+| `hover` | Inspect a symbol's inferred type and doc comment at a specific location. |
+| `rename_symbol` | Rename a symbol and update all references safely, instead of find-and-replace. |
+| `diagnostics` | Check a file for type errors and warnings after editing. |
+| `edit_file` | Apply line-based text edits to a file. |
+
 ## FE1: Vitest covers behavior, Storybook covers visual states
 
 Frontend changes should have behavior coverage in Vitest and/or visual

--- a/.claude/docs/FRONTEND_PATTERNS.md
+++ b/.claude/docs/FRONTEND_PATTERNS.md
@@ -20,14 +20,14 @@ When a `typescript-language-server` MCP is available, prefer it over text search
 for navigating and understanding `site/src/` TypeScript. It resolves symbols
 semantically, so it stays accurate across re-exports, overloads, and renames.
 
-| Tool | When to use |
-|------|-------------|
-| `definition` | Jump to where a symbol (function, type, constant, component) is defined to read its implementation. |
-| `references` | Find every usage of a symbol across the codebase before changing or removing it. |
-| `hover` | Inspect a symbol's inferred type and doc comment at a specific location. |
-| `rename_symbol` | Rename a symbol and update all references safely, instead of find-and-replace. |
-| `diagnostics` | Check a file for type errors and warnings after editing. |
-| `edit_file` | Apply line-based text edits to a file. |
+| Tool            | When to use                                                                                         |
+|-----------------|-----------------------------------------------------------------------------------------------------|
+| `definition`    | Jump to where a symbol (function, type, constant, component) is defined to read its implementation. |
+| `references`    | Find every usage of a symbol across the codebase before changing or removing it.                    |
+| `hover`         | Inspect a symbol's inferred type and doc comment at a specific location.                            |
+| `rename_symbol` | Rename a symbol and update all references safely, instead of find-and-replace.                      |
+| `diagnostics`   | Check a file for type errors and warnings after editing.                                            |
+| `edit_file`     | Apply line-based text edits to a file.                                                              |
 
 ## FE1: Vitest covers behavior, Storybook covers visual states
 


### PR DESCRIPTION
Adds a "Language server tools" section near the top of `.claude/docs/FRONTEND_PATTERNS.md` documenting the `typescript-language-server` MCP tools and when to use each. This mirrors `.claude/docs/GO.md`: https://github.com/coder/coder/blob/main/.claude/docs/GO.md#go-lsp-navigation

The table covers `definition`, `references`, `hover`, `rename_symbol`, `diagnostics`, and `edit_file`, with a note to prefer the language server over text search for navigating `site/src/` TypeScript.

---
_This PR was generated by Coder Agents on behalf of @jeremyruppel._
