### PR TITLE
fix: add OpenAI Daybreak alias pricing

### DIFF
--- a/coderd/aibridge/prices/data/prices.json
+++ b/coderd/aibridge/prices/data/prices.json
@@ -2793,6 +2793,22 @@
   },
   {
     "provider": "openai",
+    "model": "gpt-daybreak-blue-latest",
+    "input_price": 4000000,
+    "output_price": 20000000,
+    "cache_read_price": 400000,
+    "cache_write_price": 5000000
+  },
+  {
+    "provider": "openai",
+    "model": "gpt-daybreak-red-latest",
+    "input_price": 12500000,
+    "output_price": 75000000,
+    "cache_read_price": 1250000,
+    "cache_write_price": 15625000
+  },
+  {
+    "provider": "openai",
     "model": "gpt-image-2",
     "input_price": 5000000,
     "output_price": 30000000,

--- a/scripts/aibridgepricesgen/overrides.jq
+++ b/scripts/aibridgepricesgen/overrides.jq
@@ -31,6 +31,37 @@ end
     )
   end
 
+# gpt-daybreak-blue-latest is an alias for gpt-5.6-sol. Copy its pricing
+# until models.dev includes the alias. Recheck the target when OpenAI updates it.
+# Ref: https://developers.openai.com/api/docs/pricing#cyber-models
+| if (.openai.models | has("gpt-daybreak-blue-latest")) then
+    error("overrides.jq: gpt-daybreak-blue-latest now present upstream; drop the injection")
+  elif (.openai.models."gpt-5.6-sol".cost | (.input | type) != "number" or (.output | type) != "number") then
+    error("overrides.jq: gpt-5.6-sol pricing missing upstream; update the gpt-daybreak-blue-latest source")
+  else
+    .openai.models."gpt-daybreak-blue-latest" = (
+      .openai.models."gpt-5.6-sol"
+      | .id = "gpt-daybreak-blue-latest"
+      | .name = "GPT Daybreak Blue Latest"
+    )
+  end
+
+# gpt-daybreak-red-latest is an alias for gpt-5.6-cyber. Neither is listed
+# on models.dev, so use OpenAI's USD-per-million-token prices directly.
+# Recheck the target and rates when OpenAI updates the alias.
+# Ref: https://developers.openai.com/api/docs/pricing#cyber-models
+| if (.openai.models | has("gpt-daybreak-red-latest")) then
+    error("overrides.jq: gpt-daybreak-red-latest now present upstream; drop the injection")
+  elif (.openai.models | has("gpt-5.6-cyber")) then
+    error("overrides.jq: gpt-5.6-cyber now present upstream; copy its pricing for gpt-daybreak-red-latest")
+  else
+    .openai.models."gpt-daybreak-red-latest" = {
+      id: "gpt-daybreak-red-latest",
+      name: "GPT Daybreak Red Latest",
+      cost: {input: 12.5, output: 75, cache_read: 1.25, cache_write: 15.625}
+    }
+  end
+
 # Mapping of provider names on models.dev to our own names
 # Ref. table definition for ai_provider_type
 # amazon-bedrock -> bedrock


### PR DESCRIPTION
Add pricing for `gpt-daybreak-blue-latest` (alias of `gpt-5.6-sol`) and `gpt-daybreak-red-latest` (alias of `gpt-5.6-cyber`), as documented on [OpenAI’s pricing page](https://developers.openai.com/api/docs/pricing#cyber-models).

Blue copies models.dev pricing; Red uses OpenAI’s published rates because Cyber is missing from models.dev. Comments link to the source and note that alias targets can change. Only these two price entries are added.

> [!NOTE]
> Generated by Coder Agents on behalf of @ssncferreira.