### PR TITLE
chore(dogfood): replace filebrowser module with copyparty

### DIFF
--- a/dogfood/coder-envbuilder/main.tf
+++ b/dogfood/coder-envbuilder/main.tf
@@ -138,14 +138,10 @@ module "jetbrains" {
   folder     = local.repo_dir
 }
 
-module "copyparty" {
-  source   = "dev.registry.coder.com/djarbz/copyparty/coder"
-  version  = "1.0.2"
+module "filebrowser" {
+  source   = "dev.registry.coder.com/coder/filebrowser/coder"
+  version  = "1.1.5"
   agent_id = coder_agent.dev.id
-  arguments = [
-    # Serve the home directory at the web root with all permissions.
-    "-v", "/home/coder:/:A",
-  ]
 }
 
 module "coder-login" {

--- a/dogfood/coder-envbuilder/main.tf
+++ b/dogfood/coder-envbuilder/main.tf
@@ -138,10 +138,14 @@ module "jetbrains" {
   folder     = local.repo_dir
 }
 
-module "filebrowser" {
-  source   = "dev.registry.coder.com/coder/filebrowser/coder"
-  version  = "1.1.5"
+module "copyparty" {
+  source   = "dev.registry.coder.com/djarbz/copyparty/coder"
+  version  = "1.0.2"
   agent_id = coder_agent.dev.id
+  arguments = [
+    # Serve the home directory at the web root with all permissions.
+    "-v", "/home/coder:/:A",
+  ]
 }
 
 module "coder-login" {

--- a/dogfood/coder/main.tf
+++ b/dogfood/coder/main.tf
@@ -380,11 +380,15 @@ module "jetbrains" {
 }
 
 module "copyparty" {
-  count    = data.coder_workspace.me.start_count
-  source   = "dev.registry.coder.com/djarbz/copyparty/coder"
-  version  = "1.0.2"
-  agent_id = coder_agent.dev.id
+  count          = data.coder_workspace.me.start_count
+  source         = "dev.registry.coder.com/djarbz/copyparty/coder"
+  version        = "1.0.2"
+  agent_id       = coder_agent.dev.id
+  subdomain      = true
+  pinned_version = "v1.20.23"
   arguments = [
+    # copyparty listens on all interfaces by default; the agent proxies localhost.
+    "-i", "127.0.0.1",
     # Serve the home directory at the web root with all permissions.
     "-v", "/home/coder:/:A",
   ]

--- a/dogfood/coder/main.tf
+++ b/dogfood/coder/main.tf
@@ -379,12 +379,15 @@ module "jetbrains" {
   tooltip       = "You need to [install JetBrains Toolbox](https://coder.com/docs/user-guides/workspace-access/jetbrains/toolbox) to use this app."
 }
 
-module "filebrowser" {
-  count      = data.coder_workspace.me.start_count
-  source     = "dev.registry.coder.com/coder/filebrowser/coder"
-  version    = "1.1.5"
-  agent_id   = coder_agent.dev.id
-  agent_name = "dev"
+module "copyparty" {
+  count    = data.coder_workspace.me.start_count
+  source   = "dev.registry.coder.com/djarbz/copyparty/coder"
+  version  = "1.0.2"
+  agent_id = coder_agent.dev.id
+  arguments = [
+    # Serve the home directory at the web root with all permissions.
+    "-v", "/home/coder:/:A",
+  ]
 }
 
 module "coder-login" {

--- a/dogfood/vscode-coder/Dockerfile
+++ b/dogfood/vscode-coder/Dockerfile
@@ -6,7 +6,7 @@ ARG DEBIAN_FRONTEND=noninteractive
 # `playwright install-deps chromium` so they track the project's
 # Electron version automatically.
 RUN apt-get update && apt-get install -y --no-install-recommends \
-    ca-certificates curl dbus git jq sudo openssh-server screen \
+    ca-certificates curl dbus git jq python3 sudo openssh-server screen \
     && apt-get clean && rm -rf /var/lib/apt/lists/*
 
 # gh CLI from releases (apt repo is unreliable, see cli/cli#6175).

--- a/dogfood/vscode-coder/main.tf
+++ b/dogfood/vscode-coder/main.tf
@@ -272,12 +272,15 @@ module "vscode-web" {
   group                   = "Web Editors"
 }
 
-module "filebrowser" {
-  count      = data.coder_workspace.me.start_count
-  source     = "dev.registry.coder.com/coder/filebrowser/coder"
-  version    = "1.1.5"
-  agent_id   = coder_agent.dev.id
-  agent_name = "dev"
+module "copyparty" {
+  count    = data.coder_workspace.me.start_count
+  source   = "dev.registry.coder.com/djarbz/copyparty/coder"
+  version  = "1.0.2"
+  agent_id = coder_agent.dev.id
+  arguments = [
+    # Serve the home directory at the web root with all permissions.
+    "-v", "/home/coder:/:A",
+  ]
 }
 
 module "coder-login" {

--- a/dogfood/vscode-coder/main.tf
+++ b/dogfood/vscode-coder/main.tf
@@ -273,11 +273,15 @@ module "vscode-web" {
 }
 
 module "copyparty" {
-  count    = data.coder_workspace.me.start_count
-  source   = "dev.registry.coder.com/djarbz/copyparty/coder"
-  version  = "1.0.2"
-  agent_id = coder_agent.dev.id
+  count          = data.coder_workspace.me.start_count
+  source         = "dev.registry.coder.com/djarbz/copyparty/coder"
+  version        = "1.0.2"
+  agent_id       = coder_agent.dev.id
+  subdomain      = true
+  pinned_version = "v1.20.23"
   arguments = [
+    # copyparty listens on all interfaces by default; the agent proxies localhost.
+    "-i", "127.0.0.1",
     # Serve the home directory at the web root with all permissions.
     "-v", "/home/coder:/:A",
   ]


### PR DESCRIPTION
Replaces the `coder/filebrowser` module with [`djarbz/copyparty`](https://registry.coder.com/modules/djarbz/copyparty) in the `dogfood/coder` and `dogfood/vscode-coder` templates.

copyparty doesn't have a `folder` input, it just takes raw CLI arguments, so we pass `-v /home/coder:/:A` to keep serving the home directory like filebrowser did by default. It also listens on all interfaces by default (filebrowser binds `127.0.0.1`), so we pass `-i 127.0.0.1` too, since the agent proxies over localhost anyway and the workspaces share a docker bridge. `subdomain = true` matches the filebrowser module default, which copyparty flips to `false` and doesn't handle path-based proxying for. I've pinned the copyparty release rather than have every workspace start hit the unauthenticated GitHub releases API. The app slug becomes `copyparty` and the port moves from 13339 to 3923.

copyparty runs from a Python self-extracting archive, and the install script bails out early if `python3` is missing. The `codercom/oss-dogfood` image already has it, but `node:24-slim` doesn't, so I've added it to `dogfood/vscode-coder/Dockerfile`. That's somewhat of a side effect of the swap rather than something that image otherwise wants, so shout if you'd rather I left filebrowser in the VS Code template.

The envbuilder template keeps filebrowser. Its image comes from whichever devcontainer repo the user picks, so we can't assume `python3` is there.

Worth flagging that `djarbz/copyparty` is a community namespace module, and isn't marked `verified` in the registry. `1.0.2` is the latest published version.

I've left the `.devcontainer/filebrowser` feature, `scaletest/templates/scaletest-runner`, the Template Builder module catalogue, and the filebrowser docs pages alone, since they're out of scope here.
