### PR TITLE
ci(.github/actions/test-go-pg): upload postgres logs on failure

### DIFF
--- a/.github/actions/test-go-pg/action.yaml
+++ b/.github/actions/test-go-pg/action.yaml
@@ -137,6 +137,20 @@ runs:
           [[ -f "${pidfile}" ]] && kill "$(cat "${pidfile}")" 2> /dev/null || true
         done
 
+    - name: Collect PostgreSQL logs (Linux)
+      if: failure() && runner.os == 'Linux'
+      shell: bash
+      env:
+        POSTGRES_VERSION: ${{ inputs.postgres-version }}
+      run: make test-postgres-docker-logs > postgres.log 2>&1
+
+    - name: Upload PostgreSQL logs (Linux)
+      if: failure() && runner.os == 'Linux'
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+      with:
+        name: postgres-logs-${{ github.job }}
+        path: postgres.log
+
     - name: Upload I/O samples (Linux)
       if: failure() && runner.os == 'Linux'
       uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1


### PR DESCRIPTION
Extends the PostgreSQL log capture (added in the `gen` job) to all `pg-*` CI jobs (`test-go-pg`, `test-go-pg-17`, `test-go-race-pg`). Since these jobs share the `./.github/actions/test-go-pg` composite action, the collect and upload steps are added there once, on the Linux path that runs the Docker postgres container (Windows/macOS use embedded postgres).

On failure, the steps run `make test-postgres-docker-logs` and upload the output as a per-job `postgres-logs-<job>` artifact. `POSTGRES_VERSION` is passed through so the target reads logs from the correct container (e.g. postgres 13 for `test-go-pg`).

<sub>Opened by Coder Agents on behalf of @spikecurtis.</sub>
