### PR TITLE
fix(site): keep user, token, and workspace stop errors in the confirm dialog

### DIFF
--- a/site/src/modules/users/UserActionDialogs.stories.tsx
+++ b/site/src/modules/users/UserActionDialogs.stories.tsx
@@ -1,7 +1,11 @@
 import type { Meta, StoryObj } from "@storybook/react-vite";
 import { expect, fn, spyOn, userEvent, within } from "storybook/test";
 import { API } from "#/api/api";
-import { MockUserMember, mockApiError } from "#/testHelpers/entities";
+import {
+	MockUserMember,
+	mockApiError,
+	SuspendedMockUser,
+} from "#/testHelpers/entities";
 import { withToaster } from "#/testHelpers/storybook";
 import { UserActionDialogs } from "./UserActionDialogs";
 
@@ -34,6 +38,73 @@ export const Suspend: Story = {
 			within(dialog).getByRole("button", { name: "Suspend" }),
 		);
 		await within(document.body).findByText(/suspended successfully/);
+	},
+};
+
+export const FailedSuspend: Story = {
+	args: {
+		action: { type: "suspend", user: MockUserMember },
+	},
+	beforeEach: () => {
+		spyOn(API, "suspendUser").mockRejectedValue(
+			mockApiError({
+				message: "Failed to suspend user.",
+				detail: "The user is already busy.",
+			}),
+		);
+	},
+	play: async () => {
+		const dialog = await within(document.body).findByRole("dialog");
+		await userEvent.click(
+			within(dialog).getByRole("button", { name: "Suspend" }),
+		);
+		await within(dialog).findByRole("alert");
+	},
+};
+
+export const FailedDelete: Story = {
+	args: {
+		action: { type: "delete", user: MockUserMember },
+	},
+	beforeEach: () => {
+		spyOn(API, "deleteUser").mockRejectedValue(
+			mockApiError({
+				message: "Failed to delete user.",
+				detail: "The user still owns workspaces.",
+			}),
+		);
+	},
+	play: async () => {
+		const dialog = await within(document.body).findByRole("dialog");
+		await userEvent.type(
+			within(dialog).getByLabelText("Name of the user to delete"),
+			MockUserMember.username,
+		);
+		await userEvent.click(
+			within(dialog).getByRole("button", { name: "Delete" }),
+		);
+		await within(dialog).findByRole("alert");
+	},
+};
+
+export const FailedActivate: Story = {
+	args: {
+		action: { type: "activate", user: SuspendedMockUser },
+	},
+	beforeEach: () => {
+		spyOn(API, "activateUser").mockRejectedValue(
+			mockApiError({
+				message: "Failed to activate user.",
+				detail: "The identity provider rejected the request.",
+			}),
+		);
+	},
+	play: async () => {
+		const dialog = await within(document.body).findByRole("dialog");
+		await userEvent.click(
+			within(dialog).getByRole("button", { name: "Activate" }),
+		);
+		await within(dialog).findByRole("alert");
 	},
 };
 

