### PR TITLE
chore(site): enable role-has-required-aria-props oxlint rule

### DIFF
--- a/site/.oxlintrc.jsonc
+++ b/site/.oxlintrc.jsonc
@@ -20,6 +20,7 @@
 		"tabindex-no-positive": "error",
 		"img-redundant-alt": "error",
 		"no-redundant-roles": "error",
+		"role-has-required-aria-props": "error",
 		"alt-text": "error",
 		"anchor-has-content": "error",
 		"aria-activedescendant-has-tabindex": "error",
@@ -199,7 +200,6 @@
 		"no-autofocus": "off", // a11y/noAutofocus (large)
 		"no-invalid-void-type": "off", // suspicious/noConfusingVoidType (large)
 		"no-redeclare": "off", // suspicious/noRedeclare (medium: TS declaration merging)
-		"role-has-required-aria-props": "off", // a11y/useAriaPropsForRole (medium)
 		"no-irregular-whitespace": "off", // suspicious/noIrregularWhitespace (medium)
 		"no-inferrable-types": "off", // style/noInferrableTypes (medium, coder error rule)
 		"consistent-type-imports": "off", // style/useImportType (medium)

--- a/site/src/components/Autocomplete/Autocomplete.tsx
+++ b/site/src/components/Autocomplete/Autocomplete.tsx
@@ -344,6 +344,7 @@ export function Autocomplete<TOption>({
 											return (
 												<CommandItem
 													role="option"
+													aria-selected={index === highlightedIndex}
 													id={`${listboxId}-option-${index}`}
 													key={optionValue}
 													value={optionValue}

--- a/site/src/modules/aiModels/ModelSelector.tsx
+++ b/site/src/modules/aiModels/ModelSelector.tsx
@@ -1,6 +1,6 @@
 import { cn } from "cn";
 import { CheckIcon, InfoIcon } from "lucide-react";
-import { type FC, useState } from "react";
+import { type FC, useId, useState } from "react";
 import { ChevronDownIcon } from "#/components/AnimatedIcons/ChevronDown";
 import { Button } from "#/components/Button/Button";
 import {
@@ -125,6 +125,7 @@ export const ModelSelector: FC<ModelSelectorProps> = ({
 	// With an unset option the selector stays usable even when no model
 	// options exist, so a saved override can still be switched back.
 	const isDisabled = disabled || (options.length === 0 && !unsetLabel);
+	const listboxId = useId();
 	const query = search.trim().toLowerCase();
 	const optionsByProvider = (() => {
 		const grouped = new Map<string, ModelSelectorOption[]>();
@@ -158,6 +159,7 @@ export const ModelSelector: FC<ModelSelectorProps> = ({
 					}
 					aria-expanded={open}
 					aria-haspopup="listbox"
+					aria-controls={open ? listboxId : undefined}
 					disabled={isDisabled}
 					role="combobox"
 					type="button"
@@ -218,6 +220,7 @@ export const ModelSelector: FC<ModelSelectorProps> = ({
 						className="h-auto py-0 text-xs font-normal leading-[18px] text-content-primary placeholder:text-content-disabled"
 					/>
 					<CommandList
+						id={listboxId}
 						role="listbox"
 						className={cn(
 							"max-h-80 border-t-0",


### PR DESCRIPTION
Enables the `role-has-required-aria-props` oxlint rule (jsx-a11y/useAriaPropsForRole), moving it out of the migration backlog and into the enforced a11y rules.

Fixes the two resulting violations:

- `ModelSelector.tsx`: wire `aria-controls` on the combobox trigger to a `useId`-generated id set on the listbox `CommandList`.
- `Autocomplete.tsx`: add `aria-selected` to each `option`, driven by the highlighted index.

> [!NOTE]
> This PR was generated by Coder Agents on behalf of @jeremyruppel.
