### PR TITLE
chore: enable oxlint media-has-caption rule

### DIFF
--- a/biome.jsonc
+++ b/biome.jsonc
@@ -15,6 +15,7 @@
 	"linter": {
 		"rules": {
 			"a11y": {
+				"useMediaCaption": "off", // oxlint owns media-has-caption
 				"noSvgWithoutTitle": "off",
 				"useButtonType": "off",
 				"useSemanticElements": "off",

--- a/site/.oxlintrc.jsonc
+++ b/site/.oxlintrc.jsonc
@@ -35,6 +35,7 @@
 		"autocomplete-valid": "error",
 		"html-has-lang": "error",
 		"lang": "error",
+		"media-has-caption": "error",
 
 		// --- complexity ---
 		"no-regex-spaces": "error",
@@ -213,7 +214,6 @@
 		"no-empty-interface": "off", // suspicious/noEmptyInterface (small)
 		"no-danger": "off", // security/noDangerouslySetInnerHtml (small: Biome suppression to migrate)
 		"no-noninteractive-tabindex": "off", // a11y/noNoninteractiveTabindex (small)
-		"media-has-caption": "off", // a11y/useMediaCaption (small)
 		"interactive-supports-focus": "off", // a11y/useFocusableInteractive (small)
 		"iframe-has-title": "off", // a11y/useIframeTitle (small)
 		"prefer-template": "off", // style/useTemplate (small)

--- a/site/src/pages/AgentsPage/components/VideoLightbox.tsx
+++ b/site/src/pages/AgentsPage/components/VideoLightbox.tsx
@@ -27,7 +27,7 @@ export const VideoLightbox: FC<VideoLightboxProps> = ({
 						{RECORDING_UNAVAILABLE_TEXT}
 					</div>
 				) : (
-					// biome-ignore lint/a11y/useMediaCaption: Screen recordings do not have caption tracks.
+					// oxlint-disable-next-line jsx-a11y/media-has-caption -- Screen recordings do not have caption tracks.
 					<video
 						src={src}
 						controls


### PR DESCRIPTION
Enables the `jsx-a11y/media-has-caption` rule in oxlint, removing it from the migration backlog in `site/.oxlintrc.jsonc`.

Following the backlog workflow, oxlint becomes the sole enforcer: Biome's `useMediaCaption` is turned off, and the one existing suppression in `VideoLightbox.tsx` is migrated from a `biome-ignore` to an `oxlint-disable` comment. That `<video>` is a screen recording with no caption track, so the suppression is retained with the same justification.

`pnpm run lint:oxlint` and `pnpm run lint:check` both pass.

> [!NOTE]
> This PR was generated by Coder Agents.