--- a/site/src/modules/users/UserActionDialogs.test.tsx
+++ b/site/src/modules/users/UserActionDialogs.test.tsx
@@ -1,0 +1,95 @@
+import { screen, waitFor, within } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { toast } from "sonner";
+import { API } from "#/api/api";
+import { MockUserMember, SuspendedMockUser } from "#/testHelpers/entities";
+import { renderWithAuth } from "#/testHelpers/renderHelpers";
+import { UserActionDialogs } from "./UserActionDialogs";
+
+describe("UserActionDialogs", () => {
+	afterEach(() => {
+		vi.restoreAllMocks();
+	});
+
+	it("does not toast when suspending a user fails", async () => {
+		const user = userEvent.setup({ delay: 0 });
+		const toastError = vi.spyOn(toast, "error");
+		const suspendUserMock = vi
+			.spyOn(API, "suspendUser")
+			.mockRejectedValueOnce(new Error("Cannot suspend user."));
+		const onClose = vi.fn();
+
+		renderWithAuth(
+			<UserActionDialogs
+				action={{ type: "suspend", user: MockUserMember }}
+				onClose={onClose}
+			/>,
+		);
+
+		const dialog = await screen.findByRole("dialog");
+		await user.click(within(dialog).getByRole("button", { name: "Suspend" }));
+
+		await waitFor(() => {
+			expect(suspendUserMock).toHaveBeenCalledWith(MockUserMember.id);
+		});
+		expect(toastError).not.toHaveBeenCalled();
+		expect(onClose).not.toHaveBeenCalled();
+	});
+
+	it("does not toast when deleting a user fails", async () => {
+		const user = userEvent.setup({ delay: 0 });
+		const toastError = vi.spyOn(toast, "error");
+		const deleteUserMock = vi
+			.spyOn(API, "deleteUser")
+			.mockRejectedValueOnce(new Error("Cannot delete user."));
+		const onClose = vi.fn();
+		const onDeleted = vi.fn();
+
+		renderWithAuth(
+			<UserActionDialogs
+				action={{ type: "delete", user: MockUserMember }}
+				onClose={onClose}
+				onDeleted={onDeleted}
+			/>,
+		);
+
+		const dialog = await screen.findByRole("dialog");
+		await user.type(
+			within(dialog).getByLabelText("Name of the user to delete"),
+			MockUserMember.username,
+		);
+		await user.click(within(dialog).getByRole("button", { name: "Delete" }));
+
+		await waitFor(() => {
+			expect(deleteUserMock).toHaveBeenCalledWith(MockUserMember.id);
+		});
+		expect(toastError).not.toHaveBeenCalled();
+		expect(onClose).not.toHaveBeenCalled();
+		expect(onDeleted).not.toHaveBeenCalled();
+	});
+
+	it("does not toast when activating a user fails", async () => {
+		const user = userEvent.setup({ delay: 0 });
+		const toastError = vi.spyOn(toast, "error");
+		const activateUserMock = vi
+			.spyOn(API, "activateUser")
+			.mockRejectedValueOnce(new Error("Cannot activate user."));
+		const onClose = vi.fn();
+
+		renderWithAuth(
+			<UserActionDialogs
+				action={{ type: "activate", user: SuspendedMockUser }}
+				onClose={onClose}
+			/>,
+		);
+
+		const dialog = await screen.findByRole("dialog");
+		await user.click(within(dialog).getByRole("button", { name: "Activate" }));
+
+		await waitFor(() => {
+			expect(activateUserMock).toHaveBeenCalledWith(SuspendedMockUser.id);
+		});
+		expect(toastError).not.toHaveBeenCalled();
+		expect(onClose).not.toHaveBeenCalled();
+	});
+});

