### PR TITLE
fix(coderd): reject redundant SSH autostarts of running workspaces

### DIFF
--- a/coderd/workspacebuilds_ssh_test.go
+++ b/coderd/workspacebuilds_ssh_test.go
@@ -1,0 +1,66 @@
+package coderd_test
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/coder/coder/v2/coderd/coderdtest"
+	"github.com/coder/coder/v2/codersdk"
+	"github.com/coder/coder/v2/testutil"
+)
+
+func TestWorkspaceBuildSSHAutostart(t *testing.T) {
+	t.Parallel()
+
+	for _, tc := range []struct {
+		name     string
+		stopped  bool
+		reason   codersdk.CreateWorkspaceBuildReason
+		conflict bool
+	}{
+		{name: "Running", reason: codersdk.CreateWorkspaceBuildReasonSSHConnection, conflict: true},
+		{name: "Stopped", stopped: true, reason: codersdk.CreateWorkspaceBuildReasonSSHConnection},
+		{name: "ExplicitStart", reason: codersdk.CreateWorkspaceBuildReasonDashboard},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			ctx := testutil.Context(t, testutil.WaitLong)
+			client := coderdtest.New(t, &coderdtest.Options{IncludeProvisionerDaemon: true})
+			user := coderdtest.CreateFirstUser(t, client)
+			version := coderdtest.CreateTemplateVersion(t, client, user.OrganizationID, nil)
+			coderdtest.AwaitTemplateVersionJobCompleted(t, client, version.ID)
+			template := coderdtest.CreateTemplate(t, client, user.OrganizationID, version.ID)
+			workspace := coderdtest.CreateWorkspace(t, client, template.ID)
+			latest := coderdtest.AwaitWorkspaceBuildJobCompleted(t, client, workspace.LatestBuild.ID)
+
+			if tc.stopped {
+				stop, err := client.CreateWorkspaceBuild(ctx, workspace.ID, codersdk.CreateWorkspaceBuildRequest{
+					Transition: codersdk.WorkspaceTransitionStop,
+				})
+				require.NoError(t, err)
+				latest = coderdtest.AwaitWorkspaceBuildJobCompleted(t, client, stop.ID)
+			}
+
+			// An SSH client may submit a delayed autostart after another
+			// client has already finished starting the workspace.
+			build, err := client.CreateWorkspaceBuild(ctx, workspace.ID, codersdk.CreateWorkspaceBuildRequest{
+				Transition: codersdk.WorkspaceTransitionStart,
+				Reason:     tc.reason,
+			})
+			if tc.conflict {
+				var apiError *codersdk.Error
+				require.ErrorAs(t, err, &apiError)
+				require.Equal(t, http.StatusConflict, apiError.StatusCode())
+				current, err := client.Workspace(ctx, workspace.ID)
+				require.NoError(t, err)
+				require.Equal(t, latest.ID, current.LatestBuild.ID)
+				return
+			}
+			require.NoError(t, err)
+			require.Equal(t, latest.BuildNumber+1, build.BuildNumber)
+			coderdtest.AwaitWorkspaceBuildJobCompleted(t, client, build.ID)
+		})
+	}
+}

--- a/coderd/wsbuilder/wsbuilder.go
+++ b/coderd/wsbuilder/wsbuilder.go
@@ -1386,6 +1386,19 @@ func (b *Builder) checkRunningBuild() error {
 			xerrors.New(msg),
 		}
 	}
+	if b.trans == database.WorkspaceTransitionStart && b.reason == database.BuildReasonSshConnection && job.JobStatus == database.ProvisionerJobStatusSucceeded {
+		build, err := b.getLastBuild()
+		if err != nil {
+			return BuildError{http.StatusInternalServerError, "failed to fetch prior build", err}
+		}
+		if build.Transition == database.WorkspaceTransitionStart {
+			// An SSH client can read a stopped workspace before another client
+			// starts it, then submit its request after that build completes.
+			// Preserve the running build and let the client reconnect on 409.
+			msg := "The workspace is already running."
+			return BuildError{http.StatusConflict, msg, xerrors.New(msg)}
+		}
+	}
 	return nil
 }
 


### PR DESCRIPTION
Written with AI

An SSH client can read a workspace as stopped, then submit its autostart request after another client has already finished starting that workspace. The server rejects starts while a provisioning job is active, but accepts this delayed request once the previous start has succeeded. That creates an unnecessary new build and invalidates agent connections belonging to the previous build. Managed devcontainers can consequently lose connectivity or authorization even though the underlying workspace machine is still running.

Reject SSH autostart requests with HTTP 409 when the latest build is already a successful start. The existing SSH client's conflict handler refreshes the workspace and connects without requesting another start, preserving the running build and its agents. Normal autostarts of stopped workspaces and explicit starts or rebuilds remain available. This server-side change protects clients that already send the SSH connection build reason; it does not require a client upgrade or a per-workspace repair script, and it does not repair agents invalidated by earlier builds.

The regression test reproduces the delayed request deterministically and verifies that the latest build stays unchanged, while stopped-workspace autostarts and explicit starts still succeed. The running-workspace case fails before the fix on v2.37.0. The new regression, workspace builder tests, and existing SSH conflict-recovery tests pass with the fix on both v2.37.0 and upstream base 5e058aab2.

<details>
<summary>Verification evidence (commands executed by Codex)</summary>

An isolated PostgreSQL instance was used for the API and CLI tests. A local Go overlay redirected the test database port to avoid touching an existing development database; neither the overlay nor the harness is part of this change.

Before the fix, running the new regression test on v2.37.0 produced this failure (excerpt):

```text
--- FAIL: TestWorkspaceBuildSSHAutostart
    --- FAIL: TestWorkspaceBuildSSHAutostart/Running
        Error: An error is expected but got nil.
        expected: *codersdk.Error
FAIL github.com/coder/coder/v2/coderd 6.941s
```

With the fix on v2.37.0:

```console
$ go test -overlay=../postgres-test-overlay.json ./coderd ./coderd/wsbuilder -run '^(TestWorkspaceBuildSSHAutostart|TestBuilder_.*)$' -count=1
ok  github.com/coder/coder/v2/coderd     1.234s
ok  github.com/coder/coder/v2/coderd/wsbuilder 0.053s
```

With the fix on upstream base 5e058aab2, the regression and builder tests passed:

```text
ok  github.com/coder/coder/v2/coderd     6.631s
ok  github.com/coder/coder/v2/coderd/wsbuilder 0.068s
```

The existing SSH autostart and conflict-recovery tests also passed on that base:

```console
$ go test -overlay=../postgres-test-main-overlay.json ./cli -run '^TestSSH/(StartStoppedWorkspace|StartStoppedWorkspaceConflict)$' -count=1
ok  github.com/coder/coder/v2/cli 9.966s
```

The regression verifies HTTP 409 and an unchanged latest-build ID for a redundant SSH autostart, and successful builds for a stopped-workspace autostart and an explicit dashboard start. `gofmt` and `git diff --check` passed. Full repository lint and tests have not been run locally; CI results are separate from the targeted checks above.

</details>
