### PR TITLE
fix(site): stop forcing overflow-y on the scroll-locked body

### DIFF
--- a/site/src/index.css
+++ b/site/src/index.css
@@ -751,6 +751,15 @@
 	over Radix's injected !important styles. The @supports guard ensures
 	we only do this on browsers that actually support scrollbar-gutter.
 
+	The reserved gutter is kept while the body is scroll-locked, so the
+	page keeps its width even though Radix hides the body scrollbar. For
+	this to hold, do not force overflow-y on the locked body: hiding the
+	scrollbar while the gutter reserves its space is what prevents the
+	shift, and any forced overflow here would fight react-remove-scroll's
+	lock styles (its lower-specificity selector must lose or the page
+	gains a scrollbar on pages where the body owns the overflow, like
+	/agents).
+
 	There’s a related issue on GitHub: Radix UI Primitives Issue #3251
 	https://github.com/radix-ui/primitives/issues/3251
 	*/
@@ -762,7 +771,6 @@
 		html body[data-scroll-locked] {
 			--removed-body-scroll-bar-size: 0 !important;
 			margin-right: 0 !important;
-			overflow-y: scroll !important;
 		}
 	}
 

--- a/site/src/index.css
+++ b/site/src/index.css
@@ -744,24 +744,22 @@
 		scrollbar-color: hsl(var(--surface-quaternary)) transparent;
 	}
 
