### PR TITLE
chore: pin docs-check model and add the measured evidence discipline

### DIFF
--- a/.claude/skills/doc-check/SKILL.md
+++ b/.claude/skills/doc-check/SKILL.md
@@ -46,6 +46,44 @@ writing them.
 6. **Report findings.** Use the method provided in the prompt, or if none
    specified, summarize findings directly.
 
+## Evidence discipline
+
+Follow this order on every review. It is the discipline that measured best
+when this job was benchmarked against 48 real merged PRs, each judged
+against the docs as they stood at that PR's own base commit. The harness,
+the answer key, and the per-PR results are in the
+[doc-check evals](https://github.com/coder/solstice/tree/main/evals/doccheck).
+
+1. **List what the user experiences, not what files changed.**
+   "User-facing" means what a user sees, types, clicks, or receives.
+   Dashboard code and wiring code count when they change what the user
+   experiences. A new label, a new tab, a new required field, a new
+   setting, and a removed control all count.
+2. **Check two kinds of page per item.** For each item on that list, check
+   the conceptual guide for that area, and any page that enumerates the
+   things this change adds to or removes from (a table of settings, a list
+   of tabs, a list of fields). An auto-generated CLI or API reference
+   never closes a gap in a conceptual guide. Treat the reference and the
+   guide as two separate checks.
+3. **Find the sentence, not the topic.** For each concrete fact the diff
+   introduces or changes (a default value, a flag name, a version number,
+   a threshold, a UI label), find the exact current sentence in `docs/`
+   that states the old fact. Read the page content, not just the diff. If
+   a page states the old fact, that is a gap. If no page states the fact
+   and the content guidelines require it, that is also a gap. If no page
+   states it and the guidelines do not require it, that is not a gap:
+   absence alone is not drift.
+4. **A PR that documents itself needs nothing more.** Judge the state
+   after the whole diff lands. If the diff already adds or fixes the
+   documentation that its own code change requires, the requirement is
+   satisfied inside the PR. Post no comment.
+5. **Write the evidence before the verdict.** For each user-facing change,
+   state the change, the page you checked, and what you found on it. Then
+   state whether that evidence shows a real unresolved gap, and comment
+   only when it does. A verdict that contradicts your own evidence is the
+   most common failure mode on this job, so read both once more before you
+   post.
+
 ## What to Check
 
 - **Accuracy**: Does documentation match current code behavior?

--- a/.claude/skills/doc-check/SKILL.md
+++ b/.claude/skills/doc-check/SKILL.md
@@ -48,11 +48,7 @@ writing them.
 
 ## Evidence discipline
 
-Follow this order on every review. It is the discipline that measured best
-when this job was benchmarked against 48 real merged PRs, each judged
-against the docs as they stood at that PR's own base commit. The harness,
-the answer key, and the per-PR results are in the
-[doc-check evals](https://github.com/coder/solstice/tree/main/evals/doccheck).
+Follow this order on every review.
 
 1. **List what the user experiences, not what files changed.**
    "User-facing" means what a user sees, types, clicks, or receives.

--- a/.github/workflows/doc-check.yaml
+++ b/.github/workflows/doc-check.yaml
@@ -12,6 +12,10 @@
 # Note: This workflow requires access to secrets and will be skipped for:
 #   - Any PR where secrets are not available
 # For these PRs, maintainers can manually trigger via workflow_dispatch.
+#
+# Model selection: the review model is pinned by the repository variable
+# DOC_CHECK_MODEL_CONFIG_ID. Leave it unset to use the deployment's default
+# model. See the "Run doc-check via Coder Agent Chat" step below.
 
 name: AI Documentation Check
 
@@ -172,6 +176,10 @@ jobs:
 
           Use \`gh\` to get PR details, diff, and all comments. Look for an existing doc-check comment containing \`<!-- doc-check-sticky -->\` - if one exists, you'll update it instead of creating a new one.
 
+          Follow the skill's evidence discipline. State the evidence for each
+          user-facing change before you decide, and post nothing when the
+          evidence does not show a real unresolved gap.
+
           **Do not comment if no documentation changes are needed.**
 
           If a sticky comment already exists, compare your current findings against it:
@@ -217,6 +225,16 @@ jobs:
         with:
           coder-url: ${{ secrets.DOC_CHECK_CODER_URL }}
           coder-token: ${{ secrets.DOC_CHECK_CODER_SESSION_TOKEN }}
+          # The bot account belongs to many organizations on this deployment,
+          # where the action's fallback organization choice is not
+          # deterministic. Pin it, because a model configuration ID only
+          # resolves inside its own organization.
+          coder-organization: coder
+          # Pins the model that reviews the PR. Set this repository variable to
+          # a model configuration ID in the organization above. Unset means the
+          # deployment's default model, so clearing the variable is the
+          # rollback path and needs no code change.
+          model-config-id: ${{ vars.DOC_CHECK_MODEL_CONFIG_ID }}
           chat-prompt: ${{ steps.extract-context.outputs.chat_prompt }}
           github-url: ${{ steps.determine-context.outputs.pr_url }}
           github-token: ${{ github.token }}

--- a/.github/workflows/doc-check.yaml
+++ b/.github/workflows/doc-check.yaml
@@ -12,10 +12,6 @@
 # Note: This workflow requires access to secrets and will be skipped for:
 #   - Any PR where secrets are not available
 # For these PRs, maintainers can manually trigger via workflow_dispatch.
-#
-# Model selection: the review model is pinned by the repository variable
-# DOC_CHECK_MODEL_CONFIG_ID. Leave it unset to use the deployment's default
-# model. See the "Run doc-check via Coder Agent Chat" step below.
 
 name: AI Documentation Check
 


### PR DESCRIPTION
This lets us choose which model reviews a PR for documentation, instead of always using the deployment default. Set the repository variable `DOC_CHECK_MODEL_CONFIG_ID` to a model configuration ID to pick one, and clear it to go back. We want this so doc-check can run on a local LLM at no marginal cost. It also pins the chat organization, because the bot account belongs to many organizations and the model ID only works inside one of them.

The skill file gains the review order that scored best when we benchmarked this job against 48 real merged PRs: list what the user experiences, check the guide and the list page separately, find the exact stale sentence, treat a PR that ships its own docs as done, and write the evidence before the verdict.

The local LLM we tested still scores lower than a frontier model on our benchmark, 89.6 percent against 96.6 percent but is deemed effective for this use case and we'll continue to iterate on models/instructions