### PR TITLE
fix(coderd/aibridgedserver): log unpriced models at debug level

### DIFF
--- a/coderd/aibridgedserver/cost.go
+++ b/coderd/aibridgedserver/cost.go
@@ -132,7 +132,7 @@ func (s *Server) resolveTokenUsageCost(ctx context.Context, intc database.AIBrid
 	switch {
 	case errors.Is(err, sql.ErrNoRows):
 		// Model not in the price table: record tokens but leave cost NULL.
-		s.logger.Info(ctx, "no price found for model, recording token usage with NULL cost",
+		s.logger.Debug(ctx, "no price found for model, recording token usage with NULL cost",
 			slog.F("provider", configuredType), slog.F("model", intc.Model))
 		if s.metrics != nil {
 			s.metrics.UnpricedTokenUsageRecords.WithLabelValues(intc.ProviderName, configuredType, intc.Model).Inc()


### PR DESCRIPTION
Move the unpriced-model log from Info to Debug to avoid per-request log noise now that weekly notifications inform owners about models missing prices.

Related to https://linear.app/codercom/issue/AIGOV-568/notify-admins-about-unpriced-ai-models

> [!NOTE]
> Generated by Coder Agents on behalf of @ssncferreira.