### PR TITLE
fix(coderd/x/chatd): clarify the no-workspace tool error message

### DIFF
--- a/coderd/x/chatd/chatd.go
+++ b/coderd/x/chatd/chatd.go
@@ -623,7 +623,7 @@ func (c *turnWorkspaceContext) loadWorkspaceAgentLocked(
 		}
 
 		if !chatSnapshot.WorkspaceID.Valid {
-			return chatSnapshot, database.WorkspaceAgent{}, xerrors.New("no workspace is associated with this chat. Use the create_workspace tool to create one")
+			return chatSnapshot, database.WorkspaceAgent{}, xerrors.New("this tool requires a workspace and this chat does not have one. Use the create_workspace tool to create one")
 		}
 
 		if chatSnapshot.AgentID.Valid {

--- a/coderd/x/chatd/store_chat_attachment.go
+++ b/coderd/x/chatd/store_chat_attachment.go
@@ -35,7 +35,7 @@ func (p *Server) storeChatAttachment(
 	data []byte,
 ) (chattool.AttachmentMetadata, error) {
 	if !chatSnapshot.WorkspaceID.Valid {
-		return chattool.AttachmentMetadata{}, xerrors.New("no workspace is associated with this chat. Use the create_workspace tool to create one")
+		return chattool.AttachmentMetadata{}, xerrors.New("this tool requires a workspace and this chat does not have one. Use the create_workspace tool to create one")
 	}
 
 	storedName, mediaType, err := chatfiles.PrepareStoredFile(name, detectName, data)

--- a/coderd/x/chatd/store_chat_attachment_internal_test.go
+++ b/coderd/x/chatd/store_chat_attachment_internal_test.go
@@ -159,7 +159,7 @@ func TestStoreChatAttachment_NoWorkspace(t *testing.T) {
 	server := &Server{db: db}
 
 	attachment, err := server.storeChatAttachment(context.Background(), database.Chat{}, "build.log", "build.log", []byte("build output"))
-	require.ErrorContains(t, err, "no workspace is associated")
+	require.ErrorContains(t, err, "this tool requires a workspace")
 	require.Equal(t, chattool.AttachmentMetadata{}, attachment)
 }
 


### PR DESCRIPTION
The old message, "no workspace is associated with this chat," read like a general chat error and did not make clear that the *tool call itself* needed a workspace. Smaller/local models tend to misread vague tool errors as a hard stop, so the new wording says directly what is missing and what to do: "this tool requires a workspace and this chat does not have one."

Fixes CODAGT-1029

> Generated by Coder Agents on behalf of @bpmct.