### PR TITLE
fix(site): keep workspace delete and bulk stop errors in the confirm dialog

### DIFF
--- a/site/src/components/Alert/ErrorAlert.tsx
+++ b/site/src/components/Alert/ErrorAlert.tsx
@@ -8,15 +8,17 @@ type ErrorAlertProps = Readonly<
 	Omit<AlertProps, "severity" | "children"> & {
 		error: unknown;
 		showDebugDetail?: boolean;
+		defaultMessage?: string;
 	}
 >;
 
 export const ErrorAlert: FC<ErrorAlertProps> = ({
 	error,
 	showDebugDetail = true,
+	defaultMessage = "Something went wrong.",
 	...alertProps
 }) => {
-	const message = getErrorMessage(error, "Something went wrong.");
+	const message = getErrorMessage(error, defaultMessage);
 	const detail = getErrorDetail(error);
 	const status = getErrorStatus(error);
 

--- a/site/src/components/Dialog/ConfirmDialog/ConfirmDialog.stories.tsx
+++ b/site/src/components/Dialog/ConfirmDialog/ConfirmDialog.stories.tsx
@@ -1,5 +1,6 @@
 import type { Meta, StoryObj } from "@storybook/react-vite";
 import { expect, fn, screen, userEvent } from "storybook/test";
+import { mockApiError } from "#/testHelpers/entities";
 import { ConfirmDialog } from "./ConfirmDialog";
 
 const meta: Meta<typeof ConfirmDialog> = {
@@ -81,6 +82,20 @@ export const SuccessDialogLoading: Story = {
 	play: async () => {
 		// Spinner prefixes the accessible name with "Loading spinner".
 		await expect(screen.getByRole("button", { name: /ok/i })).toBeDisabled();
+	},
+};
+
+export const FailedConfirm: Story = {
+	args: {
+		description: "Are you sure you want to stop 3 workspaces?",
+		hideCancel: false,
+		type: "delete",
+		confirmText: "Stop",
+		title: "Stop 3 workspaces",
+		error: mockApiError({
+			message: "Failed to stop workspaces.",
+			detail: "workspace-2 is already busy with a build.",
+		}),
 	},
 };
 

--- a/site/src/components/Dialog/ConfirmDialog/ConfirmDialog.stories.tsx
+++ b/site/src/components/Dialog/ConfirmDialog/ConfirmDialog.stories.tsx
@@ -1,6 +1,5 @@
 import type { Meta, StoryObj } from "@storybook/react-vite";
 import { expect, fn, screen, userEvent } from "storybook/test";
-import { mockApiError } from "#/testHelpers/entities";
 import { ConfirmDialog } from "./ConfirmDialog";
 
 const meta: Meta<typeof ConfirmDialog> = {
@@ -92,10 +91,8 @@ export const FailedConfirm: Story = {
 		type: "delete",
 		confirmText: "Stop",
 		title: "Stop 3 workspaces",
-		error: mockApiError({
-			message: "Failed to stop workspaces.",
-			detail: "workspace-2 is already busy with a build.",
-		}),
+		error: new Error("The network request failed."),
+		errorMessage: "Failed to stop workspaces.",
 	},
 };
 

--- a/site/src/components/Dialog/ConfirmDialog/ConfirmDialog.test.tsx
+++ b/site/src/components/Dialog/ConfirmDialog/ConfirmDialog.test.tsx
@@ -1,0 +1,23 @@
+import { render } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { ConfirmDialog } from "./ConfirmDialog";
+
+describe("ConfirmDialog", () => {
+	it("does not close while confirming", async () => {
+		const user = userEvent.setup();
+		const onClose = vi.fn();
+		render(
+			<ConfirmDialog
+				open
+				title="Delete workspace"
+				description="Are you sure?"
+				confirmLoading
+				onClose={onClose}
+			/>,
+		);
+
+		await user.keyboard("{Escape}");
+
+		expect(onClose).not.toHaveBeenCalled();
+	});
+});

--- a/site/src/components/Dialog/ConfirmDialog/ConfirmDialog.tsx
+++ b/site/src/components/Dialog/ConfirmDialog/ConfirmDialog.tsx
@@ -50,6 +50,7 @@ export interface ConfirmDialogProps {
 	 */
 	readonly onConfirm?: () => void;
 	readonly error?: unknown;
+	readonly errorMessage?: string;
 	readonly type?: ConfirmDialogType;
 	/**
 	 * Defaults to shown for "delete", hidden for "info"/"success".
@@ -74,6 +75,7 @@ export const ConfirmDialog: FC<ConfirmDialogProps> = ({
 	description,
 	disabled = false,
 	error,
+	errorMessage,
 	hideCancel,
 	onClose,
 	onCloseAutoFocus,
@@ -91,7 +93,7 @@ export const ConfirmDialog: FC<ConfirmDialogProps> = ({
 		<Dialog
 			open={open}
 			onOpenChange={(nextOpen) => {
-				if (!nextOpen) {
+				if (!nextOpen && !confirmLoading) {
 					onClose();
 				}
 			}}
@@ -111,7 +113,11 @@ export const ConfirmDialog: FC<ConfirmDialogProps> = ({
 				</DialogHeader>
 
 				{error != null && !confirmLoading && (
-					<ErrorAlert error={error} showDebugDetail={false} />
+					<ErrorAlert
+						error={error}
+						defaultMessage={errorMessage}
+						showDebugDetail={false}
+					/>
 				)}
 
 				<DialogFooter>

--- a/site/src/components/Dialog/ConfirmDialog/ConfirmDialog.tsx
+++ b/site/src/components/Dialog/ConfirmDialog/ConfirmDialog.tsx
@@ -1,4 +1,5 @@
 import type { FC, ReactNode } from "react";
+import { ErrorAlert } from "#/components/Alert/ErrorAlert";
 import {
 	Dialog,
 	DialogActions,
@@ -48,6 +49,7 @@ export interface ConfirmDialogProps {
 	 * dialog without `onConfirm` closes without deleting anything.
 	 */
 	readonly onConfirm?: () => void;
+	readonly error?: unknown;
 	readonly type?: ConfirmDialogType;
 	/**
 	 * Defaults to shown for "delete", hidden for "info"/"success".
@@ -71,6 +73,7 @@ export const ConfirmDialog: FC<ConfirmDialogProps> = ({
 	confirmText,
 	description,
 	disabled = false,
+	error,
 	hideCancel,
 	onClose,
 	onCloseAutoFocus,
@@ -106,6 +109,10 @@ export const ConfirmDialog: FC<ConfirmDialogProps> = ({
 						</div>
 					</DialogDescription>
 				</DialogHeader>
+
+				{error != null && !confirmLoading && (
+					<ErrorAlert error={error} showDebugDetail={false} />
+				)}
 
 				<DialogFooter>
 					<DialogActions

--- a/site/src/components/Dialog/DeleteDialog/DeleteDialog.stories.tsx
+++ b/site/src/components/Dialog/DeleteDialog/DeleteDialog.stories.tsx
@@ -1,6 +1,5 @@
 import type { Meta, StoryObj } from "@storybook/react-vite";
 import { expect, fn, userEvent, within } from "storybook/test";
-import { mockApiError } from "#/testHelpers/entities";
 import { DeleteDialog } from "./DeleteDialog";
 
 const meta: Meta<typeof DeleteDialog> = {
@@ -59,10 +58,7 @@ export const FilledWrong: Story = {
 
 export const FailedDelete: Story = {
 	args: {
-		error: mockApiError({
-			message: "Failed to delete foo.",
-			detail: "This foo is still in use.",
-		}),
+		error: new Error("The network request failed."),
 	},
 	play: async ({ canvasElement }) => {
 		const user = userEvent.setup();

--- a/site/src/components/Dialog/DeleteDialog/DeleteDialog.stories.tsx
+++ b/site/src/components/Dialog/DeleteDialog/DeleteDialog.stories.tsx
@@ -1,5 +1,6 @@
 import type { Meta, StoryObj } from "@storybook/react-vite";
 import { expect, fn, userEvent, within } from "storybook/test";
+import { mockApiError } from "#/testHelpers/entities";
 import { DeleteDialog } from "./DeleteDialog";
 
 const meta: Meta<typeof DeleteDialog> = {
@@ -53,6 +54,23 @@ export const FilledWrong: Story = {
 		await expect(
 			body.getByText("InvalidFooName does not match the name of this foo"),
 		).toBeVisible();
+	},
+};
+
+export const FailedDelete: Story = {
+	args: {
+		error: mockApiError({
+			message: "Failed to delete foo.",
+			detail: "This foo is still in use.",
+		}),
+	},
+	play: async ({ canvasElement }) => {
+		const user = userEvent.setup();
+		const body = within(canvasElement.ownerDocument.body);
+		await user.type(
+			await body.findByLabelText("Name of the foo to delete"),
+			"MyFoo",
+		);
 	},
 };
 

--- a/site/src/components/Dialog/DeleteDialog/DeleteDialog.test.tsx
+++ b/site/src/components/Dialog/DeleteDialog/DeleteDialog.test.tsx
@@ -1,0 +1,24 @@
+import { render } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { DeleteDialog } from "./DeleteDialog";
+
+describe("DeleteDialog", () => {
+	it("does not cancel while deleting", async () => {
+		const user = userEvent.setup();
+		const onCancel = vi.fn();
+		render(
+			<DeleteDialog
+				isOpen
+				entity="workspace"
+				name="my-workspace"
+				confirmLoading
+				onCancel={onCancel}
+				onConfirm={vi.fn()}
+			/>,
+		);
+
+		await user.keyboard("{Escape}");
+
+		expect(onCancel).not.toHaveBeenCalled();
+	});
+});

--- a/site/src/components/Dialog/DeleteDialog/DeleteDialog.tsx
+++ b/site/src/components/Dialog/DeleteDialog/DeleteDialog.tsx
@@ -1,5 +1,6 @@
 import { type FC, type FormEvent, useId, useState } from "react";
 import { Alert } from "#/components/Alert/Alert";
+import { ErrorAlert } from "#/components/Alert/ErrorAlert";
 import { Button } from "#/components/Button/Button";
 import {
 	Dialog,
@@ -21,6 +22,7 @@ interface DeleteDialogProps {
 	name: string;
 	info?: string;
 	confirmLoading?: boolean;
+	error?: unknown;
 	verb?: string;
 	title?: string;
 	label?: string;
@@ -35,6 +37,7 @@ export const DeleteDialog: FC<DeleteDialogProps> = ({
 	info,
 	name,
 	confirmLoading = false,
+	error,
 	// Optional overrides for verbiage, e.g. "unlinking" vs "deleting".
 	verb,
 	title,
@@ -117,6 +120,10 @@ export const DeleteDialog: FC<DeleteDialogProps> = ({
 							</span>
 						)}
 					</div>
+
+					{error != null && !confirmLoading && (
+						<ErrorAlert error={error} showDebugDetail={false} />
+					)}
 
 					<DialogFooter>
 						<Button

--- a/site/src/components/Dialog/DeleteDialog/DeleteDialog.tsx
+++ b/site/src/components/Dialog/DeleteDialog/DeleteDialog.tsx
@@ -23,6 +23,7 @@ interface DeleteDialogProps {
 	info?: string;
 	confirmLoading?: boolean;
 	error?: unknown;
+	errorMessage?: string;
 	verb?: string;
 	title?: string;
 	label?: string;
@@ -38,6 +39,7 @@ export const DeleteDialog: FC<DeleteDialogProps> = ({
 	name,
 	confirmLoading = false,
 	error,
+	errorMessage = `Failed to delete ${entity}.`,
 	// Optional overrides for verbiage, e.g. "unlinking" vs "deleting".
 	verb,
 	title,
@@ -60,7 +62,7 @@ export const DeleteDialog: FC<DeleteDialogProps> = ({
 	};
 
 	const handleOpenChange = (open: boolean) => {
-		if (!open) {
+		if (!open && !confirmLoading) {
 			resetConfirmation();
 			onCancel();
 		}
@@ -122,7 +124,11 @@ export const DeleteDialog: FC<DeleteDialogProps> = ({
 					</div>
 
 					{error != null && !confirmLoading && (
-						<ErrorAlert error={error} showDebugDetail={false} />
+						<ErrorAlert
+							error={error}
+							defaultMessage={errorMessage}
+							showDebugDetail={false}
+						/>
 					)}
 
 					<DialogFooter>

--- a/site/src/modules/workspaces/WorkspaceMoreActions/WorkspaceDeleteDialog.stories.tsx
+++ b/site/src/modules/workspaces/WorkspaceMoreActions/WorkspaceDeleteDialog.stories.tsx
@@ -1,6 +1,10 @@
 import type { Meta, StoryObj } from "@storybook/react-vite";
 import { expect, fn, userEvent, waitFor, within } from "storybook/test";
-import { MockFailedWorkspace, MockWorkspace } from "#/testHelpers/entities";
+import {
+	MockFailedWorkspace,
+	MockWorkspace,
+	mockApiError,
+} from "#/testHelpers/entities";
 import { daysAgo } from "#/utils/time";
 import { WorkspaceDeleteDialog } from "./WorkspaceDeleteDialog";
 
@@ -90,5 +94,21 @@ export const FilledWrong: Story = {
 			{ timeout: 5_000 },
 		);
 		await expect(body.getByRole("button", { name: "Delete" })).toBeDisabled();
+	},
+};
+
+export const FailedDelete: Story = {
+	args: {
+		error: mockApiError({
+			message: "Failed to delete workspace.",
+			detail: "The provisioner could not destroy resources.",
+		}),
+	},
+	play: async ({ canvasElement }) => {
+		const body = within(canvasElement.ownerDocument.body);
+		await userEvent.type(
+			body.getByTestId("delete-dialog-name-confirmation"),
+			MockWorkspace.name,
+		);
 	},
 };

--- a/site/src/modules/workspaces/WorkspaceMoreActions/WorkspaceDeleteDialog.tsx
+++ b/site/src/modules/workspaces/WorkspaceMoreActions/WorkspaceDeleteDialog.tsx
@@ -77,6 +77,7 @@ export const WorkspaceDeleteDialog: FC<WorkspaceDeleteDialogProps> = ({
 			disabled={!deletionConfirmed}
 			confirmLoading={confirmLoading}
 			error={error}
+			errorMessage={`Failed to delete workspace "${workspace.name}".`}
 			description={
 				<>
 					<div className="flex items-center justify-between rounded-md border border-solid border-border p-4 mb-5 leading-snug">

--- a/site/src/modules/workspaces/WorkspaceMoreActions/WorkspaceDeleteDialog.tsx
+++ b/site/src/modules/workspaces/WorkspaceMoreActions/WorkspaceDeleteDialog.tsx
@@ -18,6 +18,8 @@ interface WorkspaceDeleteDialogProps {
 	workspace: Workspace;
 	canDeleteFailedWorkspace: boolean;
 	isOpen: boolean;
+	confirmLoading?: boolean;
+	error?: unknown;
 	onCancel: () => void;
 	onConfirm: (arg: CreateWorkspaceBuildRequest["orphan"]) => void;
 }
@@ -26,6 +28,8 @@ export const WorkspaceDeleteDialog: FC<WorkspaceDeleteDialogProps> = ({
 	workspace,
 	canDeleteFailedWorkspace,
 	isOpen,
+	confirmLoading = false,
+	error,
 	onCancel,
 	onConfirm,
 }) => {
@@ -44,7 +48,7 @@ export const WorkspaceDeleteDialog: FC<WorkspaceDeleteDialogProps> = ({
 
 	const onSubmit = (event: FormEvent) => {
 		event.preventDefault();
-		if (deletionConfirmed) {
+		if (deletionConfirmed && !confirmLoading) {
 			onConfirm(orphanWorkspace);
 		}
 	};
@@ -71,6 +75,8 @@ export const WorkspaceDeleteDialog: FC<WorkspaceDeleteDialogProps> = ({
 			onConfirm={() => onConfirm(orphanWorkspace)}
 			onClose={onCancel}
 			disabled={!deletionConfirmed}
+			confirmLoading={confirmLoading}
+			error={error}
 			description={
 				<>
 					<div className="flex items-center justify-between rounded-md border border-solid border-border p-4 mb-5 leading-snug">

--- a/site/src/modules/workspaces/WorkspaceMoreActions/WorkspaceMoreActions.test.tsx
+++ b/site/src/modules/workspaces/WorkspaceMoreActions/WorkspaceMoreActions.test.tsx
@@ -1,0 +1,58 @@
+import { screen, waitFor, within } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { toast } from "sonner";
+import { API } from "#/api/api";
+import { MockWorkspace } from "#/testHelpers/entities";
+import { renderWithAuth } from "#/testHelpers/renderHelpers";
+import { WorkspaceMoreActions } from "./WorkspaceMoreActions";
+
+describe("WorkspaceMoreActions", () => {
+	afterEach(() => {
+		vi.restoreAllMocks();
+	});
+	it("does not toast when deleting a workspace fails", async () => {
+		const user = userEvent.setup({ delay: 0 });
+		const toastError = vi.spyOn(toast, "error");
+		const deleteWorkspaceMock = vi
+			.spyOn(API, "deleteWorkspace")
+			.mockRejectedValueOnce(new Error("Cannot delete workspace."));
+		vi.spyOn(API, "checkAuthorization").mockResolvedValue({
+			readWorkspace: true,
+			shareWorkspace: true,
+			updateWorkspace: true,
+			updateWorkspaceVersion: false,
+			deleteFailedWorkspace: false,
+		});
+		vi.spyOn(API, "getWorkspaceBuildParameters").mockResolvedValue([]);
+
+		const onActionSuccess = vi.fn();
+		renderWithAuth(
+			<WorkspaceMoreActions
+				workspace={MockWorkspace}
+				disabled={false}
+				onActionSuccess={onActionSuccess}
+			/>,
+		);
+
+		await user.click(await screen.findByTestId("workspace-options-button"));
+		await user.click(await screen.findByTestId("delete-button"));
+
+		const dialog = await screen.findByTestId("dialog");
+		await user.type(
+			within(dialog).getByLabelText("Workspace name"),
+			MockWorkspace.name,
+		);
+		await user.click(
+			within(dialog).getByRole("button", {
+				name: "Delete",
+				hidden: false,
+			}),
+		);
+
+		await waitFor(() => {
+			expect(deleteWorkspaceMock).toHaveBeenCalled();
+		});
+		expect(toastError).not.toHaveBeenCalled();
+		expect(onActionSuccess).not.toHaveBeenCalled();
+	});
+});

--- a/site/src/modules/workspaces/WorkspaceMoreActions/WorkspaceMoreActions.tsx
+++ b/site/src/modules/workspaces/WorkspaceMoreActions/WorkspaceMoreActions.tsx
@@ -10,14 +10,7 @@ import {
 import { type FC, useEffect, useState } from "react";
 import { useMutation, useQuery, useQueryClient } from "react-query";
 import { Link as RouterLink } from "react-router";
-import { toast } from "sonner";
 import { ParameterValidationError } from "#/api/api";
-import {
-	type ApiError,
-	getErrorDetail,
-	getErrorMessage,
-	isApiError,
-} from "#/api/errors";
 import {
 	changeVersion,
 	deleteWorkspace,
@@ -32,7 +25,6 @@ import {
 	DropdownMenuSeparator,
 	DropdownMenuTrigger,
 } from "#/components/DropdownMenu/DropdownMenu";
-import { WorkspaceErrorDialog } from "../ErrorDialog/WorkspaceErrorDialog";
 import { UpdateBuildParametersDialog } from "../WorkspaceUpdateDialogs";
 import { ChangeWorkspaceVersionDialog } from "./ChangeWorkspaceVersionDialog";
 import { DownloadLogsDialog } from "./DownloadLogsDialog";
@@ -56,11 +48,6 @@ export const WorkspaceMoreActions: FC<WorkspaceMoreActionsProps> = ({
 }) => {
 	const queryClient = useQueryClient();
 
-	const [workspaceErrorDialog, setWorkspaceErrorDialog] = useState<{
-		open: boolean;
-		error?: ApiError;
-	}>({ open: false });
-
 	// Permissions
 	const { data: permissions } = useQuery(workspacePermissions(workspace));
 
@@ -73,25 +60,6 @@ export const WorkspaceMoreActions: FC<WorkspaceMoreActionsProps> = ({
 		changeVersion(workspace, queryClient),
 	);
 
-	const handleError = (error: unknown) => {
-		if (isApiError(error) && error.code === "ERR_BAD_REQUEST") {
-			setWorkspaceErrorDialog({
-				open: true,
-				error: error,
-			});
-		} else {
-			toast.error(
-				getErrorMessage(
-					error,
-					`Failed to delete workspace "${workspace.name}".`,
-				),
-				{
-					description: getErrorDetail(error),
-				},
-			);
-		}
-	};
-
 	// Delete
 	const [isConfirmingDelete, setIsConfirmingDelete] = useState(false);
 	const deleteWorkspaceOptions = deleteWorkspace(workspace, queryClient);
@@ -100,9 +68,7 @@ export const WorkspaceMoreActions: FC<WorkspaceMoreActionsProps> = ({
 		onSuccess: async (build) => {
 			await deleteWorkspaceOptions.onSuccess?.(build);
 			await onActionSuccess?.();
-		},
-		onError: (error: unknown) => {
-			handleError(error);
+			setIsConfirmingDelete(false);
 		},
 	});
 
@@ -222,23 +188,15 @@ export const WorkspaceMoreActions: FC<WorkspaceMoreActionsProps> = ({
 				workspace={workspace}
 				canDeleteFailedWorkspace={Boolean(permissions?.deleteFailedWorkspace)}
 				isOpen={isConfirmingDelete}
+				confirmLoading={deleteWorkspaceMutation.isPending}
+				error={deleteWorkspaceMutation.error}
 				onCancel={() => {
 					setIsConfirmingDelete(false);
+					deleteWorkspaceMutation.reset();
 				}}
 				onConfirm={(orphan) => {
 					deleteWorkspaceMutation.mutate({ orphan });
-					setIsConfirmingDelete(false);
 				}}
-			/>
-
-			<WorkspaceErrorDialog
-				open={workspaceErrorDialog.open}
-				error={workspaceErrorDialog.error}
-				onClose={() => setWorkspaceErrorDialog({ open: false })}
-				workspaceOwner={workspace.owner_name}
-				workspaceName={workspace.name}
-				templateVersionId={workspace.latest_build.template_version_id}
-				isDeleting
 			/>
 		</>
 	);

--- a/site/src/pages/WorkspacesPage/BatchDeleteConfirmation.stories.tsx
+++ b/site/src/pages/WorkspacesPage/BatchDeleteConfirmation.stories.tsx
@@ -1,6 +1,11 @@
 import type { Meta, StoryObj } from "@storybook/react-vite";
 import { action } from "storybook/actions";
-import { MockUserMember, MockWorkspace } from "#/testHelpers/entities";
+import { userEvent, within } from "storybook/test";
+import {
+	MockUserMember,
+	MockWorkspace,
+	mockApiError,
+} from "#/testHelpers/entities";
 import { BatchDeleteConfirmation } from "./BatchDeleteConfirmation";
 
 const meta: Meta<typeof BatchDeleteConfirmation> = {
@@ -14,6 +19,7 @@ const meta: Meta<typeof BatchDeleteConfirmation> = {
 			MockWorkspace,
 			{
 				...MockWorkspace,
+				id: "workspace-2",
 				name: "Test-Workspace-2",
 				last_used_at: "2023-08-16T15:29:10.302441433Z",
 				owner_id: MockUserMember.id,
@@ -21,6 +27,7 @@ const meta: Meta<typeof BatchDeleteConfirmation> = {
 			},
 			{
 				...MockWorkspace,
+				id: "workspace-3",
 				name: "Test-Workspace-3",
 				last_used_at: "2023-11-16T15:29:10.302441433Z",
 				owner_id: MockUserMember.id,
@@ -34,5 +41,24 @@ export default meta;
 type Story = StoryObj<typeof BatchDeleteConfirmation>;
 
 const Example: Story = {};
+
+export const FailedDelete: Story = {
+	args: {
+		error: mockApiError({
+			message: "Failed to delete some workspaces.",
+			detail: "Test-Workspace-2 is already busy with a build.",
+		}),
+	},
+	play: async ({ canvasElement }) => {
+		const user = userEvent.setup();
+		const body = within(canvasElement.ownerDocument.body);
+		await user.click(
+			body.getByRole("button", { name: /review selected workspaces/i }),
+		);
+		await user.click(
+			body.getByRole("button", { name: /confirm 3 workspaces/i }),
+		);
+	},
+};
 
 export { Example as BatchDeleteConfirmation };

--- a/site/src/pages/WorkspacesPage/BatchDeleteConfirmation.tsx
+++ b/site/src/pages/WorkspacesPage/BatchDeleteConfirmation.tsx
@@ -93,6 +93,7 @@ export const BatchDeleteConfirmation: FC<BatchDeleteConfirmationProps> = ({
 			confirmText={confirmText}
 			onConfirm={onProceed}
 			error={error}
+			errorMessage="Failed to delete some workspaces."
 			description={
 				<>
 					{stage === "consequences" && <Consequences />}

--- a/site/src/pages/WorkspacesPage/BatchDeleteConfirmation.tsx
+++ b/site/src/pages/WorkspacesPage/BatchDeleteConfirmation.tsx
@@ -13,6 +13,7 @@ type BatchDeleteConfirmationProps = {
 	checkedWorkspaces: readonly Workspace[];
 	open: boolean;
 	isLoading: boolean;
+	error?: unknown;
 	onClose: () => void;
 	onConfirm: () => void;
 };
@@ -23,6 +24,7 @@ export const BatchDeleteConfirmation: FC<BatchDeleteConfirmationProps> = ({
 	onClose,
 	onConfirm,
 	isLoading,
+	error,
 }) => {
 	const [stage, setStage] = useState<
 		"consequences" | "workspaces" | "resources"
@@ -90,6 +92,7 @@ export const BatchDeleteConfirmation: FC<BatchDeleteConfirmationProps> = ({
 			confirmLoading={isLoading}
 			confirmText={confirmText}
 			onConfirm={onProceed}
+			error={error}
 			description={
 				<>
 					{stage === "consequences" && <Consequences />}

--- a/site/src/pages/WorkspacesPage/BatchStopConfirmation.stories.tsx
+++ b/site/src/pages/WorkspacesPage/BatchStopConfirmation.stories.tsx
@@ -1,0 +1,41 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { action } from "storybook/actions";
+import { MockWorkspace, mockApiError } from "#/testHelpers/entities";
+import { BatchStopConfirmation } from "./BatchStopConfirmation";
+
+const meta: Meta<typeof BatchStopConfirmation> = {
+	title: "pages/WorkspacesPage/BatchStopConfirmation",
+	component: BatchStopConfirmation,
+	args: {
+		onClose: action("onClose"),
+		onConfirm: action("onConfirm"),
+		open: true,
+		workspacesToStop: [
+			MockWorkspace,
+			{
+				...MockWorkspace,
+				id: "workspace-2",
+				name: "Test-Workspace-2",
+			},
+			{
+				...MockWorkspace,
+				id: "workspace-3",
+				name: "Test-Workspace-3",
+			},
+		],
+	},
+};
+
+export default meta;
+type Story = StoryObj<typeof BatchStopConfirmation>;
+
+export const Example: Story = {};
+
+export const FailedStop: Story = {
+	args: {
+		error: mockApiError({
+			message: "Failed to stop workspaces.",
+			detail: "Test-Workspace-2 is already busy with a build.",
+		}),
+	},
+};

--- a/site/src/pages/WorkspacesPage/BatchStopConfirmation.tsx
+++ b/site/src/pages/WorkspacesPage/BatchStopConfirmation.tsx
@@ -6,6 +6,7 @@ type BatchStopConfirmationProps = {
 	workspacesToStop: readonly Workspace[];
 	open: boolean;
 	isLoading: boolean;
+	error?: unknown;
 	onClose: () => void;
 	onConfirm: () => void;
 };
@@ -16,6 +17,7 @@ export const BatchStopConfirmation: FC<BatchStopConfirmationProps> = ({
 	onClose,
 	onConfirm,
 	isLoading,
+	error,
 }) => {
 	const workspaceCount = `${workspacesToStop.length} ${
 		workspacesToStop.length === 1 ? "workspace" : "workspaces"
@@ -30,6 +32,7 @@ export const BatchStopConfirmation: FC<BatchStopConfirmationProps> = ({
 			confirmLoading={isLoading}
 			confirmText="Stop"
 			onConfirm={onConfirm}
+			error={error}
 			description={`Are you sure you want to stop ${workspaceCount}? This will terminate all running processes and disconnect any active sessions.`}
 		/>
 	);

--- a/site/src/pages/WorkspacesPage/BatchStopConfirmation.tsx
+++ b/site/src/pages/WorkspacesPage/BatchStopConfirmation.tsx
@@ -33,6 +33,7 @@ export const BatchStopConfirmation: FC<BatchStopConfirmationProps> = ({
 			confirmText="Stop"
 			onConfirm={onConfirm}
 			error={error}
+			errorMessage="Failed to stop workspaces."
 			description={`Are you sure you want to stop ${workspaceCount}? This will terminate all running processes and disconnect any active sessions.`}
 		/>
 	);

--- a/site/src/pages/WorkspacesPage/WorkspacesPage.tsx
+++ b/site/src/pages/WorkspacesPage/WorkspacesPage.tsx
@@ -155,6 +155,7 @@ const WorkspacesPage: FC = () => {
 		onSuccess: async () => {
 			await refetch();
 			resetChecked();
+			setActiveBatchAction(undefined);
 		},
 	});
 
@@ -239,10 +240,13 @@ const WorkspacesPage: FC = () => {
 				isLoading={batchActions.isProcessing}
 				checkedWorkspaces={checkedWorkspaces}
 				open={activeBatchAction === "delete"}
-				onClose={() => setActiveBatchAction(undefined)}
-				onConfirm={async () => {
-					await batchActions.delete(checkedWorkspaces);
+				error={batchActions.deleteError}
+				onClose={() => {
+					batchActions.resetDelete();
 					setActiveBatchAction(undefined);
+				}}
+				onConfirm={() => {
+					batchActions.delete(checkedWorkspaces);
 				}}
 			/>
 
@@ -250,10 +254,13 @@ const WorkspacesPage: FC = () => {
 				isLoading={batchActions.isProcessing}
 				workspacesToStop={workspacesToStop}
 				open={activeBatchAction === "stop"}
-				onClose={() => setActiveBatchAction(undefined)}
-				onConfirm={async () => {
-					await batchActions.stop(workspacesToStop);
+				error={batchActions.stopError}
+				onClose={() => {
+					batchActions.resetStop();
 					setActiveBatchAction(undefined);
+				}}
+				onConfirm={() => {
+					batchActions.stop(workspacesToStop);
 				}}
 			/>
 

--- a/site/src/pages/WorkspacesPage/batchActions.test.tsx
+++ b/site/src/pages/WorkspacesPage/batchActions.test.tsx
@@ -1,0 +1,60 @@
+import { act, renderHook, waitFor } from "@testing-library/react";
+import type { FC, PropsWithChildren } from "react";
+import { QueryClientProvider } from "react-query";
+import { toast } from "sonner";
+import { API } from "#/api/api";
+import { MockWorkspace } from "#/testHelpers/entities";
+import { createTestQueryClient } from "#/testHelpers/renderHelpers";
+import { useBatchActions } from "./batchActions";
+
+const createWrapper = (): FC<PropsWithChildren> => {
+	const queryClient = createTestQueryClient();
+	return ({ children }) => (
+		<QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+	);
+};
+
+describe("useBatchActions", () => {
+	afterEach(() => {
+		vi.restoreAllMocks();
+	});
+	it("does not toast when stopping workspaces fails", async () => {
+		const error = new Error("workspace is already busy with a build");
+		vi.spyOn(API, "stopWorkspace").mockRejectedValue(error);
+		const toastError = vi.spyOn(toast, "error");
+		const onSuccess = vi.fn();
+		const { result } = renderHook(() => useBatchActions({ onSuccess }), {
+			wrapper: createWrapper(),
+		});
+
+		act(() => {
+			result.current.stop([MockWorkspace]);
+		});
+
+		await waitFor(() => {
+			expect(result.current.stopError).toBe(error);
+		});
+		expect(toastError).not.toHaveBeenCalled();
+		expect(onSuccess).not.toHaveBeenCalled();
+	});
+
+	it("does not toast when deleting workspaces fails", async () => {
+		const error = new Error("workspace cannot be deleted");
+		vi.spyOn(API, "deleteWorkspace").mockRejectedValue(error);
+		const toastError = vi.spyOn(toast, "error");
+		const onSuccess = vi.fn();
+		const { result } = renderHook(() => useBatchActions({ onSuccess }), {
+			wrapper: createWrapper(),
+		});
+
+		act(() => {
+			result.current.delete([MockWorkspace]);
+		});
+
+		await waitFor(() => {
+			expect(result.current.deleteError).toBe(error);
+		});
+		expect(toastError).not.toHaveBeenCalled();
+		expect(onSuccess).not.toHaveBeenCalled();
+	});
+});

--- a/site/src/pages/WorkspacesPage/batchActions.ts
+++ b/site/src/pages/WorkspacesPage/batchActions.ts
@@ -15,8 +15,12 @@ type UpdateAllPayload = Readonly<{
 type UseBatchActionsResult = Readonly<{
 	isProcessing: boolean;
 	start: (workspaces: readonly Workspace[]) => Promise<WorkspaceBuild[]>;
-	stop: (workspaces: readonly Workspace[]) => Promise<WorkspaceBuild[]>;
-	delete: (workspaces: readonly Workspace[]) => Promise<WorkspaceBuild[]>;
+	stop: (workspaces: readonly Workspace[]) => void;
+	stopError: unknown;
+	resetStop: () => void;
+	delete: (workspaces: readonly Workspace[]) => void;
+	deleteError: unknown;
+	resetDelete: () => void;
 	updateTemplateVersions: (
 		payload: UpdateAllPayload,
 	) => Promise<WorkspaceBuild[]>;
@@ -56,11 +60,6 @@ export function useBatchActions(
 			);
 		},
 		onSuccess,
-		onError: (error) => {
-			toast.error("Failed to stop workspaces.", {
-				description: getErrorDetail(error),
-			});
-		},
 	});
 
 	const deleteAllMutation = useMutation({
@@ -68,11 +67,6 @@ export function useBatchActions(
 			return Promise.all(workspaces.map((w) => API.deleteWorkspace(w.id)));
 		},
 		onSuccess,
-		onError: (error) => {
-			toast.error("Failed to delete some workspaces.", {
-				description: getErrorDetail(error),
-			});
-		},
 	});
 
 	const updateAllMutation = useMutation({
@@ -133,8 +127,16 @@ export function useBatchActions(
 		favorite: favoriteAllMutation.mutateAsync,
 		unfavorite: unfavoriteAllMutation.mutateAsync,
 		start: startAllMutation.mutateAsync,
-		stop: stopAllMutation.mutateAsync,
-		delete: deleteAllMutation.mutateAsync,
+		stop: (workspaces) => {
+			stopAllMutation.mutate(workspaces);
+		},
+		stopError: stopAllMutation.error,
+		resetStop: stopAllMutation.reset,
+		delete: (workspaces) => {
+			deleteAllMutation.mutate(workspaces);
+		},
+		deleteError: deleteAllMutation.error,
+		resetDelete: deleteAllMutation.reset,
 		updateTemplateVersions: updateAllMutation.mutateAsync,
 		isProcessing:
 			favoriteAllMutation.isPending ||


### PR DESCRIPTION
> 🤖 Modified with Cursor

Confirm and delete dialogs now take an error slot, and a failed confirm stays in that dialog instead of toasting and closing. Workspace delete, bulk stop, and bulk delete use that so the user can retry or cancel without missing the failure.

- ConfirmDialog / DeleteDialog render ErrorAlert when error is set
- Workspace delete no longer closes on submit, toasts, or opens a second error dialog
- Bulk stop/delete keep the confirmation open and skip the toast on failure

<img width="555" height="534" alt="image" src="https://github.com/user-attachments/assets/c4829168-fd81-47f9-b3bd-f809864078ff" />

