### PR TITLE
ci: default GOTMPDIR before mounting the Linux Go tmpfs

### DIFF
--- a/.github/actions/test-go-pg/action.yaml
+++ b/.github/actions/test-go-pg/action.yaml
@@ -56,9 +56,11 @@ runs:
       run: |
         # GOTMPDIR holds test binaries and t.TempDir() output. Keep them off
         # the EBS-backed root disk like the Windows and macOS RAM disks do.
+        # Default the path here so the mount does not depend on the caller
+        # also running ./.github/actions/setup-go-paths.
         if [[ -z "${GOTMPDIR:-}" ]]; then
-          echo "GOTMPDIR is not set, skipping"
-          exit 0
+          GOTMPDIR="${RUNNER_TEMP}/go-tmp"
+          echo "GOTMPDIR=${GOTMPDIR}" >> "${GITHUB_ENV}"
         fi
         mkdir -p "${GOTMPDIR}"
         sudo mount -t tmpfs -o size=8g tmpfs "${GOTMPDIR}"

--- a/.github/actions/test-go-pg/action.yaml
+++ b/.github/actions/test-go-pg/action.yaml
@@ -53,7 +53,7 @@ runs:
     - name: Mount tmpfs for Go temp dir (Linux)
       if: runner.os == 'Linux'
       shell: bash
-      run: |
+      run: | # zizmor: ignore[github-env] GOTMPDIR uses only runner-provided paths.
         # GOTMPDIR holds test binaries and t.TempDir() output. Keep them off
         # the EBS-backed root disk like the Windows and macOS RAM disks do.
         # Default the path here so the mount does not depend on the caller


### PR DESCRIPTION
Follow-up to https://github.com/coder/coder/pull/28919.

The tmpfs mount step only ran when `GOTMPDIR` was already exported, and the only thing that exports it is `./.github/actions/setup-go-paths`, which just `test-go-pg` uses. So on `test-go-pg-17`, `test-go-race-pg` and `flake_go` the step printed `GOTMPDIR is not set, skipping` and exited 0, and Go test binaries and `t.TempDir()` output stayed on the root disk. https://github.com/coder/coder/actions/runs/34359015069/job/102491022886 is one such run.

To fix, we'll just have the action default `GOTMPDIR` to `${RUNNER_TEMP}/go-tmp` (the same path `setup-go-paths` uses) and export it via `$GITHUB_ENV` before mounting. The skip path is gone, so a mount failure now fails the step.

Worth noting that `test-go-pg`, where the mount was already active, still stalled on https://github.com/coder/coder/actions/runs/34481693660/job/102889890085, with the `iostat` samples showing the disk at 100% utilisation regardless. So I don't expect this to fix the stalls on its own, but it at least makes all the Linux jobs behave the same whilst we chase the underlying issue with Depot.
