### PR TITLE
chore(site): enable heading-has-content oxlint rule

### DIFF
--- a/site/.oxlintrc.jsonc
+++ b/site/.oxlintrc.jsonc
@@ -23,6 +23,7 @@
 		"role-has-required-aria-props": "error",
 		"alt-text": "error",
 		"anchor-has-content": "error",
+		"heading-has-content": "error",
 		"aria-activedescendant-has-tabindex": "error",
 		"mouse-events-have-key-events": "error",
 		"anchor-is-valid": "error",
@@ -204,7 +205,6 @@
 		"no-inferrable-types": "off", // style/noInferrableTypes (medium, coder error rule)
 		"consistent-type-imports": "off", // style/useImportType (medium)
 		"jsx-curly-brace-presence": "off", // style/useConsistentCurlyBraces (medium, coder error rule)
-		"heading-has-content": "off", // a11y/useHeadingContent (medium)
 		"anchor-ambiguous-text": "off", // a11y/noAmbiguousAnchorText (medium)
 		"no-fallthrough": "off", // suspicious/noFallthroughSwitchClause (medium)
 		"role-supports-aria-props": "off", // a11y/useAriaPropsSupportedByRole (small)

--- a/site/src/components/Alert/Alert.tsx
+++ b/site/src/components/Alert/Alert.tsx
@@ -143,7 +143,12 @@ export const AlertDescription: React.FC<React.PropsWithChildren> = ({
 
 export const AlertTitle: React.FC<React.ComponentPropsWithRef<"h2">> = ({
 	className,
+	children,
 	...props
 }) => {
-	return <h2 className={cn("m-0 text-sm", className)} {...props} />;
+	return (
+		<h2 className={cn("m-0 text-sm", className)} {...props}>
+			{children}
+		</h2>
+	);
 };

--- a/site/src/pages/AgentsPage/components/ChatsSidebar/filters/FilterPopover.tsx
+++ b/site/src/pages/AgentsPage/components/ChatsSidebar/filters/FilterPopover.tsx
@@ -85,18 +85,25 @@ const SOURCE_OPTIONS: readonly Readonly<{
 	label: SOURCE_LABELS[source],
 }));
 
-const SectionHeading: FC<ComponentProps<"h2">> = ({ className, ...props }) => (
+const SectionHeading: FC<ComponentProps<"h2">> = ({
+	className,
+	children,
+	...props
+}) => (
 	<h2
 		className={cn(
 			"m-0 text-xs font-semibold leading-[18px] text-content-secondary",
 			className,
 		)}
 		{...props}
-	/>
+	>
+		{children}
+	</h2>
 );
 
 const FilterGroupHeading: FC<ComponentProps<"h3">> = ({
 	className,
+	children,
 	...props
 }) => (
 	<h3
@@ -105,7 +112,9 @@ const FilterGroupHeading: FC<ComponentProps<"h3">> = ({
 			className,
 		)}
 		{...props}
-	/>
+	>
+		{children}
+	</h3>
 );
 
 const OptionRow: FC<{ readonly children: ReactNode }> = ({ children }) => (


### PR DESCRIPTION
Enables the `heading-has-content` oxlint rule (jsx-a11y/useHeadingContent), moving it out of the migration backlog and into the enforced a11y rules.

Fixes the three heading wrapper components that spread props onto a bare heading element (`AlertTitle`, and the `SectionHeading`/`FilterGroupHeading` in the agents filter popover) so they destructure and render `children` explicitly, letting the rule verify the headings have content.

> [!NOTE]
> Stacked on top of #29188. Review and merge that PR first.

> [!NOTE]
> This PR was generated by Coder Agents on behalf of @jeremyruppel.