--- a/site/src/modules/users/UserActionDialogs.tsx
+++ b/site/src/modules/users/UserActionDialogs.tsx
@@ -93,26 +93,21 @@ export const UserActionDialogs: FC<UserActionDialogsProps> = ({
 				<DeleteDialog
 					isOpen
 					confirmLoading={deleteUserMutation.isPending}
+					error={deleteUserMutation.error}
 					name={user.username}
 					entity="user"
-					onCancel={onClose}
-					onConfirm={async () => {
-						try {
-							await deleteUserMutation.mutateAsync(user.id);
-							onClose();
-							toast.success(`User "${user.username}" deleted successfully.`);
-							onDeleted?.(user);
-						} catch (error) {
-							toast.error(
-								getErrorMessage(
-									error,
-									`Error deleting user "${user.username}".`,
-								),
-								{
-									description: getErrorDetail(error),
-								},
-							);
-						}
+					onCancel={() => {
+						deleteUserMutation.reset();
+						onClose();
+					}}
+					onConfirm={() => {
+						deleteUserMutation.mutate(user.id, {
+							onSuccess: () => {
+								onClose();
+								toast.success(`User "${user.username}" deleted successfully.`);
+								onDeleted?.(user);
+							},
+						});
 					}}
 				/>
 			)}
@@ -123,26 +118,23 @@ export const UserActionDialogs: FC<UserActionDialogsProps> = ({
 					hideCancel={false}
 					open
 					confirmLoading={suspendUserMutation.isPending}
+					error={suspendUserMutation.error}
 					title="Suspend user"
 					confirmText="Suspend"
-					onClose={onClose}
-					onConfirm={async () => {
-						try {
-							await suspendUserMutation.mutateAsync(user.id);
-							await invalidateUser(user);
-							onClose();
-							toast.success(`User "${user.username}" suspended successfully.`);
-						} catch (error) {
-							toast.error(
-								getErrorMessage(
-									error,
-									`Error suspending user "${user.username}".`,
-								),
-								{
-									description: getErrorDetail(error),
-								},
-							);
-						}
+					onClose={() => {
+						suspendUserMutation.reset();
+						onClose();
+					}}
+					onConfirm={() => {
+						suspendUserMutation.mutate(user.id, {
+							onSuccess: async () => {
+								await invalidateUser(user);
+								onClose();
+								toast.success(
+									`User "${user.username}" suspended successfully.`,
+								);
+							},
+						});
 					}}
 					description={
 						<>
@@ -158,26 +150,23 @@ export const UserActionDialogs: FC<UserActionDialogsProps> = ({
 					hideCancel={false}
 					open
 					confirmLoading={activateUserMutation.isPending}
+					error={activateUserMutation.error}
 					title="Activate user"
 					confirmText="Activate"
-					onClose={onClose}
-					onConfirm={async () => {
-						try {
-							await activateUserMutation.mutateAsync(user.id);
-							await invalidateUser(user);
-							onClose();
-							toast.success(`User "${user.username}" activated successfully.`);
-						} catch (error) {
-							toast.error(
-								getErrorMessage(
-									error,
-									`Error activating user "${user.username}".`,
-								),
-								{
-									description: getErrorDetail(error),
-								},
-							);
-						}
+					onClose={() => {
+						activateUserMutation.reset();
+						onClose();
+					}}
+					onConfirm={() => {
+						activateUserMutation.mutate(user.id, {
+							onSuccess: async () => {
+								await invalidateUser(user);
+								onClose();
+								toast.success(
+									`User "${user.username}" activated successfully.`,
+								);
+							},
+						});
 					}}
 					description={
 						<>

--- a/site/src/modules/users/UserActionDialogs.tsx
+++ b/site/src/modules/users/UserActionDialogs.tsx
@@ -94,6 +94,7 @@ export const UserActionDialogs: FC<UserActionDialogsProps> = ({
 					isOpen
 					confirmLoading={deleteUserMutation.isPending}
 					error={deleteUserMutation.error}
+					errorMessage={`Error deleting user "${user.username}".`}
 					name={user.username}
 					entity="user"
 					onCancel={() => {
@@ -119,6 +120,7 @@ export const UserActionDialogs: FC<UserActionDialogsProps> = ({
 					open
 					confirmLoading={suspendUserMutation.isPending}
 					error={suspendUserMutation.error}
+					errorMessage={`Error suspending user "${user.username}".`}
 					title="Suspend user"
 					confirmText="Suspend"
 					onClose={() => {
@@ -151,6 +153,7 @@ export const UserActionDialogs: FC<UserActionDialogsProps> = ({
 					open
 					confirmLoading={activateUserMutation.isPending}
 					error={activateUserMutation.error}
+					errorMessage={`Error activating user "${user.username}".`}
 					title="Activate user"
 					confirmText="Activate"
 					onClose={() => {

--- a/site/src/pages/UserSettingsPage/TokensPage/ConfirmDeleteDialog.stories.tsx
+++ b/site/src/pages/UserSettingsPage/TokensPage/ConfirmDeleteDialog.stories.tsx
@@ -1,6 +1,8 @@
 import type { Meta, StoryObj } from "@storybook/react-vite";
 import { QueryClient, QueryClientProvider } from "react-query";
-import { MockToken } from "#/testHelpers/entities";
+import { spyOn, userEvent, within } from "storybook/test";
+import { API } from "#/api/api";
+import { MockToken, mockApiError } from "#/testHelpers/entities";
 import { ConfirmDeleteDialog } from "./ConfirmDeleteDialog";
 
 const queryClient = new QueryClient({
@@ -33,5 +35,28 @@ export const DeleteDialog: Story = {
 		queryKey: ["tokens"],
 		token: MockToken,
 		setToken: () => null,
+	},
+};
+
+export const FailedDelete: Story = {
+	args: {
+		queryKey: ["tokens"],
+		token: MockToken,
+		setToken: () => null,
+	},
+	beforeEach: () => {
+		spyOn(API, "deleteToken").mockRejectedValue(
+			mockApiError({
+				message: "Failed to delete token.",
+				detail: "The token is already expired.",
+			}),
+		);
+	},
+	play: async () => {
+		const dialog = await within(document.body).findByRole("dialog");
+		await userEvent.click(
+			within(dialog).getByRole("button", { name: "Delete" }),
+		);
+		await within(dialog).findByRole("alert");
 	},
 };

--- a/site/src/pages/UserSettingsPage/TokensPage/ConfirmDeleteDialog.test.tsx
+++ b/site/src/pages/UserSettingsPage/TokensPage/ConfirmDeleteDialog.test.tsx
@@ -2,6 +2,7 @@ import { screen, waitFor, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { toast } from "sonner";
 import { API } from "#/api/api";
+import { createDeferred } from "#/testHelpers/deferred";
 import { MockToken } from "#/testHelpers/entities";
 import { renderWithAuth } from "#/testHelpers/renderHelpers";
 import { ConfirmDeleteDialog } from "./ConfirmDeleteDialog";
@@ -34,6 +35,27 @@ describe("ConfirmDeleteDialog", () => {
 			expect(deleteTokenMock).toHaveBeenCalledWith(MockToken.id);
 		});
 		expect(toastError).not.toHaveBeenCalled();
+		expect(setToken).not.toHaveBeenCalled();
+	});
+
+	it("does not dismiss while deleting a token", async () => {
+		const user = userEvent.setup({ delay: 0 });
+		const deletion = createDeferred<void>();
+		vi.spyOn(API, "deleteToken").mockReturnValueOnce(deletion.promise);
+		const setToken = vi.fn();
+
+		renderWithAuth(
+			<ConfirmDeleteDialog
+				queryKey={["tokens"]}
+				token={MockToken}
+				setToken={setToken}
+			/>,
+		);
+
+		const dialog = await screen.findByRole("dialog");
+		await user.click(within(dialog).getByRole("button", { name: "Delete" }));
+		await user.keyboard("{Escape}");
+
 		expect(setToken).not.toHaveBeenCalled();
 	});
 });

--- a/site/src/pages/UserSettingsPage/TokensPage/ConfirmDeleteDialog.test.tsx
+++ b/site/src/pages/UserSettingsPage/TokensPage/ConfirmDeleteDialog.test.tsx
@@ -1,0 +1,39 @@
+import { screen, waitFor, within } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { toast } from "sonner";
+import { API } from "#/api/api";
+import { MockToken } from "#/testHelpers/entities";
+import { renderWithAuth } from "#/testHelpers/renderHelpers";
+import { ConfirmDeleteDialog } from "./ConfirmDeleteDialog";
+
+describe("ConfirmDeleteDialog", () => {
+	afterEach(() => {
+		vi.restoreAllMocks();
+	});
+
+	it("does not toast when deleting a token fails", async () => {
+		const user = userEvent.setup({ delay: 0 });
+		const toastError = vi.spyOn(toast, "error");
+		const deleteTokenMock = vi
+			.spyOn(API, "deleteToken")
+			.mockRejectedValueOnce(new Error("Cannot delete token."));
+		const setToken = vi.fn();
+
+		renderWithAuth(
+			<ConfirmDeleteDialog
+				queryKey={["tokens"]}
+				token={MockToken}
+				setToken={setToken}
+			/>,
+		);
+
+		const dialog = await screen.findByRole("dialog");
+		await user.click(within(dialog).getByRole("button", { name: "Delete" }));
+
+		await waitFor(() => {
+			expect(deleteTokenMock).toHaveBeenCalledWith(MockToken.id);
+		});
+		expect(toastError).not.toHaveBeenCalled();
+		expect(setToken).not.toHaveBeenCalled();
+	});
+});

--- a/site/src/pages/UserSettingsPage/TokensPage/ConfirmDeleteDialog.tsx
+++ b/site/src/pages/UserSettingsPage/TokensPage/ConfirmDeleteDialog.tsx
@@ -1,6 +1,5 @@
 import type { FC } from "react";
 import { toast } from "sonner";
-import { getErrorDetail, getErrorMessage } from "#/api/errors";
 import type { APIKeyWithOwner } from "#/api/typesGenerated";
 import { ConfirmDialog } from "#/components/Dialog/ConfirmDialog/ConfirmDialog";
 import { useDeleteToken } from "./hooks";
@@ -18,21 +17,12 @@ export const ConfirmDeleteDialog: FC<ConfirmDeleteDialogProps> = ({
 }) => {
 	const tokenName = token?.token_name;
 
-	const { mutate: deleteToken, isPending: isDeleting } =
-		useDeleteToken(queryKey);
-
-	const onDeleteSuccess = () => {
-		toast.success("Token has been deleted.");
-		setToken(undefined);
-	};
-
-	const onDeleteError = (error: Error) => {
-		const message = getErrorMessage(error, "Failed to delete token");
-		toast.error(message, {
-			description: getErrorDetail(error),
-		});
-		setToken(undefined);
-	};
+	const {
+		mutate: deleteToken,
+		isPending: isDeleting,
+		error,
+		reset,
+	} = useDeleteToken(queryKey);
 
 	return (
 		<ConfirmDialog
@@ -44,18 +34,22 @@ export const ConfirmDeleteDialog: FC<ConfirmDeleteDialogProps> = ({
 					<strong>{tokenName}</strong>?
 				</>
 			}
-			open={Boolean(token) || isDeleting}
+			open={Boolean(token)}
 			confirmLoading={isDeleting}
+			error={error}
 			onConfirm={() => {
 				if (!token) {
 					return;
 				}
 				deleteToken(token.id, {
-					onError: onDeleteError,
-					onSuccess: onDeleteSuccess,
+					onSuccess: () => {
+						toast.success("Token has been deleted.");
+						setToken(undefined);
+					},
 				});
 			}}
 			onClose={() => {
+				reset();
 				setToken(undefined);
 			}}
 		/>

--- a/site/src/pages/UserSettingsPage/TokensPage/ConfirmDeleteDialog.tsx
+++ b/site/src/pages/UserSettingsPage/TokensPage/ConfirmDeleteDialog.tsx
@@ -37,6 +37,7 @@ export const ConfirmDeleteDialog: FC<ConfirmDeleteDialogProps> = ({
 			open={Boolean(token)}
 			confirmLoading={isDeleting}
 			error={error}
+			errorMessage="Failed to delete token."
 			onConfirm={() => {
 				if (!token) {
 					return;

--- a/site/src/pages/UsersPage/UsersPage.stories.tsx
+++ b/site/src/pages/UsersPage/UsersPage.stories.tsx
@@ -8,7 +8,11 @@ import { authMethodsQueryKey, usersKey } from "#/api/queries/users";
 import type { User } from "#/api/typesGenerated";
 import { MockGroups } from "#/pages/UsersPage/storybookData/groups";
 import { MockRoles } from "#/pages/UsersPage/storybookData/roles";
-import { MockAuthMethodsAll, MockUserOwner } from "#/testHelpers/entities";
+import {
+	MockAuthMethodsAll,
+	MockUserOwner,
+	mockApiError,
+} from "#/testHelpers/entities";
 import {
 	withAuthProvider,
 	withDashboardProvider,
@@ -108,14 +112,19 @@ export const SuspendUserError: Story = {
 		const user = userEvent.setup();
 		const canvas = within(canvasElement);
 		const body = within(document.body);
-		spyOn(API, "suspendUser").mockRejectedValue(undefined);
+		spyOn(API, "suspendUser").mockRejectedValue(
+			mockApiError({
+				message: "Failed to suspend user.",
+				detail: "The user is already busy.",
+			}),
+		);
 
 		await openUserMenu(canvas, user);
 		await user.click(await body.findByRole("menuitem", { name: "Suspend…" }));
 
 		const dialog = await body.findByRole("dialog");
 		await user.click(within(dialog).getByRole("button", { name: "Suspend" }));
-		await body.findByText(/Error suspending user/);
+		await within(dialog).findByRole("alert");
 	},
 };
 
@@ -152,7 +161,12 @@ export const DeleteUserError: Story = {
 		const user = userEvent.setup();
 		const canvas = within(canvasElement);
 		const body = within(document.body);
-		spyOn(API, "deleteUser").mockRejectedValue({});
+		spyOn(API, "deleteUser").mockRejectedValue(
+			mockApiError({
+				message: "Failed to delete user.",
+				detail: "The user still owns workspaces.",
+			}),
+		);
 
 		await openUserMenu(canvas, user);
 		await user.click(await body.findByRole("menuitem", { name: "Delete…" }));
@@ -163,7 +177,7 @@ export const DeleteUserError: Story = {
 			MockUsers[0].username,
 		);
 		await user.click(within(dialog).getByRole("button", { name: "Delete" }));
-		await body.findByText(/Error deleting user/);
+		await within(dialog).findByRole("alert");
 	},
 };
 
@@ -214,14 +228,19 @@ export const ActivateUserError: Story = {
 		const user = userEvent.setup();
 		const canvas = within(canvasElement);
 		const body = within(document.body);
-		spyOn(API, "activateUser").mockRejectedValue({});
+		spyOn(API, "activateUser").mockRejectedValue(
+			mockApiError({
+				message: "Failed to activate user.",
+				detail: "The identity provider rejected the request.",
+			}),
+		);
 
 		await openUserMenu(canvas, user);
 		await user.click(await body.findByRole("menuitem", { name: "Activate…" }));
 
 		const dialog = await body.findByRole("dialog");
 		await user.click(within(dialog).getByRole("button", { name: "Activate" }));
-		await body.findByText(/Error activating user/);
+		await within(dialog).findByRole("alert");
 	},
 };
 

--- a/site/src/pages/WorkspacesPage/WorkspacesPageView.test.tsx
+++ b/site/src/pages/WorkspacesPage/WorkspacesPageView.test.tsx
@@ -1,6 +1,9 @@
-import { screen } from "@testing-library/react";
+import { screen, waitFor, within } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { toast } from "sonner";
+import { API } from "#/api/api";
 import type { UseFilterResult } from "#/components/Filter/Filter";
-import { MockTemplate } from "#/testHelpers/entities";
+import { MockTemplate, MockWorkspace } from "#/testHelpers/entities";
 import { renderWithAuth } from "#/testHelpers/renderHelpers";
 import { WorkspacesPageView } from "./WorkspacesPageView";
 
@@ -38,6 +41,10 @@ const defaultProps = {
 };
 
 describe("WorkspacesPageView", () => {
+	afterEach(() => {
+		vi.restoreAllMocks();
+	});
+
 	it("hides the New workspace button and explains the missing permission", async () => {
 		renderWithAuth(
 			<WorkspacesPageView {...defaultProps} canCreateWorkspace={false} />,
@@ -84,5 +91,46 @@ describe("WorkspacesPageView", () => {
 		expect(
 			screen.queryByText(/don't have permission to create workspaces/i),
 		).not.toBeInTheDocument();
+	});
+
+	it("does not toast when stopping a workspace fails", async () => {
+		const user = userEvent.setup({ delay: 0 });
+		const toastError = vi.spyOn(toast, "error");
+		const stopWorkspaceMock = vi
+			.spyOn(API, "stopWorkspace")
+			.mockRejectedValueOnce(new Error("Cannot stop workspace."));
+		vi.spyOn(API, "checkAuthorization").mockResolvedValue({
+			readWorkspace: true,
+			shareWorkspace: true,
+			updateWorkspace: true,
+			updateWorkspaceVersion: false,
+			deleteFailedWorkspace: false,
+		});
+		vi.spyOn(API, "getWorkspaceBuildParameters").mockResolvedValue([]);
+		const onActionSuccess = vi.fn().mockResolvedValue(undefined);
+		const onActionError = vi.fn();
+
+		renderWithAuth(
+			<WorkspacesPageView
+				{...defaultProps}
+				workspaces={[MockWorkspace]}
+				count={1}
+				onActionSuccess={onActionSuccess}
+				onActionError={onActionError}
+			/>,
+		);
+
+		await user.click(await screen.findByTestId("workspace-options-button"));
+		await user.click(await screen.findByRole("menuitem", { name: /stop/i }));
+
+		const dialog = await screen.findByRole("dialog");
+		await user.click(within(dialog).getByRole("button", { name: "Stop" }));
+
+		await waitFor(() => {
+			expect(stopWorkspaceMock).toHaveBeenCalled();
+		});
+		expect(toastError).not.toHaveBeenCalled();
+		expect(onActionError).not.toHaveBeenCalled();
+		expect(onActionSuccess).not.toHaveBeenCalled();
 	});
 });

--- a/site/src/pages/WorkspacesPage/WorkspacesTable.tsx
+++ b/site/src/pages/WorkspacesPage/WorkspacesTable.tsx
@@ -418,7 +418,6 @@ const WorkspaceActionsCell: FC<WorkspaceActionsCellProps> = ({
 			stopWorkspaceOptions.onSuccess(build);
 			await onActionSuccess();
 		},
-		onError: onActionError,
 	});
 
 	const cancelJobOptions = cancelBuild(workspace, queryClient);
@@ -466,7 +465,12 @@ const WorkspaceActionsCell: FC<WorkspaceActionsCellProps> = ({
 				startWorkspaceMutation.mutate({});
 				break;
 			case "stop":
-				stopWorkspaceMutation.mutate({});
+				stopWorkspaceMutation.mutate(
+					{},
+					{
+						onError: onActionError,
+					},
+				);
 				break;
 			case "delete":
 				deleteWorkspaceMutation.mutate({});
@@ -576,7 +580,10 @@ const WorkspaceActionsCell: FC<WorkspaceActionsCellProps> = ({
 					disabled={!abilities.canAcceptJobs}
 					onStop={
 						abilities.actions.includes("stop")
-							? () => setIsStopConfirmOpen(true)
+							? () => {
+									stopWorkspaceMutation.reset();
+									setIsStopConfirmOpen(true);
+								}
 							: undefined
 					}
 					isStopping={stopWorkspaceMutation.isPending}
@@ -585,14 +592,18 @@ const WorkspaceActionsCell: FC<WorkspaceActionsCellProps> = ({
 			</div>
 			{/* Stop workspace confirmation dialog */}
 			<ConfirmDialog
-				open={isStopConfirmOpen}
+				open={isStopConfirmOpen && !stopWorkspaceMutation.isSuccess}
 				title="Stop workspace"
 				description={`Are you sure you want to stop the workspace "${workspace.name}"? This will terminate all running processes and disconnect any active sessions.`}
 				confirmText="Stop"
-				onClose={() => setIsStopConfirmOpen(false)}
+				confirmLoading={stopWorkspaceMutation.isPending}
+				error={stopWorkspaceMutation.error}
+				onClose={() => {
+					setIsStopConfirmOpen(false);
+					stopWorkspaceMutation.reset();
+				}}
 				onConfirm={() => {
 					stopWorkspaceMutation.mutate({});
-					setIsStopConfirmOpen(false);
 				}}
 				type="delete"
 			/>

--- a/site/src/pages/WorkspacesPage/WorkspacesTable.tsx
+++ b/site/src/pages/WorkspacesPage/WorkspacesTable.tsx
@@ -411,11 +411,15 @@ const WorkspaceActionsCell: FC<WorkspaceActionsCellProps> = ({
 		onError: onActionError,
 	});
 
+	const [isStopConfirmOpen, setIsStopConfirmOpen] = useState(false);
+	const [isCancelConfirmOpen, setIsCancelConfirmOpen] = useState(false);
+
 	const stopWorkspaceOptions = stopWorkspace(workspace, queryClient);
 	const stopWorkspaceMutation = useMutation({
 		...stopWorkspaceOptions,
 		onSuccess: async (build) => {
 			stopWorkspaceOptions.onSuccess(build);
+			setIsStopConfirmOpen(false);
 			await onActionSuccess();
 		},
 	});
@@ -450,9 +454,6 @@ const WorkspaceActionsCell: FC<WorkspaceActionsCellProps> = ({
 		},
 		onError: onActionError,
 	});
-
-	const [isStopConfirmOpen, setIsStopConfirmOpen] = useState(false);
-	const [isCancelConfirmOpen, setIsCancelConfirmOpen] = useState(false);
 
 	const isRetrying =
 		startWorkspaceMutation.isPending ||
@@ -592,12 +593,13 @@ const WorkspaceActionsCell: FC<WorkspaceActionsCellProps> = ({
 			</div>
 			{/* Stop workspace confirmation dialog */}
 			<ConfirmDialog
-				open={isStopConfirmOpen && !stopWorkspaceMutation.isSuccess}
+				open={isStopConfirmOpen}
 				title="Stop workspace"
 				description={`Are you sure you want to stop the workspace "${workspace.name}"? This will terminate all running processes and disconnect any active sessions.`}
 				confirmText="Stop"
 				confirmLoading={stopWorkspaceMutation.isPending}
 				error={stopWorkspaceMutation.error}
+				errorMessage={`Failed to stop workspace "${workspace.name}".`}
 				onClose={() => {
 					setIsStopConfirmOpen(false);
 					stopWorkspaceMutation.reset();


### PR DESCRIPTION
Failed user delete/suspend/activate, token delete, and per-row workspace stop stay in the confirm dialog instead of toasting and closing. Same pattern as workspace delete and bulk stop, so the user can retry or cancel without missing the failure.

- User delete, suspend, and activate pass the mutation error into the dialog and close only on success
- Token delete keeps the confirmation open and skips the toast on failure
- Per-row workspace stop uses the mutation error/pending/success state and no longer toasts on confirm failure

<img width="580" height="326" alt="image" src="https://github.com/user-attachments/assets/0f57c370-07c6-45ba-b2cf-42d3bce8852b" />
