### PR TITLE
chore(site): enable oxlint role-supports-aria-props rule

### DIFF
--- a/site/.oxlintrc.jsonc
+++ b/site/.oxlintrc.jsonc
@@ -21,6 +21,7 @@
 		"img-redundant-alt": "error",
 		"no-redundant-roles": "error",
 		"role-has-required-aria-props": "error",
+		"role-supports-aria-props": "error",
 		"alt-text": "error",
 		"anchor-has-content": "error",
 		"anchor-ambiguous-text": "error",
@@ -207,7 +208,6 @@
 		"consistent-type-imports": "off", // style/useImportType (medium)
 		"jsx-curly-brace-presence": "off", // style/useConsistentCurlyBraces (medium, coder error rule)
 		"no-fallthrough": "off", // suspicious/noFallthroughSwitchClause (medium)
-		"role-supports-aria-props": "off", // a11y/useAriaPropsSupportedByRole (small)
 		"click-events-have-key-events": "off", // a11y/useKeyWithClickEvents (small)
 		"prefer-function-type": "off", // style/useShorthandFunctionType (small)
 		"no-empty-interface": "off", // suspicious/noEmptyInterface (small)

--- a/site/src/components/Autocomplete/Autocomplete.tsx
+++ b/site/src/components/Autocomplete/Autocomplete.tsx
@@ -374,7 +374,6 @@ export function Autocomplete<TOption>({
 					data-testid={testId}
 					aria-expanded={isOpen}
 					aria-haspopup="listbox"
-					aria-invalid={triggerAriaInvalid}
 					aria-describedby={triggerAriaDescribedBy}
 					disabled={disabled}
 					className={cn(

--- a/site/src/modules/resources/AgentLatency.tsx
+++ b/site/src/modules/resources/AgentLatency.tsx
@@ -46,10 +46,7 @@ export const AgentLatency: FC<AgentLatencyProps> = ({ agent }) => {
 				<button
 					type="button"
 					aria-label="latency"
-					className={cn(
-						"cursor-pointer border-0 bg-transparent p-0 [font:inherit]",
-						latency.color,
-					)}
+					className={cn("cursor-pointer", latency.color)}
 				>
 					{Math.round(latency.latency_ms)}ms
 				</button>

--- a/site/src/modules/resources/AgentLatency.tsx
+++ b/site/src/modules/resources/AgentLatency.tsx
@@ -43,13 +43,16 @@ export const AgentLatency: FC<AgentLatencyProps> = ({ agent }) => {
 	return (
 		<HelpPopover>
 			<HelpPopoverTrigger asChild>
-				<span
-					role="presentation"
+				<button
+					type="button"
 					aria-label="latency"
-					className={cn("cursor-pointer", latency.color)}
+					className={cn(
+						"cursor-pointer border-0 bg-transparent p-0 [font:inherit]",
+						latency.color,
+					)}
 				>
 					{Math.round(latency.latency_ms)}ms
-				</span>
+				</button>
 			</HelpPopoverTrigger>
 			<HelpPopoverContent>
 				<HelpPopoverTitle>Latency</HelpPopoverTitle>


### PR DESCRIPTION
Enables the `role-supports-aria-props` oxlint rule (jsx-a11y), moving it out of the migration backlog and setting it to `error`.

Stacked on top of #29191. Review that PR first; the base of this PR is its branch.

## Fixes for the two violations the rule surfaced

- **`Autocomplete.tsx` (select-only trigger button):** removed `aria-invalid` from the `<button>`. `aria-invalid` is not exposed by the implicit `button` role, so it had no effect for assistive tech. The error message linkage via `aria-describedby` (a global attribute) is kept. The only consumer that sets an invalid state (`ModelIdentifierField`) uses the `inlineSearch` variant, which renders an `<input role="combobox">` that still keeps `aria-invalid` (valid there).
- **`AgentLatency.tsx` (latency popover trigger):** the trigger was a `<span role="presentation" aria-label="latency">`; `presentation` does not support `aria-label`, and a presentational role on an interactive trigger is wrong. Converted it to a real `<button>` with reset styling so it stays visually identical (inline colored text, no button chrome) while being a focusable, correctly-labeled control.

## Verification

- `oxlint --deny-warnings`: 0 warnings, 0 errors.
- `biome lint --error-on-warnings` on the changed files: clean.
- `tsc -p .`: clean.
- Storybook visual check of `components/AgentRow --example`: latency renders as inline colored text (no boxed button) and clicking it still opens the "Latency" popover.

---
_This PR was generated by Coder Agents on behalf of @jeremyruppel._
