### PR TITLE
fix: require the doc-check skill to search before a silent pass

### DIFF
--- a/.claude/skills/doc-check/SKILL.md
+++ b/.claude/skills/doc-check/SKILL.md
@@ -61,24 +61,40 @@ Follow this order on every review.
    of tabs, a list of fields). An auto-generated CLI or API reference
    never closes a gap in a conceptual guide. Treat the reference and the
    guide as two separate checks.
-3. **Find the sentence, not the topic.** For each concrete fact the diff
-   introduces or changes (a default value, a flag name, a version number,
-   a threshold, a UI label), find the exact current sentence in `docs/`
-   that states the old fact. Read the page content, not just the diff. If
-   a page states the old fact, that is a gap. If no page states the fact
-   and the content guidelines require it, that is also a gap. If no page
-   states it and the guidelines do not require it, that is not a gap:
-   absence alone is not drift.
+3. **Search for the old fact, do not read only the diff.** List every
+   literal the diff changes: default values, flag names, env var names,
+   thresholds, UI labels. Search the whole docs tree for each **old**
+   literal before you decide:
+
+   ```sh
+   grep -rn '<the old literal>' docs/ | grep -v '^docs/reference/'
+   ```
+
+   Search the value as a number and as prose, because a guide can spell it
+   out ("thirty days" as well as `30d`). A hit outside `docs/reference/` is
+   a gap: this PR regenerating a reference page never fixes a conceptual
+   guide. Report each search you ran and what it returned. A review that
+   inspects only the files in the diff cannot find this class of gap, which
+   is the most common real one, so it is not a review.
+
+   If no page states the fact and the content guidelines require it, that
+   is also a gap. If no page states it and the guidelines do not require
+   it, that is not a gap: absence alone is not drift.
 4. **A PR that documents itself needs nothing more.** Judge the state
    after the whole diff lands. If the diff already adds or fixes the
    documentation that its own code change requires, the requirement is
    satisfied inside the PR. Post no comment.
 5. **Write the evidence before the verdict.** For each user-facing change,
-   state the change, the page you checked, and what you found on it. Then
-   state whether that evidence shows a real unresolved gap, and comment
-   only when it does. A verdict that contradicts your own evidence is the
-   most common failure mode on this job, so read both once more before you
-   post.
+   state the change, the searches you ran, the page you checked, and what
+   you found on it. Then state whether that evidence shows a real
+   unresolved gap, and comment only when it does. A verdict that
+   contradicts your own evidence is the most common failure mode on this
+   job, so read both once more before you post.
+
+   Staying silent is a finding too, and it earns the same evidence. Post
+   nothing only after every search in step 3 came back empty outside
+   `docs/reference/`. "The diff already updates its own reference page" is
+   not a reason to skip the search.
 
 ## What to Check
 

--- a/.github/workflows/doc-check.yaml
+++ b/.github/workflows/doc-check.yaml
@@ -172,9 +172,12 @@ jobs:
 
           Use \`gh\` to get PR details, diff, and all comments. Look for an existing doc-check comment containing \`<!-- doc-check-sticky -->\` - if one exists, you'll update it instead of creating a new one.
 
-          Follow the skill's evidence discipline. State the evidence for each
-          user-facing change before you decide, and post nothing when the
-          evidence does not show a real unresolved gap.
+          Follow the skill's evidence discipline, including its mandatory
+          search: list every literal this diff changes, then search the whole
+          docs tree for each OLD literal before you decide. Do not review only
+          the files in the diff. Report each search you ran and what it
+          returned, and post nothing only after every search came back empty
+          outside \`docs/reference/\`.
 
           **Do not comment if no documentation changes are needed.**
 


### PR DESCRIPTION
Follow-up to #29194. That PR let us pick the review model, and picking a smaller local model exposed a hole in the instructions rather than in the model.

## What went wrong

On a PR that raises one documented default from `1m` to `5m`, the review read the diff, saw that the diff already regenerated `docs/reference/cli/server.md`, concluded "the changes are minimal and fully accounted for", and posted nothing. Two pages still stated the old default. It never searched `docs/` at all, because nothing required it and staying silent was the cheapest exit.

A larger model went looking on its own and found one of the two pages. That difference is initiative, not judgment, so the instructions have to supply it.

## What changes

`.claude/skills/doc-check/SKILL.md`, step 3: name the search, show the command, and say plainly that a review of only the files in the diff is not a review.

```sh
grep -rn '<the old literal>' docs/ | grep -v '^docs/reference/'
```

Step 5: staying silent is a finding and earns the same evidence. Post nothing only after every search comes back empty outside `docs/reference/`. "The diff already updates its own reference page" is not a reason to skip the search.

The workflow prompt says the same in short, so the requirement is visible without loading the skill.

## Measured

One real PR that changes a documented default, same model, same harness, before and after this change:

| | Before | After |
|---|---|---|
| `prebuilt-workspaces.md` (guide states "defaults to 1 minute") | missed | found |
| `configuration-reference.md` (generated, still states the old default) | missed | found |
| Declined to ask for a hand edit of the generated CLI reference | n/a, stayed silent | correct |
| Outcome | silent pass | both gaps reported |

The larger model, on the same PR before this change, found the first page and missed the second.

The examples in the text deliberately use an unrelated value, so the PR above stays usable as a blind regression case.