-	/* Prevent layout shift when modals open by maintaining scrollbar width.
-	scrollbar-gutter: stable reserves space for the scrollbar so Radix's
-	scroll-bar compensation (margin-right/padding-right) is unnecessary
-	and causes double spacing. We zero it out with !important to win
-	over Radix's injected !important styles. The @supports guard ensures
-	we only do this on browsers that actually support scrollbar-gutter.
+	/* Prevent layout shift when modals and dropdowns open.
 
-	The reserved gutter is kept while the body is scroll-locked, so the
-	page keeps its width even though Radix hides the body scrollbar. For
-	this to hold, do not force overflow-y on the locked body: hiding the
-	scrollbar while the gutter reserves its space is what prevents the
-	shift, and any forced overflow here would fight react-remove-scroll's
-	lock styles (its lower-specificity selector must lose or the page
-	gains a scrollbar on pages where the body owns the overflow, like
-	/agents).
+	scrollbar-gutter: stable reserves space for the scrollbar. When Radix
+	locks the scroll, Radix hides the body scrollbar and injects
+	margin-right and padding-right. The reserved gutter already keeps the
+	page width constant. The injected compensation adds a second space and
+	causes a shift. Set --removed-body-scroll-bar-size and margin-right to
+	0 with !important to disable the compensation. The @supports guard
+	applies these rules only to browsers that support scrollbar-gutter.
 
-	There’s a related issue on GitHub: Radix UI Primitives Issue #3251
-	https://github.com/radix-ui/primitives/issues/3251
+	Do not set overflow-y on body[data-scroll-locked]. A forced overflow-y
+	overrides the scroll lock. On pages that set overflow: hidden on
+	<html> (for example /agents), the body then shows a new scrollbar and
+	the page width changes.
+
+	Related issue: https://github.com/radix-ui/primitives/issues/3251
 	*/
 	@supports (scrollbar-gutter: stable) {
 		html {

--- a/site/src/pages/AgentsPage/AgentsPageLayout.tsx
+++ b/site/src/pages/AgentsPage/AgentsPageLayout.tsx
@@ -180,14 +180,13 @@ const AgentsPageLayout: FC = () => {
 	const [isSearchDialogOpen, setIsSearchDialogOpen] = useState(false);
 
 	// The global CSS sets scrollbar-gutter: stable on <html> to prevent
-	// layout shift on pages that toggle scrollbars. The agents page
-	// uses its own internal scroll containers so the reserved gutter
-	// space is unnecessary and wastes horizontal room.
+	// layout shift on pages that show and hide a scrollbar. The agents
+	// page scrolls in internal containers only. The reserved gutter is
+	// not necessary and uses horizontal space.
 	//
-	// Removing the gutter requires overflow:hidden on both <html> and
-	// <body> so neither element can produce a scrollbar, plus
-	// scrollbar-gutter:auto on <html> so the browser stops reserving
-	// space for a scrollbar that will never appear.
+	// Set overflow: hidden on <html> and <body>. Neither element can
+	// then show a scrollbar. Set scrollbar-gutter: auto on <html> so that
+	// the browser does not reserve space for a scrollbar.
 	useEffect(() => {
 		const html = document.documentElement;
 		const body = document.body;

--- a/site/src/pages/AgentsPage/AgentsPageLayout.tsx
+++ b/site/src/pages/AgentsPage/AgentsPageLayout.tsx
@@ -184,19 +184,10 @@ const AgentsPageLayout: FC = () => {
 	// uses its own internal scroll containers so the reserved gutter
 	// space is unnecessary and wastes horizontal room.
 	//
-	// Removing the gutter requires three things:
-	//
-	// 1. overflow:hidden on both <html> and <body> so neither element
-	//    can produce a scrollbar.
-	// 2. scrollbar-gutter:auto on <html> so the browser stops
-	//    reserving space for a scrollbar that will never appear.
-	//    This is what makes react-remove-scroll-bar measure a gap of
-	//    0 when a Radix dropdown opens, so it injects no padding or
-	//    margin compensation.
-	// 3. An injected <style> that overrides the global
-	//    `overflow-y: scroll !important` on body[data-scroll-locked].
-	//    Without this, opening any Radix dropdown would force a
-	//    scrollbar onto <body>, re-introducing the layout shift.
+	// Removing the gutter requires overflow:hidden on both <html> and
+	// <body> so neither element can produce a scrollbar, plus
+	// scrollbar-gutter:auto on <html> so the browser stops reserving
+	// space for a scrollbar that will never appear.
 	useEffect(() => {
 		const html = document.documentElement;
 		const body = document.body;
@@ -209,16 +200,10 @@ const AgentsPageLayout: FC = () => {
 		html.style.scrollbarGutter = "auto";
 		body.style.overflow = "hidden";
 
-		const style = document.createElement("style");
-		style.textContent =
-			"html body[data-scroll-locked] { overflow-y: hidden !important; }";
-		document.head.appendChild(style);
-
 		return () => {
 			html.style.overflow = prevHtmlOverflow;
 			html.style.scrollbarGutter = prevHtmlScrollbarGutter;
 			body.style.overflow = prevBodyOverflow;
-			style.remove();
 		};
 	}, []);
 


### PR DESCRIPTION
Stops layout shift from happening on the AgentsPage when opening a portal/dialog/dropdown.

<details>
<summary>LLM Slop description</summary>

Opening any popover or dropdown on the agents page slightly shrank the visible page width, because the global scrollbar rules forced `overflow-y: scroll !important` on `body[data-scroll-locked]`. On the agents page, where `<html>` has inline `overflow: hidden`, the forced scroll no longer propagated to the viewport and instead grew a scrollbar on `<body>` itself, reserving scrollbar width every time a Radix overlay opened.

The forced scroll (added in #22387 to keep the scrollbar thumb visible during scroll lock) is not needed to prevent the layout shift: `scrollbar-gutter: stable` keeps the gutter reserved while the body is locked, so page width stays constant even though the scrollbar is hidden. This removes the forced `overflow-y`, along with the agents page `<style>` injection that existed only to override it (from #22448).

One visible trade-off, accepted deliberately: the scrollbar thumb now disappears into the reserved gutter while a modal or dropdown is open, instead of staying painted. This also removes the `!important` cascade dependency that the Tailwind v4 migration (`@layer base` becoming a real cascade layer with reversed `!important` precedence) had silently broken.

Refs radix-ui/primitives#3251

<details>
<summary>Verification</summary>

Verified against a dev server with classic (layout-consuming) scrollbars:

- `/agents`: sidebar dropdown opens, `data-scroll-locked` set, body `overflow-y: hidden`, page width 1280px before and during, 0px shift
- `/templates` (scrollable body): overlay open hides the scrollbar but the stable gutter preserves width, 0px shift
- `pnpm lint:types`, `pnpm check`, `pnpm format`, and the `AgentsPageLayout` unit tests pass
</details>

Generated by Coder Agents

</details>