### PR TITLE
fix: fail the doc-check when the review workspace is dormant

### DIFF
--- a/.github/workflows/doc-check.yaml
+++ b/.github/workflows/doc-check.yaml
@@ -170,11 +170,11 @@ jobs:
 
           When creating a new workspace, use the \"coder-workflow-bot\" template.
 
-          If any tool call fails with \`get workspace agents in latest build: unauthorized: rbac: forbidden\`, this chat's workspace is stopped or dormant. That is an infrastructure state, not a mistake in your command. Do not retry the same command, because it fails the same way.
+          If a tool call fails because this chat has no working workspace, repair it before you review anything. The clearest sign is \`get workspace agents in latest build: unauthorized: rbac: forbidden\`, which means the workspace is stopped or dormant. It is an infrastructure state, not a mistake in your command, so the same command fails again if you retry it.
 
-          Call \`start_workspace\` with no arguments. It starts the workspace this chat already owns, and it clears dormancy. Wait for it to finish, then run the failed tool call again.
+          Call \`start_workspace\` with no arguments. It starts the workspace this chat already owns, and it clears dormancy. If it answers \`workspace was deleted\` or \`chat has no workspace\`, the old workspace is gone: call \`list_templates\` to get the ID of the \`coder-workflow-bot\` template, then call \`create_workspace\` with that ID. Wait for the workspace to be ready, then run the failed tool call again.
 
-          If \`start_workspace\` fails, or the same error comes back after it, stop. Say that you could not review the PR, and name this error. Post no doc-check comment. Do not say or imply the docs are fine, because you did not read them.
+          If the repair fails, stop. Say that you could not review the PR, and name the error you got. Post no doc-check comment. Do not say or imply the docs are fine, because you did not read them.
 
           Use \`gh\` to get PR details, diff, and all comments. Look for an existing doc-check comment containing \`<!-- doc-check-sticky -->\` - if one exists, you'll update it instead of creating a new one.
 

--- a/.github/workflows/doc-check.yaml
+++ b/.github/workflows/doc-check.yaml
@@ -144,9 +144,10 @@ jobs:
           # The workspace stops after about a day and then goes dormant. A chat
           # cannot repair a dormant workspace: start_workspace and
           # create_workspace both fail with
-          # "unauthorized: rbac: forbidden" (CODAGT-1025). The review then reads
+          # "unauthorized: rbac: forbidden". The review then reads
           # nothing and posts nothing, and this job used to still pass. Fail
           # here instead, so the check reports what happened.
+          # https://linear.app/codercom/issue/CODAGT-1025
           WS_NAME="doc-check-pr-${PR_NUMBER}"
           RESPONSE=$(curl -sS --fail-with-body -G \
             -H "Coder-Session-Token: ${CODER_TOKEN}" \
@@ -157,13 +158,13 @@ jobs:
             }
           DORMANT_AT=$(echo "${RESPONSE}" | jq -r '.workspaces[0].dormant_at // empty')
           if [[ -n "${DORMANT_AT}" ]]; then
-            echo "::error::${WS_NAME} is dormant since ${DORMANT_AT}. The review cannot run, because a chat cannot start its own dormant workspace (CODAGT-1025)."
+            echo "::error::${WS_NAME} is dormant since ${DORMANT_AT}. The review cannot run, because a chat cannot start its own dormant workspace: https://linear.app/codercom/issue/CODAGT-1025"
             {
               echo "### Documentation check did not run"
               echo ""
               echo "The workspace \`${WS_NAME}\` is dormant since ${DORMANT_AT}."
               echo ""
-              echo "A chat cannot start its own dormant workspace, so the review would read no files and post no comment. See CODAGT-1025."
+              echo "A chat cannot start its own dormant workspace, so the review would read no files and post no comment. See [CODAGT-1025](https://linear.app/codercom/issue/CODAGT-1025)."
               echo ""
               echo "To run the review now, start \`${WS_NAME}\` in Coder, then push again or re-run this job."
             } >> "${GITHUB_STEP_SUMMARY}"

--- a/.github/workflows/doc-check.yaml
+++ b/.github/workflows/doc-check.yaml
@@ -132,6 +132,45 @@ jobs:
             exit 1
           fi
 
+      - name: Check the review workspace is usable
+        if: steps.check-secrets.outputs.skip != 'true'
+        id: check-workspace
+        env:
+          CODER_URL: ${{ secrets.DOC_CHECK_CODER_URL }}
+          CODER_TOKEN: ${{ secrets.DOC_CHECK_CODER_SESSION_TOKEN }}
+          PR_NUMBER: ${{ steps.determine-context.outputs.pr_number }}
+        run: |
+          # A review reuses one chat per PR, and that chat owns one workspace.
+          # The workspace stops after about a day and then goes dormant. A chat
+          # cannot repair a dormant workspace: start_workspace and
+          # create_workspace both fail with
+          # "unauthorized: rbac: forbidden" (CODAGT-1025). The review then reads
+          # nothing and posts nothing, and this job used to still pass. Fail
+          # here instead, so the check reports what happened.
+          WS_NAME="doc-check-pr-${PR_NUMBER}"
+          RESPONSE=$(curl -sS --fail-with-body -G \
+            -H "Coder-Session-Token: ${CODER_TOKEN}" \
+            --data-urlencode "q=owner:me name:${WS_NAME}" \
+            "${CODER_URL%/}/api/v2/workspaces") || {
+              echo "::warning::Could not read the workspace state from Coder. Continuing."
+              exit 0
+            }
+          DORMANT_AT=$(echo "${RESPONSE}" | jq -r '.workspaces[0].dormant_at // empty')
+          if [[ -n "${DORMANT_AT}" ]]; then
+            echo "::error::${WS_NAME} is dormant since ${DORMANT_AT}. The review cannot run, because a chat cannot start its own dormant workspace (CODAGT-1025)."
+            {
+              echo "### Documentation check did not run"
+              echo ""
+              echo "The workspace \`${WS_NAME}\` is dormant since ${DORMANT_AT}."
+              echo ""
+              echo "A chat cannot start its own dormant workspace, so the review would read no files and post no comment. See CODAGT-1025."
+              echo ""
+              echo "To run the review now, start \`${WS_NAME}\` in Coder, then push again or re-run this job."
+            } >> "${GITHUB_STEP_SUMMARY}"
+            exit 1
+          fi
+          echo "Workspace state is usable."
+
       - name: Build chat prompt
         if: steps.check-secrets.outputs.skip != 'true'
         id: extract-context
@@ -170,11 +209,13 @@ jobs:
 
           When creating a new workspace, use the \"coder-workflow-bot\" template.
 
-          If a tool call fails because this chat has no working workspace, repair it before you review anything. The clearest sign is \`get workspace agents in latest build: unauthorized: rbac: forbidden\`, which means the workspace is stopped or dormant. It is an infrastructure state, not a mistake in your command, so the same command fails again if you retry it.
+          If a tool call fails with \`get workspace agents in latest build: unauthorized: rbac: forbidden\`, this chat has no working workspace. That is an infrastructure state, not a mistake in your command, so the same command fails again if you retry it.
 
-          Call \`start_workspace\` with no arguments. It starts the workspace this chat already owns, and it clears dormancy. If it answers \`workspace was deleted\` or \`chat has no workspace\`, the old workspace is gone: call \`list_templates\` to get the ID of the \`coder-workflow-bot\` template, then call \`create_workspace\` with that ID. Wait for the workspace to be ready, then run the failed tool call again.
+          Call \`start_workspace\` with no arguments to start the workspace this chat owns. If it answers \`workspace was deleted\` or \`chat has no workspace\`, the old one is gone: call \`list_templates\` to get the ID of the \`coder-workflow-bot\` template, then call \`create_workspace\` with that ID. Wait for the workspace to be ready, then run the failed tool call again.
 
-          If the repair fails, stop. Say that you could not review the PR, and name the error you got. Post no doc-check comment. Do not say or imply the docs are fine, because you did not read them.
+          If \`start_workspace\` answers \`load workspace: unauthorized: rbac: forbidden\`, the workspace is dormant and you cannot repair it. Stop there.
+
+          When you cannot repair the workspace, say that you could not review the PR, and name the error you got. Post no doc-check comment. Do not say or imply the docs are fine, because you did not read them.
 
           Use \`gh\` to get PR details, diff, and all comments. Look for an existing doc-check comment containing \`<!-- doc-check-sticky -->\` - if one exists, you'll update it instead of creating a new one.
 

--- a/.github/workflows/doc-check.yaml
+++ b/.github/workflows/doc-check.yaml
@@ -170,6 +170,12 @@ jobs:
 
           When creating a new workspace, use the \"coder-workflow-bot\" template.
 
+          If any tool call fails with \`get workspace agents in latest build: unauthorized: rbac: forbidden\`, this chat's workspace is stopped or dormant. That is an infrastructure state, not a mistake in your command. Do not retry the same command, because it fails the same way.
+
+          Call \`start_workspace\` with no arguments. It starts the workspace this chat already owns, and it clears dormancy. Wait for it to finish, then run the failed tool call again.
+
+          If \`start_workspace\` fails, or the same error comes back after it, stop. Say that you could not review the PR, and name this error. Post no doc-check comment. Do not say or imply the docs are fine, because you did not read them.
+
           Use \`gh\` to get PR details, diff, and all comments. Look for an existing doc-check comment containing \`<!-- doc-check-sticky -->\` - if one exists, you'll update it instead of creating a new one.
 
           Follow the skill's evidence discipline, including its mandatory


### PR DESCRIPTION
A review reuses one chat for each pull request, and that chat owns one workspace. The workspace stops after about a day and then goes dormant. When a later push reuses the chat, every tool call fails:

```
get workspace agents in latest build: unauthorized: rbac: forbidden
```

The review reads no files, searches no docs, and posts nothing. This job read only the chat's terminal status, so the pull request got a green check for a review that never ran.

Tracked in [CODAGT-1025](https://linear.app/codercom/issue/CODAGT-1025).

## How often

Measured on the deployment that runs doc-check, over 30 days:

| | |
|---|---|
| review sessions inspected | 250 |
| sessions that hit this error | 54 (21.6%), 54 distinct pull requests |
| failure on a reused chat, more than 48 h after the chat was created | 44 |
| reused chat, 6 to 48 h later | 9 |
| within 15 min of chat creation | 1 |
| first seen | 2026-07-23 |

The failing turn ran on Opus 4.8 in 49 of 54 cases, so this is not model specific. Right now 116 of 159 review workspaces are dormant, and 20 of those belong to open pull requests.

## What changes

A new step reads the workspace state from Coder before the chat starts. If the workspace is dormant, the job fails, and the error and the summary link [CODAGT-1025](https://linear.app/codercom/issue/CODAGT-1025) and say how to start the workspace. If Coder cannot be read, the step warns and continues, so this never blocks a review on its own.

The prompt now tells the review what to do when a tool call fails on the workspace, and it matches what the tools can actually do:

- stopped workspace: call `start_workspace`
- deleted workspace: `list_templates`, then `create_workspace` with the `coder-workflow-bot` template
- dormant workspace: it cannot be repaired from inside the chat, so stop, say the review did not happen, and post no comment

## Why the chat cannot repair a dormant workspace

A dormant workspace is a different RBAC resource. `WorkspaceTable.RBACObject` returns `ResourceWorkspaceDormant` when `DormantAt` is set. The chat daemon subject holds `workspace` read and update and no `workspace_dormant` permission, so both `start_workspace` and `create_workspace` fail on the same read before they do any work. Full write-up, with the code paths and a suggested fix, in [CODAGT-1025](https://linear.app/codercom/issue/CODAGT-1025).

I tested this on this pull request: with its workspace stopped and dormant, the review called `start_workspace` twice, got `load workspace: unauthorized: rbac: forbidden`, then stopped and posted nothing. The new step then failed the job before the chat started, which is what the red check on this pull request is.

## Still open

The job reads only the chat's terminal status, so a review that could not run and a review that found nothing both report success. The dormant case is covered here. Other failures are not.
