### PR TITLE
chore(site/.oxlintrc.jsonc): enable oxlint anchor-ambiguous-text rule

### DIFF
--- a/site/.oxlintrc.jsonc
+++ b/site/.oxlintrc.jsonc
@@ -23,6 +23,7 @@
 		"role-has-required-aria-props": "error",
 		"alt-text": "error",
 		"anchor-has-content": "error",
+		"anchor-ambiguous-text": "error",
 		"heading-has-content": "error",
 		"aria-activedescendant-has-tabindex": "error",
 		"mouse-events-have-key-events": "error",
@@ -205,7 +206,6 @@
 		"no-inferrable-types": "off", // style/noInferrableTypes (medium, coder error rule)
 		"consistent-type-imports": "off", // style/useImportType (medium)
 		"jsx-curly-brace-presence": "off", // style/useConsistentCurlyBraces (medium, coder error rule)
-		"anchor-ambiguous-text": "off", // a11y/noAmbiguousAnchorText (medium)
 		"no-fallthrough": "off", // suspicious/noFallthroughSwitchClause (medium)
 		"role-supports-aria-props": "off", // a11y/useAriaPropsSupportedByRole (small)
 		"click-events-have-key-events": "off", // a11y/useKeyWithClickEvents (small)


### PR DESCRIPTION
Enables the `anchor-ambiguous-text` oxlint rule (jsx-a11y), moving it out of the migration backlog and setting it to `error`.

The codebase already has zero violations, so no code changes were needed. Verified with `oxlint --deny-warnings` (0 warnings, 0 errors) and confirmed the rule is active by testing it against a known-bad `<a>click here</a>` sample.

Per request, the corresponding Biome rule (`a11y/noAmbiguousAnchorText`) is intentionally left enabled for now so both linters double-check this.

---
_This PR was generated by Coder Agents on behalf of @jeremyruppel._
