### PR TITLE
feat: add experimental FOCUS-format AI Gateway spend export

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -132,3 +132,8 @@ docs/.audit/
 
 /release-action
 test-timings.tsv
+# Local-only FOCUS export dev/review artifacts (not part of the PR).
+/scripts/focusdevserver/
+/focus_export_review_prompt.md
+/focus_export_review_findings.md
+/focus_export_pr_description.md

--- a/coderd/aibridge/focus/csv.go
+++ b/coderd/aibridge/focus/csv.go
@@ -1,0 +1,124 @@
+package focus
+
+import (
+	"encoding/csv"
+	"io"
+	"strconv"
+	"strings"
+)
+
+// Header is the FOCUS export's CSV column order, matching Row's field order.
+var Header = []string{
+	"BilledCost", "BillingAccountId", "BillingAccountName", "BillingAccountType",
+	"BillingCurrency", "BillingPeriodEnd", "BillingPeriodStart",
+	"ChargeCategory", "ChargeClass", "ChargeDescription", "ChargeFrequency",
+	"ChargePeriodEnd", "ChargePeriodStart",
+	"ConsumedQuantity", "ConsumedUnit",
+	"ContractedCost", "ContractedUnitPrice", "EffectiveCost", "InvoiceIssuerName",
+	"ListCost", "ListUnitPrice",
+	"PricingCategory", "PricingQuantity", "PricingUnit",
+	"ProviderName", "PublisherName",
+	"ResourceId", "ResourceName", "ResourceType",
+	"ServiceCategory", "ServiceName", "ServiceSubcategory",
+	"SkuId", "SkuPriceId",
+	"SubAccountId", "SubAccountName", "SubAccountType",
+	"Tags",
+	"x_ProviderResponseId", "x_InterceptionId", "x_SessionId", "x_InitiatorId",
+	"x_CredentialKind", "x_WireProtocol", "x_ProviderInstance", "x_ClientTool",
+	"x_ErrorType", "x_PricingStatus", "x_TokenType", "x_RowCount",
+}
+
+// csvFormulaPrefixes are the leading characters a spreadsheet treats as the
+// start of a formula rather than text. Duplicated from
+// enterprise/coderd/aibridge.go's unexported escapeCSVCell/csvFormulaPrefixes
+// rather than imported: the original lives in the enterprise package, and
+// this AGPL package shouldn't depend on it anyway, per the same
+// license-boundary principle that keeps the feature gate entirely in
+// enterprise/coderd/aibridge.go.
+const csvFormulaPrefixes = "=+-@\t\r"
+
+// escapeCSVCell prefixes a leading formula character with a single quote,
+// which spreadsheets strip on display, so the value renders as its original
+// text instead of being evaluated as a formula.
+func escapeCSVCell(value string) string {
+	if value == "" || !strings.ContainsRune(csvFormulaPrefixes, rune(value[0])) {
+		return value
+	}
+	return "'" + value
+}
+
+// escapeCSVCellPtr applies escapeCSVCell to a possibly-nil pointer, returning
+// "" for nil.
+func escapeCSVCellPtr(value *string) string {
+	if value == nil {
+		return ""
+	}
+	return escapeCSVCell(*value)
+}
+
+// csvCells returns r's values in Header order for one CSV row.
+//
+// Escaped (spreadsheet formula-injection risk): SubAccountName (a synced IdP
+// group name has no server-side character validation), ChargeDescription and
+// ResourceName (both embed interceptions.model, already treated as untrusted
+// by the existing AI spend export's own escaping), BillingAccountName (embeds
+// a username; low risk since usernames are normalized, escaped anyway for
+// defense in depth), ProviderName/PublisherName/ServiceName/InvoiceIssuerName
+// (safe when resolved from the canonical vendor-label map, but the
+// openai-compat fallback is admin-set free text with no validation), and
+// x_ProviderResponseId (populated verbatim from the upstream provider's own
+// API response, which Coder never validates).
+//
+// Not escaped: x_ProviderInstance (ai_providers.name has a DB CHECK
+// constraint matching a safe pattern) and x_ClientTool (always one of a fixed
+// enum of values, never raw user-agent text).
+func csvCells(r Row) []string {
+	return []string{
+		r.BilledCost, r.BillingAccountID, escapeCSVCell(r.BillingAccountName), r.BillingAccountType,
+		r.BillingCurrency, r.BillingPeriodEnd.UTC().Format(rfc3339Micro), r.BillingPeriodStart.UTC().Format(rfc3339Micro),
+		r.ChargeCategory, ptrOrEmpty(r.ChargeClass), escapeCSVCell(r.ChargeDescription), r.ChargeFrequency,
+		r.ChargePeriodEnd.UTC().Format(rfc3339Micro), r.ChargePeriodStart.UTC().Format(rfc3339Micro),
+		strconv.FormatInt(r.ConsumedQuantity, 10), r.ConsumedUnit,
+		r.ContractedCost, ptrOrEmpty(r.ContractedUnitPrice), r.EffectiveCost, escapeCSVCell(r.InvoiceIssuerName),
+		r.ListCost, ptrOrEmpty(r.ListUnitPrice),
+		r.PricingCategory, strconv.FormatInt(r.PricingQuantity, 10), r.PricingUnit,
+		escapeCSVCell(r.ProviderName), escapeCSVCell(r.PublisherName),
+		ptrOrEmpty(r.ResourceID), escapeCSVCell(r.ResourceName), r.ResourceType,
+		r.ServiceCategory, escapeCSVCell(r.ServiceName), r.ServiceSubcategory,
+		r.SkuID, r.SkuPriceID,
+		ptrOrEmpty(r.SubAccountID), escapeCSVCellPtr(r.SubAccountName), r.SubAccountType,
+		r.Tags,
+		escapeCSVCellPtr(r.XProviderResponseID), ptrOrEmpty(r.XInterceptionID), ptrOrEmpty(r.XSessionID), r.XInitiatorID,
+		r.XCredentialKind, r.XWireProtocol, r.XProviderInstance, r.XClientTool,
+		ptrOrEmpty(r.XErrorType), r.XPricingStatus, r.XTokenType, strconv.FormatInt(r.XRowCount, 10),
+	}
+}
+
+const rfc3339Micro = "2006-01-02T15:04:05.999999Z07:00"
+
+func ptrOrEmpty(s *string) string {
+	if s == nil {
+		return ""
+	}
+	return *s
+}
+
+// WriteCSV writes rows as a FOCUS CSV document, header first, to w.
+// Formula-injection escaping happens only here, applied to a cell just
+// before it's written, never on the Row struct itself: WriteParquet and the
+// Row values it serializes are never touched, since formula injection is a
+// spreadsheet-import risk specific to CSV, and Parquet consumers read typed
+// binary data, not evaluated formulas.
+func WriteCSV(w io.Writer, rows []Row) error {
+	cw := csv.NewWriter(w)
+	if err := cw.Write(Header); err != nil {
+		return err
+	}
+	for _, row := range rows {
+		if err := cw.Write(csvCells(row)); err != nil {
+			return err
+		}
+	}
+	cw.Flush()
+	return cw.Error()
+}

--- a/coderd/aibridge/focus/csv_test.go
+++ b/coderd/aibridge/focus/csv_test.go
@@ -1,0 +1,108 @@
+package focus_test
+
+import (
+	"bytes"
+	"encoding/csv"
+	"strings"
+	"testing"
+
+	"github.com/coder/coder/v2/coderd/aibridge/focus"
+)
+
+// ptr is a small generic helper shared by this package's black-box tests
+// (csv_test.go, parquet_test.go) for building a pointer to a literal.
+func ptr[T any](v T) *T { return &v }
+
+// TestWriteCSV_EscapesRiskyColumnsOnly confirms the columns the Phase One
+// Draft calls out as formula-injection risks are escaped, that the two
+// columns explicitly declared safe by construction are left alone, and that
+// WriteParquet on the same Row leaves every value untouched.
+func TestWriteCSV_EscapesRiskyColumnsOnly(t *testing.T) {
+	t.Parallel()
+
+	formula := "=cmd|' /C calc'!A1"
+	row := focus.Row{
+		BillingAccountName:  formula,
+		ChargeDescription:   formula,
+		ResourceName:        formula,
+		ProviderName:        formula,
+		PublisherName:       formula,
+		ServiceName:         formula,
+		InvoiceIssuerName:   formula,
+		SubAccountName:      ptr(formula),
+		XProviderResponseID: ptr(formula),
+		// Safe by construction: never escaped even though they share the
+		// same leading character.
+		XProviderInstance: formula,
+		XClientTool:       formula,
+
+		ConsumedUnit:    "Tokens",
+		PricingUnit:     "Tokens",
+		SubAccountType:  "Coder Budget Group",
+		BillingCurrency: "USD",
+		ChargeCategory:  "Usage",
+		ChargeFrequency: "Usage-Based",
+		Tags:            "{}",
+	}
+
+	var buf bytes.Buffer
+	if err := focus.WriteCSV(&buf, []focus.Row{row}); err != nil {
+		t.Fatalf("WriteCSV: %v", err)
+	}
+
+	r := csv.NewReader(&buf)
+	records, err := r.ReadAll()
+	if err != nil {
+		t.Fatalf("parse csv: %v", err)
+	}
+	if len(records) != 2 {
+		t.Fatalf("got %d records, want 2 (header + 1 row)", len(records))
+	}
+	if len(records[0]) != len(focus.Header) {
+		t.Fatalf("header has %d columns, want %d", len(records[0]), len(focus.Header))
+	}
+	if len(records[1]) != len(records[0]) {
+		t.Fatalf("row has %d columns, want %d (matching the header)", len(records[1]), len(records[0]))
+	}
+
+	header := records[0]
+	values := records[1]
+	byName := func(name string) string {
+		for i, h := range header {
+			if h == name {
+				return values[i]
+			}
+		}
+		t.Fatalf("column %q not found in header", name)
+		return ""
+	}
+
+	escapedCols := []string{
+		"BillingAccountName", "ChargeDescription", "ResourceName",
+		"ProviderName", "PublisherName", "ServiceName", "InvoiceIssuerName",
+		"SubAccountName", "x_ProviderResponseId",
+	}
+	for _, col := range escapedCols {
+		got := byName(col)
+		if !strings.HasPrefix(got, "'") {
+			t.Errorf("column %s = %q, want a leading single-quote escape", col, got)
+		}
+	}
+
+	safeCols := []string{"x_ProviderInstance", "x_ClientTool"}
+	for _, col := range safeCols {
+		got := byName(col)
+		if got != formula {
+			t.Errorf("column %s = %q, want unescaped %q", col, got, formula)
+		}
+	}
+
+	// The same Row written as Parquet must never see escaping.
+	var pbuf bytes.Buffer
+	if err := focus.WriteParquet(&pbuf, []focus.Row{row}); err != nil {
+		t.Fatalf("WriteParquet: %v", err)
+	}
+	if pbuf.Len() == 0 {
+		t.Fatal("expected non-empty parquet output")
+	}
+}

--- a/coderd/aibridge/focus/dto.go
+++ b/coderd/aibridge/focus/dto.go
@@ -1,0 +1,143 @@
+// Package focus maps AI Gateway usage records into FOCUS v1.2-shaped rows for
+// the experimental FOCUS export endpoint.
+//
+// This package is a read-only projection over aibridge_interceptions and
+// aibridge_token_usages. It introduces no new source-of-truth table, and
+// nothing here changes how usage is recorded or how cost is calculated.
+package focus
+
+import (
+	"time"
+
+	"github.com/google/uuid"
+
+	"github.com/coder/coder/v2/coderd/database"
+)
+
+// TokenType is one of the token categories FOCUS fans a UsageRecord out into.
+type TokenType string
+
+const (
+	TokenTypeInput      TokenType = "Input"
+	TokenTypeOutput     TokenType = "Output"
+	TokenTypeCacheRead  TokenType = "CacheRead"
+	TokenTypeCacheWrite TokenType = "CacheWrite"
+)
+
+// Label returns the human-readable token type name used in ChargeDescription,
+// e.g. "Input tokens".
+func (t TokenType) Label() string {
+	switch t {
+	case TokenTypeInput:
+		return "Input tokens"
+	case TokenTypeOutput:
+		return "Output tokens"
+	case TokenTypeCacheRead:
+		return "Cache read tokens"
+	case TokenTypeCacheWrite:
+		return "Cache write tokens"
+	default:
+		return string(t) + " tokens"
+	}
+}
+
+// TokenUsage is one non-zero token-type entry within a UsageRecord. One
+// UsageRecord fans out into one FOCUS Row per TokenUsage.
+type TokenUsage struct {
+	Type   TokenType
+	Tokens int64
+	// UnitPriceMicros is nil when unpriced, never zero-for-unknown.
+	UnitPriceMicros *int64
+}
+
+// BudgetGroup is the resolved sub-account (budget group) a UsageRecord is
+// attributed to. Distinct from budget.EffectiveGroup, which carries only a
+// group ID and limit and has no Name field.
+type BudgetGroup struct {
+	ID   uuid.UUID
+	Name string
+}
+
+// BillingAccount is the resolved account identity for one UsageRecord. It has
+// no Coder analog today; both fields are derived by policy from Credential
+// and, for BYOK, ProviderInstance and InitiatorID.
+type BillingAccount struct {
+	ID   string
+	Name string
+	Type string
+}
+
+// UsageRecord is one unit of AI Gateway usage with everything the export
+// formats need already resolved. It deliberately holds no prompt, response,
+// thinking, or tool-call payload, so no output format can leak one.
+//
+// At raw granularity, one UsageRecord corresponds to exactly one priced
+// provider response (one aibridge_token_usages row). At a rolled-up
+// granularity, one UsageRecord corresponds to a bucket of provider responses
+// sharing every FOCUS dimension except quantity; RowCount then reports how
+// many underlying responses were folded together, and the response-level
+// identifiers (ResponseID, InterceptionID, SessionID) are empty whenever the
+// bucket folded together more than one distinct value for that identifier,
+// since no single value would be well-defined.
+type UsageRecord struct {
+	// TokenUsageID becomes ResourceId. At raw granularity this is
+	// token_usages.id, unique per priced response. At a rolled-up
+	// granularity there is no natural key, so this is a deterministic
+	// synthetic UUID derived from the bucket's grouping key, stable for a
+	// given billing period and mapping version.
+	TokenUsageID uuid.UUID
+	// ResponseID becomes x_ProviderResponseId. Empty when not uniquely
+	// determined (rollup only).
+	ResponseID string
+	// InterceptionID becomes x_InterceptionId. Empty when not uniquely
+	// determined (rollup only).
+	InterceptionID uuid.UUID
+	// SessionID becomes x_SessionId. Empty when not uniquely determined
+	// (rollup only).
+	SessionID  string
+	ClientTool string  // interceptions.client, e.g. Mux
+	ErrorType  *string // interceptions.error_type, nil when the interception succeeded (or, in rollup mode, when every folded response succeeded)
+
+	StartedAt time.Time
+	EndedAt   time.Time // already coalesced, never zero
+
+	// BillingPeriodAnchor is the instant BillingPeriodStart/End is derived
+	// from, per the AI Gateway to FOCUS Mapping table: token_usages.created_at
+	// at raw granularity (i.e. the finest-real-timestamp proxy for "when this
+	// priced response was recorded"), or the rollup bucket's start at a
+	// rolled-up granularity. This is deliberately its own field rather than a
+	// reuse of StartedAt or EndedAt:
+	//   - StartedAt (interception.started_at) is when the request began, not
+	//     when it was recorded/priced; using it can misattribute a request
+	//     that starts in one calendar month but resolves in the next.
+	//   - EndedAt is an exclusive bucket end at rollup granularity, so for the
+	//     final bucket of any month it lands on the first instant of the
+	//     following month, which is the wrong month for BillingPeriodStart/End.
+	BillingPeriodAnchor time.Time
+
+	InitiatorID       uuid.UUID
+	InitiatorUsername string
+	BudgetGroup       *BudgetGroup // nil when unresolved
+
+	Model string
+	// Vendor is the canonical, human-readable vendor label (ProviderName /
+	// ServiceName / InvoiceIssuerName), resolved from ai_providers.type or the
+	// wire-protocol fallback label.
+	Vendor string
+	// VendorTypeRaw is the short, machine-oriented vendor code used inside
+	// SkuId/SkuPriceId: ai_providers.type's raw string when a provider row
+	// resolved, else the wire protocol.
+	VendorTypeRaw    string
+	Publisher        string // derived from the model string
+	WireProtocol     string // interceptions.provider, the upstream API format. Kept distinct from Vendor
+	ProviderInstance string
+
+	Credential     database.CredentialKind // centralized or byok. Independent of BillingAccount
+	BillingAccount BillingAccount          // resolved by policy, not switched on Credential's value
+
+	Usage []TokenUsage // one entry per token type with non-zero usage
+
+	// RowCount is the number of raw aibridge_token_usages rows folded into
+	// this UsageRecord. Always 1 at raw granularity.
+	RowCount int64
+}

--- a/coderd/aibridge/focus/escapecsv_internal_test.go
+++ b/coderd/aibridge/focus/escapecsv_internal_test.go
@@ -1,0 +1,31 @@
+package focus
+
+import "testing"
+
+// TestEscapeCSVCell is a white-box test of the pure escaping helper itself;
+// TestWriteCSV_EscapesRiskyColumnsOnly (csv_test.go) covers it end to end
+// through the public WriteCSV API.
+//
+//nolint:testpackage // exercises the unexported escapeCSVCell directly.
+func TestEscapeCSVCell(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		in   string
+		want string
+	}{
+		{"", ""},
+		{"normal", "normal"},
+		{"=SUM(A1:A2)", "'=SUM(A1:A2)"},
+		{"+1", "'+1"},
+		{"-1", "'-1"},
+		{"@cmd", "'@cmd"},
+		{"\ttab", "'\ttab"},
+		{"\rcr", "'\rcr"},
+	}
+	for _, tc := range cases {
+		if got := escapeCSVCell(tc.in); got != tc.want {
+			t.Errorf("escapeCSVCell(%q) = %q, want %q", tc.in, got, tc.want)
+		}
+	}
+}

--- a/coderd/aibridge/focus/parquet.go
+++ b/coderd/aibridge/focus/parquet.go
@@ -1,0 +1,18 @@
+package focus
+
+import (
+	"io"
+
+	"github.com/parquet-go/parquet-go"
+)
+
+// WriteParquet writes rows as a FOCUS Parquet document to w, using gzip
+// compression: measured smallest among the codecs parquet-go supports for
+// this schema (Phase One Draft, Parquet library selection). Row's `optional`
+// pointer fields become nullable Parquet columns for free, matching FOCUS's
+// nullable columns (ContractedUnitPrice, SubAccountId, and so on) exactly.
+// Row values are written unescaped: formula-injection escaping is a
+// CSV/spreadsheet-import concern only (see csv.go).
+func WriteParquet(w io.Writer, rows []Row) error {
+	return parquet.Write[Row](w, rows, parquet.Compression(&parquet.Gzip))
+}

--- a/coderd/aibridge/focus/parquet_test.go
+++ b/coderd/aibridge/focus/parquet_test.go
@@ -1,0 +1,114 @@
+package focus_test
+
+import (
+	"bytes"
+	"testing"
+	"time"
+
+	"github.com/parquet-go/parquet-go"
+
+	"github.com/coder/coder/v2/coderd/aibridge/focus"
+)
+
+// TestParquetRoundTrip writes a small set of Rows, including nullable fields
+// in both their present and absent states, and reads them back, confirming
+// optional columns and pre-formatted decimal strings survive unchanged.
+func TestParquetRoundTrip(t *testing.T) {
+	t.Parallel()
+
+	price := "0.0000010000"
+	priced := focus.Row{
+		BilledCost:          "0",
+		BillingAccountID:    "dev.coder.com",
+		BillingAccountName:  "Coder Deployment (dev.coder.com)",
+		BillingAccountType:  "Coder Deployment",
+		BillingCurrency:     "USD",
+		BillingPeriodStart:  time.Date(2026, 6, 1, 0, 0, 0, 0, time.UTC),
+		BillingPeriodEnd:    time.Date(2026, 7, 1, 0, 0, 0, 0, time.UTC),
+		ChargeCategory:      "Usage",
+		ChargeClass:         nil,
+		ChargeDescription:   "claude-haiku-4-5 - Input tokens",
+		ChargeFrequency:     "Usage-Based",
+		ChargePeriodStart:   time.Date(2026, 6, 19, 22, 58, 41, 374962000, time.UTC),
+		ChargePeriodEnd:     time.Date(2026, 6, 19, 22, 58, 42, 674767000, time.UTC),
+		ConsumedQuantity:    3,
+		ConsumedUnit:        "Tokens",
+		ContractedCost:      "0.0000030000",
+		ContractedUnitPrice: &price,
+		EffectiveCost:       "0.0000030000",
+		InvoiceIssuerName:   "Anthropic",
+		ListCost:            "0.0000030000",
+		ListUnitPrice:       &price,
+		PricingCategory:     "Standard",
+		PricingQuantity:     3,
+		PricingUnit:         "Tokens",
+		ProviderName:        "Anthropic",
+		PublisherName:       "Anthropic",
+		ResourceID:          ptr("d1739bba-6711-4bc7-aa46-b9e32bfaa451"),
+		ResourceName:        "claude-haiku-4-5",
+		ResourceType:        "LLM Model",
+		ServiceCategory:     "AI and Machine Learning",
+		ServiceName:         "Anthropic",
+		ServiceSubcategory:  "Generative AI",
+		SkuID:               "anthropic/claude-haiku-4-5/InputTokens",
+		SkuPriceID:          "anthropic/claude-haiku-4-5/InputTokens/unversioned",
+		SubAccountID:        nil,
+		SubAccountName:      nil,
+		SubAccountType:      "Coder Budget Group",
+		Tags:                `{"aibridge.client":"Mux","coder.username":"callum"}`,
+		XInitiatorID:        "a26a1adc-48a9-4823-a58d-8e0b7e9c60f2",
+		XCredentialKind:     "centralized",
+		XWireProtocol:       "anthropic",
+		XProviderInstance:   "anthropic",
+		XClientTool:         "Mux",
+		XPricingStatus:      "priced",
+		XTokenType:          "Input",
+		XRowCount:           1,
+	}
+
+	unpriced := priced
+	unpriced.ContractedUnitPrice = nil
+	unpriced.ListUnitPrice = nil
+	unpriced.ResourceID = nil
+	unpriced.SubAccountID = ptr("3ea6ae38-ff77-446a-ad06-fb1ba0c9e1b1")
+	unpriced.SubAccountName = ptr("Vibes")
+	unpriced.XPricingStatus = "unpriced"
+
+	rows := []focus.Row{priced, unpriced}
+
+	var buf bytes.Buffer
+	if err := focus.WriteParquet(&buf, rows); err != nil {
+		t.Fatalf("WriteParquet: %v", err)
+	}
+
+	got, err := parquet.Read[focus.Row](bytes.NewReader(buf.Bytes()), int64(buf.Len()))
+	if err != nil {
+		t.Fatalf("parquet.Read: %v", err)
+	}
+	if len(got) != 2 {
+		t.Fatalf("got %d rows, want 2", len(got))
+	}
+
+	if got[0].ContractedUnitPrice == nil || *got[0].ContractedUnitPrice != price {
+		t.Errorf("row 0 ContractedUnitPrice = %v, want %s", got[0].ContractedUnitPrice, price)
+	}
+	if got[0].ResourceID == nil || *got[0].ResourceID != *priced.ResourceID {
+		t.Errorf("row 0 ResourceID = %v", got[0].ResourceID)
+	}
+	if got[0].SubAccountID != nil {
+		t.Errorf("row 0 SubAccountID = %v, want nil", got[0].SubAccountID)
+	}
+
+	if got[1].ContractedUnitPrice != nil {
+		t.Errorf("row 1 ContractedUnitPrice = %v, want nil (unpriced)", got[1].ContractedUnitPrice)
+	}
+	if got[1].ResourceID != nil {
+		t.Errorf("row 1 ResourceID = %v, want nil", got[1].ResourceID)
+	}
+	if got[1].SubAccountID == nil || *got[1].SubAccountID != "3ea6ae38-ff77-446a-ad06-fb1ba0c9e1b1" {
+		t.Errorf("row 1 SubAccountID = %v", got[1].SubAccountID)
+	}
+	if !got[1].ChargePeriodStart.Equal(unpriced.ChargePeriodStart) {
+		t.Errorf("row 1 ChargePeriodStart = %v, want %v", got[1].ChargePeriodStart, unpriced.ChargePeriodStart)
+	}
+}

--- a/coderd/aibridge/focus/query.go
+++ b/coderd/aibridge/focus/query.go
@@ -1,0 +1,352 @@
+package focus
+
+import (
+	"context"
+	"crypto/sha1" //nolint:gosec // used only as a deterministic (non-cryptographic) UUIDv5 name-hash input, not for security.
+	"database/sql"
+	"fmt"
+	"reflect"
+	"strings"
+	"time"
+
+	"github.com/google/uuid"
+	"golang.org/x/xerrors"
+
+	"github.com/coder/coder/v2/coderd/database"
+)
+
+// Store is the subset of database.Store needed to load FOCUS usage records.
+type Store interface {
+	GetOrganizationAIFOCUSUsage(ctx context.Context, arg database.GetOrganizationAIFOCUSUsageParams) ([]database.GetOrganizationAIFOCUSUsageRow, error)
+	GetOrganizationAIFOCUSUsageRollup(ctx context.Context, arg database.GetOrganizationAIFOCUSUsageRollupParams) ([]database.GetOrganizationAIFOCUSUsageRollupRow, error)
+}
+
+// MaxGranularitySeconds bounds the rollup bucket width to at most one
+// calendar day. It does NOT guarantee a bucket stays within a single
+// calendar month: buckets are anchored to the UNIX epoch in UTC (see
+// GetOrganizationAIFOCUSUsageRollup), so the final bucket of every month
+// straddles the month boundary at any granularity, including granularities
+// that evenly divide a day. BillingPeriodStart/End is derived from each
+// record's bucket-start instant specifically to make this deterministic
+// (row.go's MapUsageRecord), not from the bucket's exclusive end. At large
+// granularities (e.g. tens of thousands of seconds) a single bucket can span
+// most of two calendar months; its spend is then wholly attributed to the
+// month containing the bucket's start. That is an accepted trade-off of
+// coarse rollups, not a bug: callers who need month-accurate billing periods
+// should request a granularity of at most a few hours.
+const MaxGranularitySeconds = 24 * 60 * 60
+
+// rollupUUIDNamespace namespaces the deterministic synthetic ResourceId
+// generated for a rolled-up UsageRecord (see loadRollupUsageRecords).
+// Generated once and fixed; changing it would change every rolled-up
+// ResourceId, which is intentionally treated the same as any other
+// mapping-version change.
+var rollupUUIDNamespace = uuid.MustParse("6a6c9b7e-8f4b-4f1c-9c0e-6a6c9b7e8f4b")
+
+// LoadUsageRecords returns AI Gateway usage for the organization over
+// [periodStart, periodEnd), resolved into UsageRecords ready for
+// MapUsageRecord.
+//
+// granularitySeconds selects the row grain: 0 (or negative) requests raw,
+// unrolled per-response grain (one UsageRecord per priced provider
+// response); a positive value requests rollup into fixed-width UTC time
+// buckets of that many seconds (e.g. 3600 for hourly), up to
+// MaxGranularitySeconds.
+func LoadUsageRecords(ctx context.Context, store Store, organizationID uuid.UUID, periodStart, periodEnd time.Time, granularitySeconds int64) ([]UsageRecord, error) {
+	if granularitySeconds <= 0 {
+		return loadRawUsageRecords(ctx, store, organizationID, periodStart, periodEnd)
+	}
+	return loadRollupUsageRecords(ctx, store, organizationID, periodStart, periodEnd, granularitySeconds)
+}
+
+func loadRawUsageRecords(ctx context.Context, store Store, organizationID uuid.UUID, periodStart, periodEnd time.Time) ([]UsageRecord, error) {
+	rows, err := store.GetOrganizationAIFOCUSUsage(ctx, database.GetOrganizationAIFOCUSUsageParams{
+		OrganizationID: organizationID,
+		PeriodStart:    periodStart,
+		PeriodEnd:      periodEnd,
+	})
+	if err != nil {
+		return nil, xerrors.Errorf("load raw FOCUS usage: %w", err)
+	}
+
+	records := make([]UsageRecord, 0, len(rows))
+	for _, row := range rows {
+		vendor := resolveVendor(nullProviderTypePtr(row.VendorType), nullStringPtr(row.VendorDisplayName), row.WireProtocol, row.Model)
+		rec := UsageRecord{
+			TokenUsageID:   row.TokenUsageID,
+			ResponseID:     row.ProviderResponseID,
+			InterceptionID: row.InterceptionID,
+			SessionID:      row.SessionID,
+			ClientTool:     nullStringOr(row.ClientTool, "Unknown"),
+			ErrorType:      nullErrorTypePtr(row.ErrorType),
+			StartedAt:      row.StartedAt,
+			EndedAt:        row.EndedAt,
+			// token_usages.created_at, per the AI Gateway to FOCUS Mapping
+			// table's BillingPeriodStart/End source column (see
+			// UsageRecord.BillingPeriodAnchor). Already selected by this
+			// query for exactly this purpose.
+			BillingPeriodAnchor: row.CreatedAt,
+			InitiatorID:         row.InitiatorID,
+			InitiatorUsername:   row.InitiatorUsername,
+			Model:               row.Model,
+			Vendor:              vendor.Label,
+			VendorTypeRaw:       vendorTypeRaw(nullProviderTypePtr(row.VendorType), row.WireProtocol),
+			Publisher:           vendor.Publisher,
+			WireProtocol:        row.WireProtocol,
+			ProviderInstance:    row.ProviderInstance,
+			Credential:          row.CredentialKind,
+			Usage: tokenUsagesFromCounts(
+				row.InputTokens, row.OutputTokens, row.CacheReadInputTokens, row.CacheWriteInputTokens,
+				row.InputPriceMicros, row.OutputPriceMicros, row.CacheReadPriceMicros, row.CacheWritePriceMicros,
+			),
+			RowCount: 1,
+		}
+		if row.EffectiveGroupID.Valid {
+			rec.BudgetGroup = &BudgetGroup{ID: row.EffectiveGroupID.UUID, Name: row.GroupName}
+		}
+		records = append(records, rec)
+	}
+	return records, nil
+}
+
+func loadRollupUsageRecords(ctx context.Context, store Store, organizationID uuid.UUID, periodStart, periodEnd time.Time, granularitySeconds int64) ([]UsageRecord, error) {
+	if granularitySeconds > MaxGranularitySeconds {
+		return nil, xerrors.Errorf("granularity_seconds %d exceeds the maximum of %d", granularitySeconds, MaxGranularitySeconds)
+	}
+
+	rows, err := store.GetOrganizationAIFOCUSUsageRollup(ctx, database.GetOrganizationAIFOCUSUsageRollupParams{
+		GranularitySeconds: granularitySeconds,
+		OrganizationID:     organizationID,
+		PeriodStart:        periodStart,
+		PeriodEnd:          periodEnd,
+	})
+	if err != nil {
+		return nil, xerrors.Errorf("load rolled-up FOCUS usage: %w", err)
+	}
+
+	records := make([]UsageRecord, 0, len(rows))
+	for _, row := range rows {
+		// bucketStart/bucketEnd are clamped symmetrically to the requested
+		// period: Postgres floors bucket_start to the epoch-anchored boundary
+		// regardless of where periodStart falls inside that bucket, so without
+		// this the first bucket of a request can report a ChargePeriodStart
+		// earlier than periodStart and claim to cover time the export was
+		// never asked for and holds no data for.
+		bucketStart := row.BucketStart
+		if bucketStart.Before(periodStart) {
+			bucketStart = periodStart
+		}
+		bucketEnd := row.BucketStart.Add(time.Duration(granularitySeconds) * time.Second)
+		if bucketEnd.After(periodEnd) {
+			bucketEnd = periodEnd
+		}
+
+		vendor := resolveVendor(nullProviderTypePtr(row.VendorType), nullStringPtr(row.VendorDisplayName), row.WireProtocol, row.Model)
+		rec := UsageRecord{
+			TokenUsageID: rollupResourceID(organizationID, granularitySeconds, row),
+			ClientTool:   nullStringOr(row.ClientTool, "Unknown"),
+			ErrorType:    nullErrorTypePtr(row.ErrorType),
+			StartedAt:    bucketStart,
+			EndedAt:      bucketEnd,
+			// The bucket's (clamped) start: there is no per-bucket analog of
+			// token_usages.created_at once more than one response has been
+			// folded together, so the bucket's start is the least-wrong
+			// single instant to anchor the billing period to (see
+			// UsageRecord.BillingPeriodAnchor). Using bucketEnd instead would
+			// misattribute the final bucket of every month to the following
+			// month, since bucketEnd is an exclusive boundary that can land
+			// on the first instant of the next month.
+			BillingPeriodAnchor: bucketStart,
+			InitiatorID:         row.InitiatorID,
+			InitiatorUsername:   row.InitiatorUsername,
+			Model:               row.Model,
+			Vendor:              vendor.Label,
+			VendorTypeRaw:       vendorTypeRaw(nullProviderTypePtr(row.VendorType), row.WireProtocol),
+			Publisher:           vendor.Publisher,
+			WireProtocol:        row.WireProtocol,
+			ProviderInstance:    row.ProviderInstance,
+			Credential:          row.CredentialKind,
+			Usage: tokenUsagesFromCounts(
+				row.InputTokens, row.OutputTokens, row.CacheReadInputTokens, row.CacheWriteInputTokens,
+				row.InputPriceMicros, row.OutputPriceMicros, row.CacheReadPriceMicros, row.CacheWritePriceMicros,
+			),
+			RowCount: row.RowCount,
+		}
+		if row.InterceptionIDDistinctCount == 1 {
+			rec.InterceptionID = row.InterceptionIDMin
+		}
+		if row.SessionIDDistinctCount == 1 {
+			rec.SessionID = row.SessionIDMin
+		}
+		if row.ProviderResponseIDDistinctCount == 1 {
+			rec.ResponseID = row.ProviderResponseIDMin
+		}
+		if row.EffectiveGroupID.Valid {
+			rec.BudgetGroup = &BudgetGroup{ID: row.EffectiveGroupID.UUID, Name: row.GroupName}
+		}
+		records = append(records, rec)
+	}
+	return records, nil
+}
+
+// rollupResourceID deterministically derives a synthetic ResourceId for a
+// rolled-up UsageRecord from its full grouping key, so re-exporting the same
+// billing period at the same granularity and mapping version reproduces the
+// same ResourceId every time (the export's determinism requirement), and two
+// buckets that differ in any GROUP BY dimension get distinct ResourceIds.
+// This holds across a user, group, or provider display-name rename: the key
+// folds in IDs (InitiatorID, EffectiveGroupID, ProviderInstance/VendorType),
+// never their mutable display labels (see rollupGroupKeyExcludedFields), so
+// renaming any of them does not change a bucket's ResourceId.
+func rollupResourceID(organizationID uuid.UUID, granularitySeconds int64, row database.GetOrganizationAIFOCUSUsageRollupRow) uuid.UUID {
+	key := rollupGroupKey(organizationID, granularitySeconds, row)
+	return uuid.NewHash(sha1.New(), rollupUUIDNamespace, []byte(key), 5) //nolint:gosec // deterministic name-hash, not a security boundary.
+}
+
+// rollupGroupKeyExcludedFields names every GetOrganizationAIFOCUSUsageRollupRow
+// field rollupGroupKey must NOT fold into the hash key, for one of two
+// reasons:
+//
+//  1. It is an aggregate computed OVER the GROUP BY key rather than a member
+//     OF it: the three MIN(...)/COUNT(DISTINCT ...) identifier pairs,
+//     row_count, and the four summed token counts. Including one of these
+//     would make the "same bucket, same ResourceId" determinism guarantee
+//     flap on quantity alone instead of only on a genuine dimension change
+//     (TestRollupResourceID_MeasuresDoNotAffectResourceID, query_internal_test.go).
+//  2. It is a mutable, human-readable display label that is functionally
+//     redundant with an ID already folded into the key: InitiatorUsername
+//     with InitiatorID, GroupName with EffectiveGroupID, VendorDisplayName
+//     with ProviderInstance/VendorType. Folding these in as well would make a
+//     user rename, group rename, or provider display-name edit change the
+//     ResourceId of every historical bucket that user/group/provider
+//     appears in, without changing anything the bucket actually
+//     aggregates over (TestRollupResourceID_ExcludedLabelFieldsDoNotAffectResourceID,
+//     query_internal_test.go).
+//
+// rollupGroupKey folds in every field NOT named here, so it never needs to
+// be told about a new GROUP BY dimension by name; it only needs to be told
+// when a new aggregate or redundant display label is added. A hand-maintained
+// allowlist of dimensions drifted silently once already (CacheWritePriceMicros
+// was grouped on in SQL but missing from the old hash key, colliding
+// ResourceIds across distinct cache-write prices); this denylist is far
+// shorter and, if it drifts by omission, fails loudly instead of silently.
+var rollupGroupKeyExcludedFields = map[string]bool{
+	// Aggregates (reason 1, above).
+	"InterceptionIDMin":               true,
+	"InterceptionIDDistinctCount":     true,
+	"SessionIDMin":                    true,
+	"SessionIDDistinctCount":          true,
+	"ProviderResponseIDMin":           true,
+	"ProviderResponseIDDistinctCount": true,
+	"RowCount":                        true,
+	"InputTokens":                     true,
+	"OutputTokens":                    true,
+	"CacheReadInputTokens":            true,
+	"CacheWriteInputTokens":           true,
+	// Mutable display labels redundant with an ID already in the key
+	// (reason 2, above).
+	"InitiatorUsername": true,
+	"GroupName":         true,
+	"VendorDisplayName": true,
+}
+
+// rollupGroupKey stringifies organizationID, granularitySeconds, and every
+// GROUP BY dimension field of row (i.e. every field not in
+// rollupGroupKeyExcludedFields), via reflection, in the row struct's
+// declared field order. Deriving the key mechanically from the row's own
+// fields, instead of naming each dimension by hand, is the fix for the
+// collision described on rollupGroupKeyExcludedFields: a future dimension
+// added to the SQL SELECT/GROUP BY list is automatically included the
+// moment sqlc regenerates the row struct, with no second call site to
+// remember to update.
+func rollupGroupKey(organizationID uuid.UUID, granularitySeconds int64, row database.GetOrganizationAIFOCUSUsageRollupRow) string {
+	var b strings.Builder
+	// strings.Builder's Write* methods never return an error (see its own
+	// docs), so these results are safe to discard.
+	_, _ = fmt.Fprintf(&b, "%s|%d", organizationID, granularitySeconds)
+	v := reflect.ValueOf(row)
+	t := v.Type()
+	for i := range t.NumField() {
+		field := t.Field(i)
+		if !field.IsExported() {
+			// sqlc only emits exported fields on generated row structs, so
+			// this never fires today; guarded because Interface() panics on
+			// an unexported field, and this runs on a request path.
+			continue
+		}
+		if rollupGroupKeyExcludedFields[field.Name] {
+			continue
+		}
+		val := v.Field(i).Interface()
+		if ts, ok := val.(time.Time); ok {
+			// Normalize location and precision so the same instant always
+			// stringifies identically regardless of the driver-returned
+			// time.Time's monotonic reading or zone.
+			val = ts.UTC().Format(time.RFC3339Nano)
+		}
+		_ = b.WriteByte('|')
+		_, _ = fmt.Fprintf(&b, "%v", val)
+	}
+	return b.String()
+}
+
+// tokenUsagesFromCounts builds the non-zero TokenUsage entries for a
+// UsageRecord from its four raw counts and matching *_price_micros snapshots.
+func tokenUsagesFromCounts(input, output, cacheRead, cacheWrite int64, inputPrice, outputPrice, cacheReadPrice, cacheWritePrice sql.NullInt64) []TokenUsage {
+	var usage []TokenUsage
+	add := func(tokenType TokenType, tokens int64, price sql.NullInt64) {
+		if tokens == 0 {
+			return
+		}
+		tu := TokenUsage{Type: tokenType, Tokens: tokens}
+		if price.Valid {
+			v := price.Int64
+			tu.UnitPriceMicros = &v
+		}
+		usage = append(usage, tu)
+	}
+	add(TokenTypeInput, input, inputPrice)
+	add(TokenTypeOutput, output, outputPrice)
+	add(TokenTypeCacheRead, cacheRead, cacheReadPrice)
+	add(TokenTypeCacheWrite, cacheWrite, cacheWritePrice)
+	return usage
+}
+
+func nullStringOr(s sql.NullString, fallback string) string {
+	if !s.Valid || s.String == "" {
+		return fallback
+	}
+	return s.String
+}
+
+func nullStringPtr(s sql.NullString) *string {
+	if !s.Valid {
+		return nil
+	}
+	return &s.String
+}
+
+func nullProviderTypePtr(t database.NullAIProviderType) *database.AIProviderType {
+	if !t.Valid {
+		return nil
+	}
+	return &t.AIProviderType
+}
+
+// vendorTypeRaw returns the short, machine-oriented vendor code used inside
+// SkuId/SkuPriceId: the raw ai_providers.type string when a provider row
+// resolved, else the wire protocol (matching resolveVendor's own fallback).
+func vendorTypeRaw(vendorType *database.AIProviderType, wireProtocol string) string {
+	if vendorType != nil {
+		return string(*vendorType)
+	}
+	return wireProtocol
+}
+
+func nullErrorTypePtr(e database.NullAIBridgeInterceptionErrorType) *string {
+	if !e.Valid {
+		return nil
+	}
+	v := string(e.AIBridgeInterceptionErrorType)
+	return &v
+}

--- a/coderd/aibridge/focus/query_internal_test.go
+++ b/coderd/aibridge/focus/query_internal_test.go
@@ -1,0 +1,193 @@
+package focus
+
+import (
+	"database/sql"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+
+	"github.com/coder/coder/v2/coderd/database"
+)
+
+// baseRollupRow is a fully-populated GetOrganizationAIFOCUSUsageRollupRow used
+// as the starting point for the tests below, which each mutate exactly one
+// field and check whether rollupResourceID changes.
+func baseRollupRow() database.GetOrganizationAIFOCUSUsageRollupRow {
+	return database.GetOrganizationAIFOCUSUsageRollupRow{
+		BucketStart:           time.Date(2026, 6, 1, 3, 0, 0, 0, time.UTC),
+		InitiatorID:           uuid.MustParse("a26a1adc-48a9-4823-a58d-8e0b7e9c60f2"),
+		InitiatorUsername:     "callum",
+		EffectiveGroupID:      uuid.NullUUID{UUID: uuid.MustParse("3ea6ae38-ff77-446a-ad06-fb1ba0c9e1b1"), Valid: true},
+		GroupName:             "Vibes",
+		OrganizationID:        uuid.MustParse("bafc64b2-1276-4518-8cd7-d8133eb6b789"),
+		Model:                 "claude-haiku-4-5",
+		WireProtocol:          "anthropic",
+		ProviderInstance:      "anthropic",
+		CredentialKind:        database.CredentialKindCentralized,
+		VendorType:            database.NullAIProviderType{AIProviderType: database.AIProviderTypeAnthropic, Valid: true},
+		VendorDisplayName:     sql.NullString{String: "anthropic", Valid: true},
+		ClientTool:            sql.NullString{String: "Mux", Valid: true},
+		InputPriceMicros:      sql.NullInt64{Int64: 1_000_000, Valid: true},
+		OutputPriceMicros:     sql.NullInt64{Int64: 5_000_000, Valid: true},
+		CacheReadPriceMicros:  sql.NullInt64{Int64: 100_000, Valid: true},
+		CacheWritePriceMicros: sql.NullInt64{Int64: 1_250_000, Valid: true},
+		InterceptionIDMin:     uuid.MustParse("edeea219-190d-4494-b2f1-0f5746639178"),
+		SessionIDMin:          "edeea219-190d-4494-b2f1-0f5746639178",
+		ProviderResponseIDMin: "msg_01Bk9iY843EAmrQYyYVgVZmP",
+		RowCount:              2,
+		InputTokens:           3,
+		OutputTokens:          51,
+		CacheReadInputTokens:  0,
+		CacheWriteInputTokens: 9278,
+	}
+}
+
+// TestRollupResourceID_MeasuresDoNotAffectResourceID is the regression test
+// referenced by rollupGroupKeyExcludedFields' doc comment: mutating a field
+// that is an aggregate computed OVER the GROUP BY key (a *_min/distinct_count
+// identifier pair, row_count, or a summed token count) must never change the
+// synthetic ResourceId. If one of these leaked into the key, the "same
+// bucket, same ResourceId" determinism guarantee would flap on quantity
+// alone, not just on a genuine dimension change.
+//
+//nolint:testpackage // exercises the unexported rollupResourceID directly.
+func TestRollupResourceID_MeasuresDoNotAffectResourceID(t *testing.T) {
+	t.Parallel()
+
+	base := baseRollupRow()
+	want := rollupResourceID(base.OrganizationID, 3600, base)
+
+	mutations := map[string]func(r *database.GetOrganizationAIFOCUSUsageRollupRow){
+		"InputTokens":                     func(r *database.GetOrganizationAIFOCUSUsageRollupRow) { r.InputTokens = 999_999 },
+		"OutputTokens":                    func(r *database.GetOrganizationAIFOCUSUsageRollupRow) { r.OutputTokens = 999_999 },
+		"CacheReadInputTokens":            func(r *database.GetOrganizationAIFOCUSUsageRollupRow) { r.CacheReadInputTokens = 999_999 },
+		"CacheWriteInputTokens":           func(r *database.GetOrganizationAIFOCUSUsageRollupRow) { r.CacheWriteInputTokens = 999_999 },
+		"RowCount":                        func(r *database.GetOrganizationAIFOCUSUsageRollupRow) { r.RowCount = 999 },
+		"InterceptionIDMin":               func(r *database.GetOrganizationAIFOCUSUsageRollupRow) { r.InterceptionIDMin = uuid.New() },
+		"InterceptionIDDistinctCount":     func(r *database.GetOrganizationAIFOCUSUsageRollupRow) { r.InterceptionIDDistinctCount = 999 },
+		"SessionIDMin":                    func(r *database.GetOrganizationAIFOCUSUsageRollupRow) { r.SessionIDMin = uuid.NewString() },
+		"SessionIDDistinctCount":          func(r *database.GetOrganizationAIFOCUSUsageRollupRow) { r.SessionIDDistinctCount = 999 },
+		"ProviderResponseIDMin":           func(r *database.GetOrganizationAIFOCUSUsageRollupRow) { r.ProviderResponseIDMin = "different" },
+		"ProviderResponseIDDistinctCount": func(r *database.GetOrganizationAIFOCUSUsageRollupRow) { r.ProviderResponseIDDistinctCount = 999 },
+	}
+
+	for name, mutate := range mutations {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			row := baseRollupRow()
+			mutate(&row)
+			got := rollupResourceID(row.OrganizationID, 3600, row)
+			require.Equal(t, want, got, "mutating measure field %s must not change ResourceId", name)
+		})
+	}
+}
+
+// TestRollupResourceID_ExcludedLabelFieldsDoNotAffectResourceID is the
+// regression test for a rename-stability fix: InitiatorUsername, GroupName,
+// and VendorDisplayName are mutable, human-readable labels functionally
+// determined by an ID already in the key (InitiatorID, EffectiveGroupID, and
+// ProviderInstance/VendorType respectively), so a rename of a user, group, or
+// provider display name must not change a bucket's ResourceId. Without this
+// exclusion, re-exporting the same historical billing period after any of
+// those three renames would silently break the "same bucket, same
+// ResourceId" determinism guarantee.
+//
+//nolint:testpackage // exercises the unexported rollupResourceID directly.
+func TestRollupResourceID_ExcludedLabelFieldsDoNotAffectResourceID(t *testing.T) {
+	t.Parallel()
+
+	base := baseRollupRow()
+	want := rollupResourceID(base.OrganizationID, 3600, base)
+
+	mutations := map[string]func(r *database.GetOrganizationAIFOCUSUsageRollupRow){
+		"InitiatorUsername": func(r *database.GetOrganizationAIFOCUSUsageRollupRow) { r.InitiatorUsername = "renamed-user" },
+		"GroupName":         func(r *database.GetOrganizationAIFOCUSUsageRollupRow) { r.GroupName = "renamed-group" },
+		"VendorDisplayName": func(r *database.GetOrganizationAIFOCUSUsageRollupRow) {
+			r.VendorDisplayName = sql.NullString{String: "renamed-display-name", Valid: true}
+		},
+	}
+
+	for name, mutate := range mutations {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			row := baseRollupRow()
+			mutate(&row)
+			got := rollupResourceID(row.OrganizationID, 3600, row)
+			require.Equal(t, want, got, "renaming %s must not change ResourceId", name)
+		})
+	}
+}
+
+// TestRollupResourceID_DimensionsDoAffectResourceID is the complement of the
+// two tests above: every field NOT in rollupGroupKeyExcludedFields is a real
+// GROUP BY dimension, and mutating any one of them must change the
+// ResourceId. This is the mechanical guarantee rollupGroupKey's reflection
+// approach is supposed to provide; it is what would have caught the
+// CacheWritePriceMicros collision this whole mechanism replaced.
+//
+//nolint:testpackage // exercises the unexported rollupResourceID directly.
+func TestRollupResourceID_DimensionsDoAffectResourceID(t *testing.T) {
+	t.Parallel()
+
+	base := baseRollupRow()
+	want := rollupResourceID(base.OrganizationID, 3600, base)
+
+	mutations := map[string]func(r *database.GetOrganizationAIFOCUSUsageRollupRow){
+		"BucketStart": func(r *database.GetOrganizationAIFOCUSUsageRollupRow) { r.BucketStart = r.BucketStart.Add(time.Hour) },
+		"InitiatorID": func(r *database.GetOrganizationAIFOCUSUsageRollupRow) { r.InitiatorID = uuid.New() },
+		"EffectiveGroupID": func(r *database.GetOrganizationAIFOCUSUsageRollupRow) {
+			r.EffectiveGroupID = uuid.NullUUID{UUID: uuid.New(), Valid: true}
+		},
+		"Model":            func(r *database.GetOrganizationAIFOCUSUsageRollupRow) { r.Model = "different-model" },
+		"WireProtocol":     func(r *database.GetOrganizationAIFOCUSUsageRollupRow) { r.WireProtocol = "openai" },
+		"ProviderInstance": func(r *database.GetOrganizationAIFOCUSUsageRollupRow) { r.ProviderInstance = "different-instance" },
+		"CredentialKind":   func(r *database.GetOrganizationAIFOCUSUsageRollupRow) { r.CredentialKind = database.CredentialKindByok },
+		"VendorType": func(r *database.GetOrganizationAIFOCUSUsageRollupRow) {
+			r.VendorType = database.NullAIProviderType{AIProviderType: database.AIProviderTypeOpenai, Valid: true}
+		},
+		"ClientTool": func(r *database.GetOrganizationAIFOCUSUsageRollupRow) {
+			r.ClientTool = sql.NullString{String: "Different", Valid: true}
+		},
+		"ErrorType": func(r *database.GetOrganizationAIFOCUSUsageRollupRow) {
+			r.ErrorType = database.NullAIBridgeInterceptionErrorType{AIBridgeInterceptionErrorType: database.AibridgeInterceptionErrorTypeServerError, Valid: true}
+		},
+		"InputPriceMicros": func(r *database.GetOrganizationAIFOCUSUsageRollupRow) {
+			r.InputPriceMicros = sql.NullInt64{Int64: 999, Valid: true}
+		},
+		"OutputPriceMicros": func(r *database.GetOrganizationAIFOCUSUsageRollupRow) {
+			r.OutputPriceMicros = sql.NullInt64{Int64: 999, Valid: true}
+		},
+		"CacheReadPriceMicros": func(r *database.GetOrganizationAIFOCUSUsageRollupRow) {
+			r.CacheReadPriceMicros = sql.NullInt64{Int64: 999, Valid: true}
+		},
+		"CacheWritePriceMicros": func(r *database.GetOrganizationAIFOCUSUsageRollupRow) {
+			r.CacheWritePriceMicros = sql.NullInt64{Int64: 999, Valid: true}
+		},
+	}
+
+	for name, mutate := range mutations {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			row := baseRollupRow()
+			mutate(&row)
+			got := rollupResourceID(row.OrganizationID, 3600, row)
+			require.NotEqual(t, want, got, "mutating dimension field %s must change ResourceId", name)
+		})
+	}
+
+	t.Run("GranularitySeconds", func(t *testing.T) {
+		t.Parallel()
+		row := baseRollupRow()
+		got := rollupResourceID(row.OrganizationID, 7200, row)
+		require.NotEqual(t, want, got, "a different granularity must change ResourceId")
+	})
+
+	t.Run("OrganizationID", func(t *testing.T) {
+		t.Parallel()
+		row := baseRollupRow()
+		got := rollupResourceID(uuid.New(), 3600, row)
+		require.NotEqual(t, want, got, "a different organization must change ResourceId")
+	})
+}

--- a/coderd/aibridge/focus/query_test.go
+++ b/coderd/aibridge/focus/query_test.go
@@ -1,0 +1,490 @@
+package focus_test
+
+import (
+	"database/sql"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+
+	"github.com/coder/coder/v2/coderd/aibridge/focus"
+	"github.com/coder/coder/v2/coderd/database"
+	"github.com/coder/coder/v2/coderd/database/dbgen"
+	"github.com/coder/coder/v2/coderd/database/dbtestutil"
+	"github.com/coder/coder/v2/testutil"
+)
+
+func TestLoadUsageRecords_Raw(t *testing.T) {
+	t.Parallel()
+
+	ctx := testutil.Context(t, testutil.WaitLong)
+	db, _ := dbtestutil.NewDB(t)
+
+	orgA := dbgen.Organization(t, db, database.Organization{})
+	orgB := dbgen.Organization(t, db, database.Organization{})
+
+	groupA := dbgen.Group(t, db, database.Group{OrganizationID: orgA.ID, Name: "group-a"})
+	groupB := dbgen.Group(t, db, database.Group{OrganizationID: orgB.ID, Name: "group-b"})
+
+	user := dbgen.User(t, db, database.User{})
+
+	provider := dbgen.AIProvider(t, db, database.AIProvider{Type: database.AIProviderTypeAnthropic, Name: "anthropic"})
+
+	periodStart := time.Date(2026, 6, 1, 0, 0, 0, 0, time.UTC)
+	periodEnd := time.Date(2026, 7, 1, 0, 0, 0, 0, time.UTC)
+	inBounds := periodStart.Add(time.Hour)
+
+	// (a) In scope: belongs to orgA via groupA.
+	inScope := dbgen.AIBridgeInterception(t, db, database.InsertAIBridgeInterceptionParams{
+		InitiatorID: user.ID, Provider: "anthropic", ProviderName: provider.Name, Model: "claude-haiku-4-5",
+		StartedAt: inBounds,
+	}, ptrTime(inBounds.Add(time.Second)))
+	inScopeUsage := dbgen.AIBridgeTokenUsage(t, db, database.InsertAIBridgeTokenUsageParams{
+		InterceptionID: inScope.ID, InputTokens: 10, OutputTokens: 20,
+		CreatedAt:        inBounds.Add(time.Second),
+		EffectiveGroupID: uuid.NullUUID{UUID: groupA.ID, Valid: true},
+		InputPriceMicros: sqlNullInt64(1_000_000),
+	})
+
+	// (b) Out of scope: belongs to orgB via groupB.
+	otherOrg := dbgen.AIBridgeInterception(t, db, database.InsertAIBridgeInterceptionParams{
+		InitiatorID: user.ID, Provider: "anthropic", ProviderName: provider.Name, Model: "claude-haiku-4-5",
+		StartedAt: inBounds,
+	}, ptrTime(inBounds.Add(time.Second)))
+	dbgen.AIBridgeTokenUsage(t, db, database.InsertAIBridgeTokenUsageParams{
+		InterceptionID: otherOrg.ID, InputTokens: 5, OutputTokens: 5,
+		CreatedAt:        inBounds.Add(time.Second),
+		EffectiveGroupID: uuid.NullUUID{UUID: groupB.ID, Valid: true},
+	})
+
+	// (c) Excluded entirely: NULL effective_group_id.
+	noGroup := dbgen.AIBridgeInterception(t, db, database.InsertAIBridgeInterceptionParams{
+		InitiatorID: user.ID, Provider: "anthropic", ProviderName: provider.Name, Model: "claude-haiku-4-5",
+		StartedAt: inBounds,
+	}, ptrTime(inBounds.Add(time.Second)))
+	dbgen.AIBridgeTokenUsage(t, db, database.InsertAIBridgeTokenUsageParams{
+		InterceptionID: noGroup.ID, InputTokens: 1, OutputTokens: 1,
+		CreatedAt: inBounds.Add(time.Second),
+	})
+
+	records, err := focus.LoadUsageRecords(ctx, db, orgA.ID, periodStart, periodEnd, 0)
+	require.NoError(t, err)
+	require.Len(t, records, 1, "only the orgA row should be returned")
+	require.Equal(t, inScopeUsage.ID, records[0].TokenUsageID)
+	require.Equal(t, "Anthropic", records[0].Vendor)
+	require.NotNil(t, records[0].BudgetGroup)
+	require.Equal(t, groupA.ID, records[0].BudgetGroup.ID)
+	require.Len(t, records[0].Usage, 2) // input + output, both non-zero
+}
+
+// TestLoadUsageRecords_Rollup_OrgIsolation mirrors
+// TestLoadUsageRecords_Raw's org A vs org B coverage, but for the rollup
+// query: the raw query's tenant isolation is well-tested, but the rollup
+// query has its own hand-written WHERE clause and its own hand-written
+// RBACObject wiring, with no equivalent regression coverage before this.
+func TestLoadUsageRecords_Rollup_OrgIsolation(t *testing.T) {
+	t.Parallel()
+
+	ctx := testutil.Context(t, testutil.WaitLong)
+	db, _ := dbtestutil.NewDB(t)
+
+	orgA := dbgen.Organization(t, db, database.Organization{})
+	orgB := dbgen.Organization(t, db, database.Organization{})
+
+	groupA := dbgen.Group(t, db, database.Group{OrganizationID: orgA.ID, Name: "group-a"})
+	groupB := dbgen.Group(t, db, database.Group{OrganizationID: orgB.ID, Name: "group-b"})
+
+	user := dbgen.User(t, db, database.User{})
+	provider := dbgen.AIProvider(t, db, database.AIProvider{Type: database.AIProviderTypeAnthropic, Name: "anthropic"})
+
+	periodStart := time.Date(2026, 6, 1, 0, 0, 0, 0, time.UTC)
+	periodEnd := time.Date(2026, 6, 2, 0, 0, 0, 0, time.UTC)
+	at := periodStart.Add(time.Hour)
+
+	inScope := dbgen.AIBridgeInterception(t, db, database.InsertAIBridgeInterceptionParams{
+		InitiatorID: user.ID, Provider: "anthropic", ProviderName: provider.Name, Model: "claude-haiku-4-5",
+		StartedAt: at,
+	}, ptrTime(at.Add(time.Second)))
+	dbgen.AIBridgeTokenUsage(t, db, database.InsertAIBridgeTokenUsageParams{
+		InterceptionID: inScope.ID, InputTokens: 10,
+		CreatedAt:        at.Add(time.Second),
+		EffectiveGroupID: uuid.NullUUID{UUID: groupA.ID, Valid: true},
+	})
+
+	otherOrg := dbgen.AIBridgeInterception(t, db, database.InsertAIBridgeInterceptionParams{
+		InitiatorID: user.ID, Provider: "anthropic", ProviderName: provider.Name, Model: "claude-haiku-4-5",
+		StartedAt: at,
+	}, ptrTime(at.Add(time.Second)))
+	dbgen.AIBridgeTokenUsage(t, db, database.InsertAIBridgeTokenUsageParams{
+		InterceptionID: otherOrg.ID, InputTokens: 999,
+		CreatedAt:        at.Add(time.Second),
+		EffectiveGroupID: uuid.NullUUID{UUID: groupB.ID, Valid: true},
+	})
+
+	records, err := focus.LoadUsageRecords(ctx, db, orgA.ID, periodStart, periodEnd, 3600)
+	require.NoError(t, err)
+	require.Len(t, records, 1, "only orgA's bucket should be returned")
+	require.Equal(t, int64(10), usageForType(t, records[0].Usage, focus.TokenTypeInput).Tokens,
+		"orgB's row must not be folded into orgA's bucket")
+}
+
+// TestLoadUsageRecords_Raw_BillingPeriodUsesTokenUsageCreatedAt is the
+// regression test for the raw-grain half of the BillingPeriodStart/End
+// source-column fix: the AI Gateway to FOCUS Mapping table specifies
+// token_usages.created_at, not interceptions.started_at, as the source. A
+// request that starts in one calendar month but whose response is recorded
+// (token_usages.created_at) in the next must be billed to the month it was
+// recorded in, not the month it started in.
+func TestLoadUsageRecords_Raw_BillingPeriodUsesTokenUsageCreatedAt(t *testing.T) {
+	t.Parallel()
+
+	ctx := testutil.Context(t, testutil.WaitLong)
+	db, _ := dbtestutil.NewDB(t)
+
+	org := dbgen.Organization(t, db, database.Organization{})
+	group := dbgen.Group(t, db, database.Group{OrganizationID: org.ID, Name: "group"})
+	user := dbgen.User(t, db, database.User{})
+	provider := dbgen.AIProvider(t, db, database.AIProvider{Type: database.AIProviderTypeAnthropic, Name: "anthropic"})
+
+	// The request starts in the last second of September, but its response
+	// (token_usages.created_at) isn't recorded until just after midnight, in
+	// October.
+	startedAt := time.Date(2026, 9, 30, 23, 59, 59, 0, time.UTC)
+	createdAt := time.Date(2026, 10, 1, 0, 0, 1, 0, time.UTC)
+	periodStart := time.Date(2026, 9, 1, 0, 0, 0, 0, time.UTC)
+	periodEnd := time.Date(2026, 10, 2, 0, 0, 0, 0, time.UTC)
+
+	interception := dbgen.AIBridgeInterception(t, db, database.InsertAIBridgeInterceptionParams{
+		InitiatorID: user.ID, Provider: "anthropic", ProviderName: provider.Name, Model: "claude-haiku-4-5",
+		StartedAt: startedAt,
+	}, ptrTime(createdAt))
+	dbgen.AIBridgeTokenUsage(t, db, database.InsertAIBridgeTokenUsageParams{
+		InterceptionID: interception.ID, InputTokens: 10,
+		CreatedAt:        createdAt,
+		EffectiveGroupID: uuid.NullUUID{UUID: group.ID, Valid: true},
+	})
+
+	records, err := focus.LoadUsageRecords(ctx, db, org.ID, periodStart, periodEnd, 0)
+	require.NoError(t, err)
+	require.Len(t, records, 1)
+	require.True(t, createdAt.Equal(records[0].BillingPeriodAnchor),
+		"want %s (token_usages.created_at), got %s", createdAt, records[0].BillingPeriodAnchor)
+
+	rows := focus.MapUsageRecord(records[0], "coder.example.com")
+	require.NotEmpty(t, rows)
+	wantPeriodStart := time.Date(2026, 10, 1, 0, 0, 0, 0, time.UTC)
+	wantPeriodEnd := time.Date(2026, 11, 1, 0, 0, 0, 0, time.UTC)
+	for _, row := range rows {
+		require.True(t, wantPeriodStart.Equal(row.BillingPeriodStart),
+			"a response recorded in October must be billed to October even though its request started in September: want %s, got %s", wantPeriodStart, row.BillingPeriodStart)
+		require.True(t, wantPeriodEnd.Equal(row.BillingPeriodEnd))
+	}
+}
+
+func TestLoadUsageRecords_SoftDeletedProviderNameReuseDoesNotDoubleCount(t *testing.T) {
+	t.Parallel()
+
+	ctx := testutil.Context(t, testutil.WaitLong)
+	db, _ := dbtestutil.NewDB(t)
+
+	org := dbgen.Organization(t, db, database.Organization{})
+	group := dbgen.Group(t, db, database.Group{OrganizationID: org.ID, Name: "group"})
+	user := dbgen.User(t, db, database.User{})
+
+	// A soft-deleted provider whose name is later reused by a live provider.
+	deleted := dbgen.AIProvider(t, db, database.AIProvider{Type: database.AIProviderTypeOpenai, Name: "shared-name"})
+	require.NoError(t, db.DeleteAIProviderByID(ctx, deleted.ID))
+	live := dbgen.AIProvider(t, db, database.AIProvider{Type: database.AIProviderTypeAnthropic, Name: "shared-name"})
+
+	periodStart := time.Date(2026, 6, 1, 0, 0, 0, 0, time.UTC)
+	periodEnd := time.Date(2026, 7, 1, 0, 0, 0, 0, time.UTC)
+	at := periodStart.Add(time.Hour)
+
+	interception := dbgen.AIBridgeInterception(t, db, database.InsertAIBridgeInterceptionParams{
+		InitiatorID: user.ID, Provider: "anthropic", ProviderName: live.Name, Model: "claude-haiku-4-5",
+		StartedAt: at,
+	}, ptrTime(at.Add(time.Second)))
+	dbgen.AIBridgeTokenUsage(t, db, database.InsertAIBridgeTokenUsageParams{
+		InterceptionID: interception.ID, InputTokens: 10, OutputTokens: 10,
+		CreatedAt:        at.Add(time.Second),
+		EffectiveGroupID: uuid.NullUUID{UUID: group.ID, Valid: true},
+	})
+
+	records, err := focus.LoadUsageRecords(ctx, db, org.ID, periodStart, periodEnd, 0)
+	require.NoError(t, err)
+	require.Len(t, records, 1, "the LEFT JOIN on provider.deleted = false must resolve to exactly the live row, not fan out across both")
+	require.Equal(t, "Anthropic", records[0].Vendor)
+}
+
+func TestLoadUsageRecords_Rollup(t *testing.T) {
+	t.Parallel()
+
+	ctx := testutil.Context(t, testutil.WaitLong)
+	db, _ := dbtestutil.NewDB(t)
+
+	org := dbgen.Organization(t, db, database.Organization{})
+	group := dbgen.Group(t, db, database.Group{OrganizationID: org.ID, Name: "group"})
+	user := dbgen.User(t, db, database.User{})
+	provider := dbgen.AIProvider(t, db, database.AIProvider{Type: database.AIProviderTypeAnthropic, Name: "anthropic"})
+
+	periodStart := time.Date(2026, 6, 1, 0, 0, 0, 0, time.UTC)
+	periodEnd := time.Date(2026, 6, 2, 0, 0, 0, 0, time.UTC)
+	hour := periodStart.Add(3 * time.Hour)
+
+	newInterception := func(at time.Time) database.AIBridgeInterception {
+		return dbgen.AIBridgeInterception(t, db, database.InsertAIBridgeInterceptionParams{
+			InitiatorID: user.ID, Provider: "anthropic", ProviderName: provider.Name, Model: "claude-haiku-4-5",
+			StartedAt: at,
+		}, ptrTime(at.Add(time.Second)))
+	}
+
+	// Two responses in the same UTC hour, same dimensions and price: expected
+	// to fold into one rolled-up row.
+	i1 := newInterception(hour.Add(5 * time.Minute))
+	dbgen.AIBridgeTokenUsage(t, db, database.InsertAIBridgeTokenUsageParams{
+		InterceptionID: i1.ID, InputTokens: 100, OutputTokens: 0,
+		CreatedAt:        hour.Add(5 * time.Minute),
+		EffectiveGroupID: uuid.NullUUID{UUID: group.ID, Valid: true},
+		InputPriceMicros: sqlNullInt64(1_000_000),
+	})
+	i2 := newInterception(hour.Add(40 * time.Minute))
+	dbgen.AIBridgeTokenUsage(t, db, database.InsertAIBridgeTokenUsageParams{
+		InterceptionID: i2.ID, InputTokens: 50, OutputTokens: 0,
+		CreatedAt:        hour.Add(40 * time.Minute),
+		EffectiveGroupID: uuid.NullUUID{UUID: group.ID, Valid: true},
+		InputPriceMicros: sqlNullInt64(1_000_000),
+	})
+
+	// A third response in the next hour must land in a separate bucket.
+	i3 := newInterception(hour.Add(90 * time.Minute))
+	dbgen.AIBridgeTokenUsage(t, db, database.InsertAIBridgeTokenUsageParams{
+		InterceptionID: i3.ID, InputTokens: 999, OutputTokens: 0,
+		CreatedAt:        hour.Add(90 * time.Minute),
+		EffectiveGroupID: uuid.NullUUID{UUID: group.ID, Valid: true},
+		InputPriceMicros: sqlNullInt64(1_000_000),
+	})
+
+	records, err := focus.LoadUsageRecords(ctx, db, org.ID, periodStart, periodEnd, 3600)
+	require.NoError(t, err)
+	require.Len(t, records, 2, "two hourly buckets")
+
+	var foldedBucket, nextBucket *focus.UsageRecord
+	for i := range records {
+		if records[i].RowCount == 2 {
+			foldedBucket = &records[i]
+		} else {
+			nextBucket = &records[i]
+		}
+	}
+	require.NotNil(t, foldedBucket, "expected one bucket folding the two same-hour responses")
+	require.NotNil(t, nextBucket)
+
+	foldedInput := usageForType(t, foldedBucket.Usage, focus.TokenTypeInput)
+	require.Equal(t, int64(150), foldedInput.Tokens, "150 = 100 + 50 input tokens summed within the bucket")
+	// Two distinct interceptions folded together: the response-level
+	// identifiers are not well-defined and must be omitted.
+	require.Equal(t, uuid.Nil, foldedBucket.InterceptionID)
+	require.Equal(t, "", foldedBucket.SessionID)
+
+	require.Equal(t, int64(1), nextBucket.RowCount)
+	require.Equal(t, int64(999), usageForType(t, nextBucket.Usage, focus.TokenTypeInput).Tokens)
+	// A single-response bucket still has a well-defined interception.
+	require.Equal(t, i3.ID, nextBucket.InterceptionID)
+
+	// The two buckets must never collide on their synthetic ResourceId.
+	require.NotEqual(t, foldedBucket.TokenUsageID, nextBucket.TokenUsageID)
+
+	// Re-running the same query must reproduce the same synthetic ResourceId
+	// for each bucket (the export's determinism requirement), matched
+	// pairwise by BucketStart rather than by set membership: a determinism
+	// regression that returned the same ResourceId twice for run 2 would
+	// still pass a set-membership check, but must fail this one.
+	again, err := focus.LoadUsageRecords(ctx, db, org.ID, periodStart, periodEnd, 3600)
+	require.NoError(t, err)
+	require.Len(t, again, 2)
+	byBucketStart := func(recs []focus.UsageRecord) map[time.Time]uuid.UUID {
+		m := make(map[time.Time]uuid.UUID, len(recs))
+		for _, r := range recs {
+			m[r.StartedAt] = r.TokenUsageID
+		}
+		return m
+	}
+	first := byBucketStart(records)
+	second := byBucketStart(again)
+	require.Equal(t, first, second, "each bucket must reproduce the exact same ResourceId across runs")
+}
+
+// TestLoadUsageRecords_Rollup_PreservesIdentifierWhenUnambiguous covers the
+// complement of the fold case above: multiple token-usage rows sharing a
+// single interception (so COUNT(DISTINCT interception_id) == 1) must retain
+// that interception's identifier, not null it out. Without this, a
+// regression that unconditionally nulled the response-level identifiers
+// would still pass every other rollup test in this file.
+func TestLoadUsageRecords_Rollup_PreservesIdentifierWhenUnambiguous(t *testing.T) {
+	t.Parallel()
+
+	ctx := testutil.Context(t, testutil.WaitLong)
+	db, _ := dbtestutil.NewDB(t)
+
+	org := dbgen.Organization(t, db, database.Organization{})
+	group := dbgen.Group(t, db, database.Group{OrganizationID: org.ID, Name: "group"})
+	user := dbgen.User(t, db, database.User{})
+	provider := dbgen.AIProvider(t, db, database.AIProvider{Type: database.AIProviderTypeAnthropic, Name: "anthropic"})
+
+	periodStart := time.Date(2026, 6, 1, 0, 0, 0, 0, time.UTC)
+	periodEnd := time.Date(2026, 6, 2, 0, 0, 0, 0, time.UTC)
+	hour := periodStart.Add(3 * time.Hour)
+
+	// One interception, two token-usage rows (e.g. an input pass and a
+	// separate output pass on the same response) in the same bucket.
+	interception := dbgen.AIBridgeInterception(t, db, database.InsertAIBridgeInterceptionParams{
+		InitiatorID: user.ID, Provider: "anthropic", ProviderName: provider.Name, Model: "claude-haiku-4-5",
+		StartedAt: hour.Add(5 * time.Minute),
+	}, ptrTime(hour.Add(6*time.Minute)))
+	dbgen.AIBridgeTokenUsage(t, db, database.InsertAIBridgeTokenUsageParams{
+		InterceptionID: interception.ID, InputTokens: 100, OutputTokens: 0,
+		CreatedAt:         hour.Add(5 * time.Minute),
+		EffectiveGroupID:  uuid.NullUUID{UUID: group.ID, Valid: true},
+		InputPriceMicros:  sqlNullInt64(1_000_000),
+		OutputPriceMicros: sqlNullInt64(2_000_000),
+	})
+	dbgen.AIBridgeTokenUsage(t, db, database.InsertAIBridgeTokenUsageParams{
+		InterceptionID: interception.ID, InputTokens: 0, OutputTokens: 200,
+		CreatedAt:         hour.Add(10 * time.Minute),
+		EffectiveGroupID:  uuid.NullUUID{UUID: group.ID, Valid: true},
+		InputPriceMicros:  sqlNullInt64(1_000_000),
+		OutputPriceMicros: sqlNullInt64(2_000_000),
+	})
+
+	records, err := focus.LoadUsageRecords(ctx, db, org.ID, periodStart, periodEnd, 3600)
+	require.NoError(t, err)
+	require.Len(t, records, 1)
+	require.Equal(t, int64(2), records[0].RowCount)
+	require.Equal(t, interception.ID, records[0].InterceptionID,
+		"a bucket whose rows share one interception must preserve it, not null it out")
+}
+
+// TestLoadUsageRecords_Rollup_DiffersAcrossCacheWritePrice is the regression
+// test for a ResourceId collision bug: cache_write_price_micros is part of
+// the SQL GROUP BY key (it can legitimately differ between two buckets that
+// otherwise share every other dimension, e.g. a mid-window price-book
+// update), so two such buckets must resolve to distinct synthetic
+// ResourceIds. A hand-maintained hash key previously omitted this column and
+// collided.
+//
+// Both interceptions are placed in the SAME hourly bucket, sharing every
+// other dimension, so cache_write_price_micros is the only thing that can
+// possibly force them into separate rows: with two different buckets
+// (bucket_start included in the key either way), this test would still pass
+// against the old, broken key that omitted cache_write_price_micros.
+func TestLoadUsageRecords_Rollup_DiffersAcrossCacheWritePrice(t *testing.T) {
+	t.Parallel()
+
+	ctx := testutil.Context(t, testutil.WaitLong)
+	db, _ := dbtestutil.NewDB(t)
+
+	org := dbgen.Organization(t, db, database.Organization{})
+	group := dbgen.Group(t, db, database.Group{OrganizationID: org.ID, Name: "group"})
+	user := dbgen.User(t, db, database.User{})
+	provider := dbgen.AIProvider(t, db, database.AIProvider{Type: database.AIProviderTypeAnthropic, Name: "anthropic"})
+
+	periodStart := time.Date(2026, 6, 1, 0, 0, 0, 0, time.UTC)
+	periodEnd := time.Date(2026, 6, 2, 0, 0, 0, 0, time.UTC)
+	hour := periodStart.Add(3 * time.Hour)
+
+	newInterception := func(at time.Time) database.AIBridgeInterception {
+		return dbgen.AIBridgeInterception(t, db, database.InsertAIBridgeInterceptionParams{
+			InitiatorID: user.ID, Provider: "anthropic", ProviderName: provider.Name, Model: "claude-haiku-4-5",
+			StartedAt: at,
+		}, ptrTime(at.Add(time.Second)))
+	}
+
+	iA := newInterception(hour.Add(5 * time.Minute))
+	dbgen.AIBridgeTokenUsage(t, db, database.InsertAIBridgeTokenUsageParams{
+		InterceptionID: iA.ID, CacheWriteInputTokens: 100,
+		CreatedAt:             hour.Add(5 * time.Minute),
+		EffectiveGroupID:      uuid.NullUUID{UUID: group.ID, Valid: true},
+		CacheWritePriceMicros: sqlNullInt64(1_000_000),
+	})
+	iB := newInterception(hour.Add(10 * time.Minute))
+	dbgen.AIBridgeTokenUsage(t, db, database.InsertAIBridgeTokenUsageParams{
+		InterceptionID: iB.ID, CacheWriteInputTokens: 100,
+		CreatedAt:             hour.Add(10 * time.Minute),
+		EffectiveGroupID:      uuid.NullUUID{UUID: group.ID, Valid: true},
+		CacheWritePriceMicros: sqlNullInt64(2_000_000),
+	})
+
+	records, err := focus.LoadUsageRecords(ctx, db, org.ID, periodStart, periodEnd, 3600)
+	require.NoError(t, err)
+	require.Len(t, records, 2, "one hourly bucket, split into two rows by cache_write_price_micros alone")
+	require.True(t, records[0].StartedAt.Equal(records[1].StartedAt),
+		"both rows must share the same bucket start; a difference here would let bucket_start, not price, explain distinct ResourceIds")
+	require.NotEqual(t, records[0].TokenUsageID, records[1].TokenUsageID,
+		"rows in the same bucket that differ only in cache_write_price_micros must not share a synthetic ResourceId")
+}
+
+// TestLoadUsageRecords_Rollup_BillingPeriodMatchesBucketMonth is the
+// regression test for a billing-period bug: the last rollup bucket of any
+// month has an exclusive end that falls on the first instant of the next
+// month. Deriving BillingPeriodStart/End from that end (rather than the
+// bucket's start) stamped the final hour of every month as spend in the
+// following month's billing period.
+func TestLoadUsageRecords_Rollup_BillingPeriodMatchesBucketMonth(t *testing.T) {
+	t.Parallel()
+
+	ctx := testutil.Context(t, testutil.WaitLong)
+	db, _ := dbtestutil.NewDB(t)
+
+	org := dbgen.Organization(t, db, database.Organization{})
+	group := dbgen.Group(t, db, database.Group{OrganizationID: org.ID, Name: "group"})
+	user := dbgen.User(t, db, database.User{})
+	provider := dbgen.AIProvider(t, db, database.AIProvider{Type: database.AIProviderTypeAnthropic, Name: "anthropic"})
+
+	// The final hourly bucket of September: [2026-09-30T23:00:00Z,
+	// 2026-10-01T00:00:00Z).
+	lastHourStart := time.Date(2026, 9, 30, 23, 0, 0, 0, time.UTC)
+	periodStart := time.Date(2026, 9, 1, 0, 0, 0, 0, time.UTC)
+	periodEnd := time.Date(2026, 10, 1, 0, 0, 0, 0, time.UTC)
+
+	interception := dbgen.AIBridgeInterception(t, db, database.InsertAIBridgeInterceptionParams{
+		InitiatorID: user.ID, Provider: "anthropic", ProviderName: provider.Name, Model: "claude-haiku-4-5",
+		StartedAt: lastHourStart.Add(5 * time.Minute),
+	}, ptrTime(lastHourStart.Add(6*time.Minute)))
+	dbgen.AIBridgeTokenUsage(t, db, database.InsertAIBridgeTokenUsageParams{
+		InterceptionID: interception.ID, InputTokens: 100,
+		CreatedAt:        lastHourStart.Add(5 * time.Minute),
+		EffectiveGroupID: uuid.NullUUID{UUID: group.ID, Valid: true},
+	})
+
+	records, err := focus.LoadUsageRecords(ctx, db, org.ID, periodStart, periodEnd, 3600)
+	require.NoError(t, err)
+	require.Len(t, records, 1)
+	require.True(t, lastHourStart.Equal(records[0].StartedAt), "want %s, got %s", lastHourStart, records[0].StartedAt)
+	require.True(t, periodEnd.Equal(records[0].EndedAt), "clamped to periodEnd since the bucket's raw end is exclusive of the requested period")
+
+	rows := focus.MapUsageRecord(records[0], "coder.example.com")
+	require.NotEmpty(t, rows)
+	wantPeriodStart := time.Date(2026, 9, 1, 0, 0, 0, 0, time.UTC)
+	wantPeriodEnd := time.Date(2026, 10, 1, 0, 0, 0, 0, time.UTC)
+	for _, row := range rows {
+		require.True(t, wantPeriodStart.Equal(row.BillingPeriodStart),
+			"the final bucket of September must still be stamped as September spend: want %s, got %s", wantPeriodStart, row.BillingPeriodStart)
+		require.True(t, wantPeriodEnd.Equal(row.BillingPeriodEnd), "want %s, got %s", wantPeriodEnd, row.BillingPeriodEnd)
+	}
+}
+
+func ptrTime(t time.Time) *time.Time { return &t }
+
+func sqlNullInt64(v int64) sql.NullInt64 { return sql.NullInt64{Int64: v, Valid: true} }
+
+func usageForType(t *testing.T, usage []focus.TokenUsage, tokenType focus.TokenType) focus.TokenUsage {
+	t.Helper()
+	for _, u := range usage {
+		if u.Type == tokenType {
+			return u
+		}
+	}
+	t.Fatalf("no %s token usage found in %+v", tokenType, usage)
+	return focus.TokenUsage{}
+}

--- a/coderd/aibridge/focus/resolve.go
+++ b/coderd/aibridge/focus/resolve.go
@@ -1,0 +1,198 @@
+package focus
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/shopspring/decimal"
+
+	"github.com/coder/coder/v2/coderd/database"
+)
+
+// vendorLabels maps a configured ai_providers.type to the canonical,
+// human-readable vendor label used for ProviderName, ServiceName, and
+// InvoiceIssuerName: the entity that actually gives access to the model,
+// never a constant "Coder" identifier. openai-compat has no canonical label
+// of its own and always falls back to the provider instance's display_name,
+// or, when no provider row is available at all, to a title-cased wire
+// protocol string (see VendorLabel).
+var vendorLabels = map[database.AIProviderType]string{
+	database.AIProviderTypeAnthropic:  "Anthropic",
+	database.AIProviderTypeOpenai:     "OpenAI",
+	database.AIProviderTypeAzure:      "Azure",
+	database.AIProviderTypeBedrock:    "Bedrock",
+	database.AIProviderTypeGoogle:     "Google",
+	database.AIProviderTypeOpenrouter: "OpenRouter",
+	database.AIProviderTypeVercel:     "Vercel",
+	database.AIProviderTypeCopilot:    "GitHub Copilot",
+}
+
+// unversionedCatalogSuffix is appended to SkuPriceId in place of a real
+// pricing-catalog version stamp, since the embedded catalog has no
+// version/git-SHA today. See the Phase One Draft, SkuId / SkuPriceId.
+const unversionedCatalogSuffix = "unversioned"
+
+// vendorResolution is the outcome of resolving a row's ai_providers join.
+type vendorResolution struct {
+	// Label is the canonical vendor label (ProviderName / ServiceName /
+	// InvoiceIssuerName).
+	Label string
+	// Publisher is the model's publisher, which may differ from Label for a
+	// reseller vendor (e.g. Vercel serving a DeepSeek model).
+	Publisher string
+}
+
+// resolveVendor resolves the canonical vendor label and publisher for a row.
+// vendorType/displayName are nil when the provider join found no live
+// ai_providers row (a soft-deleted or never-configured provider name); in
+// that case wireProtocol is title-cased as a last-resort label.
+func resolveVendor(vendorType *database.AIProviderType, displayName *string, wireProtocol, model string) vendorResolution {
+	var label string
+	switch {
+	case vendorType == nil:
+		// No live provider row. Fall back to the raw wire-protocol string,
+		// title-cased. Expected mainly for a provider name an operator deleted
+		// with no live replacement (Open Questions Q1, parent RFC), or an
+		// interception recorded under a provider name that was never
+		// registered in ai_providers. Since coderd no longer seeds ai_providers
+		// from deployment env config (removed in #29053; providers are
+		// configured exclusively through the admin API/UI now), this can occur
+		// for any provider name that was never explicitly created there, not
+		// just a narrow historical window.
+		label = titleCase(wireProtocol)
+	case *vendorType == database.AIProviderTypeOpenaiCompat:
+		// openai-compat has no canonical vendor label; fall back to the
+		// instance's admin-set display_name, else the same last-resort label.
+		if displayName != nil && strings.TrimSpace(*displayName) != "" {
+			label = *displayName
+		} else {
+			label = titleCase(wireProtocol)
+		}
+	default:
+		if l, ok := vendorLabels[*vendorType]; ok {
+			label = l
+		} else {
+			// Unknown type value (e.g. a future addition this map hasn't
+			// caught up with yet). Fall back rather than emit an empty label.
+			label = titleCase(string(*vendorType))
+		}
+	}
+
+	publisher := resolvePublisher(vendorType, label, model)
+	return vendorResolution{Label: label, Publisher: publisher}
+}
+
+// resolvePublisher parses the model string for vendors whose model strings
+// are namespaced, and otherwise reuses the vendor label: on a direct,
+// non-reseller instance the publisher and the vendor are the same entity.
+func resolvePublisher(vendorType *database.AIProviderType, vendorLabel, model string) string {
+	if vendorType == nil {
+		return vendorLabel
+	}
+	switch *vendorType {
+	case database.AIProviderTypeBedrock:
+		if prefix, _, ok := strings.Cut(model, "."); ok {
+			return prefix
+		}
+	case database.AIProviderTypeOpenrouter, database.AIProviderTypeVercel:
+		if prefix, _, ok := strings.Cut(model, "/"); ok {
+			return prefix
+		}
+	}
+	return vendorLabel
+}
+
+// titleCase upper-cases the first letter of s. Used only for the
+// no-provider-row fallback label, where the input is already a short,
+// lowercase wire-protocol token (e.g. "anthropic", "openai", "copilot").
+func titleCase(s string) string {
+	if s == "" {
+		return s
+	}
+	return strings.ToUpper(s[:1]) + s[1:]
+}
+
+// resolveBillingAccount resolves BillingAccountId/Name/Type, branching on
+// credential kind, per the Phase One Draft's BillingAccount section.
+// deploymentID is api.AccessURL.Host; vendorLabel is the resolved vendor
+// label for the row's provider instance.
+func resolveBillingAccount(credential database.CredentialKind, deploymentID, providerInstance, initiatorID, initiatorUsername, vendorLabel string) BillingAccount {
+	switch credential {
+	case database.CredentialKindByok:
+		return BillingAccount{
+			ID:   fmt.Sprintf("byok:%s:%s", providerInstance, initiatorID),
+			Name: fmt.Sprintf("%s (BYOK, %s)", initiatorUsername, vendorLabel),
+			Type: "User Provider Account",
+		}
+	default:
+		return BillingAccount{
+			ID:   deploymentID,
+			Name: fmt.Sprintf("Coder Deployment (%s)", deploymentID),
+			Type: "Coder Deployment",
+		}
+	}
+}
+
+var microDivisor = decimal.NewFromInt(1_000_000)
+
+// unitPrice converts a snapshotted *_price_micros value (micro-USD per
+// million tokens) into an exact decimal USD-per-token unit price. Returns nil
+// when priceMicros is nil (unpriced), never zero-for-unknown.
+func unitPrice(priceMicros *int64) *decimal.Decimal {
+	if priceMicros == nil {
+		return nil
+	}
+	v := decimal.NewFromInt(*priceMicros).Div(microDivisor).Div(microDivisor)
+	return &v
+}
+
+// lineCost returns the exact decimal cost of quantity tokens at price,
+// or zero when price is nil (unpriced).
+//
+// This is the authoritative per-line-item cost for the FOCUS export: unlike
+// coderd/aibridgedserver's tokenCost/computeCost (which truncates each token
+// category to whole micro-USD before summing, so that a per-category
+// breakdown recomputed from the persisted cost_micros integer adds up
+// exactly), LineCost keeps full decimal precision and is never truncated.
+// The two are expected to diverge by a small, systematic sub-micro-USD delta
+// per row; a consumer reconciling the FOCUS export against the existing
+// /export endpoint's cost_micros column should expect that and treat FOCUS's
+// ContractedCost/EffectiveCost/ListCost as the more precise figure.
+//
+// Separately: when aibridgedserver rejected a total cost as out of range
+// (see validateTotalCost), it persists token_usages.cost_micros as NULL and
+// the aggregated /export endpoint's cost_micros for that period is
+// correspondingly reduced. The FOCUS export has no equivalent "unknown"
+// state for LineCost: it recomputes cost from the same snapshotted
+// per-token prices regardless of whether the original write considered the
+// total trustworthy, so it can emit a cost for a token-usage row that the
+// rest of the system recorded as unknown. This is a known limitation, not
+// yet reconciled in Phase 1.
+func lineCost(quantity int64, price *decimal.Decimal) decimal.Decimal {
+	if price == nil {
+		return decimal.Zero
+	}
+	return decimal.NewFromInt(quantity).Mul(*price)
+}
+
+// skuID composes the FOCUS SkuId for one token type: <vendorType>/<model>/<TokenType>Tokens.
+// vendorType is the raw ai_providers.type string (or the wire protocol, when
+// no provider row resolved) rather than the display label, matching the
+// Phase One Draft.
+func skuID(vendorTypeOrWireProtocol, model string, tokenType TokenType) string {
+	return fmt.Sprintf("%s/%s/%sTokens", vendorTypeOrWireProtocol, model, tokenType)
+}
+
+// skuPriceID appends the (currently unversioned) pricing-catalog version
+// suffix to a SkuId. See unversionedCatalogSuffix.
+func skuPriceID(sku string) string {
+	return sku + "/" + unversionedCatalogSuffix
+}
+
+// chargeDescription builds the FOCUS ChargeDescription for one token type:
+// "<model> - <TokenType label>". No join and no vendor label: model is
+// already on aibridge_interceptions, and using it alone keeps the format
+// identical across every provider.
+func chargeDescription(model string, tokenType TokenType) string {
+	return fmt.Sprintf("%s - %s", model, tokenType.Label())
+}

--- a/coderd/aibridge/focus/resolve_internal_test.go
+++ b/coderd/aibridge/focus/resolve_internal_test.go
@@ -1,0 +1,210 @@
+package focus
+
+import (
+	"testing"
+
+	"github.com/coder/coder/v2/coderd/database"
+)
+
+// These are white-box tests of resolveVendor, resolveBillingAccount,
+// unitPrice, lineCost, skuID, and skuPriceID: unexported helpers with no
+// callers outside this package (row.go and query.go), kept unexported
+// specifically so they are not part of the package's public API. Exercising
+// them directly requires being in package focus rather than focus_test; see
+// escapecsv_internal_test.go for the same trade-off made for escapeCSVCell.
+
+//nolint:testpackage // exercises the unexported resolveVendor directly.
+func TestResolveVendor(t *testing.T) {
+	t.Parallel()
+
+	anthropic := database.AIProviderTypeAnthropic
+	bedrock := database.AIProviderTypeBedrock
+	openrouter := database.AIProviderTypeOpenrouter
+	vercel := database.AIProviderTypeVercel
+	openaiCompat := database.AIProviderTypeOpenaiCompat
+	copilot := database.AIProviderTypeCopilot
+
+	cases := []struct {
+		name          string
+		vendorType    *database.AIProviderType
+		displayName   *string
+		wireProtocol  string
+		model         string
+		wantLabel     string
+		wantPublisher string
+	}{
+		{
+			name:          "direct anthropic",
+			vendorType:    &anthropic,
+			wireProtocol:  "anthropic",
+			model:         "claude-haiku-4-5",
+			wantLabel:     "Anthropic",
+			wantPublisher: "Anthropic",
+		},
+		{
+			name:          "bedrock publisher split on dot",
+			vendorType:    &bedrock,
+			wireProtocol:  "anthropic",
+			model:         "anthropic.claude-3-sonnet",
+			wantLabel:     "Bedrock",
+			wantPublisher: "anthropic",
+		},
+		{
+			name:          "openrouter publisher split on slash",
+			vendorType:    &openrouter,
+			wireProtocol:  "openai",
+			model:         "deepseek/deepseek-v4",
+			wantLabel:     "OpenRouter",
+			wantPublisher: "deepseek",
+		},
+		{
+			name:          "vercel reseller: provider diverges from publisher",
+			vendorType:    &vercel,
+			wireProtocol:  "openai",
+			model:         "deepseek/deepseek-v4-flash-0731",
+			wantLabel:     "Vercel",
+			wantPublisher: "deepseek",
+		},
+		{
+			name:          "openai-compat falls back to display name",
+			vendorType:    &openaiCompat,
+			displayName:   strPtr("Poolside"),
+			wireProtocol:  "openai",
+			model:         "poolside/laguna-xs-2.1",
+			wantLabel:     "Poolside",
+			wantPublisher: "Poolside",
+		},
+		{
+			name:          "openai-compat with no display name falls back to wire protocol",
+			vendorType:    &openaiCompat,
+			wireProtocol:  "openai",
+			model:         "some-model",
+			wantLabel:     "Openai",
+			wantPublisher: "Openai",
+		},
+		{
+			name:          "copilot canonical label",
+			vendorType:    &copilot,
+			wireProtocol:  "copilot",
+			model:         "gpt-4o",
+			wantLabel:     "GitHub Copilot",
+			wantPublisher: "GitHub Copilot",
+		},
+		{
+			name:          "no provider row falls back to title-cased wire protocol",
+			vendorType:    nil,
+			wireProtocol:  "copilot",
+			model:         "gpt-4o",
+			wantLabel:     "Copilot",
+			wantPublisher: "Copilot",
+		},
+	}
+
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			got := resolveVendor(tc.vendorType, tc.displayName, tc.wireProtocol, tc.model)
+			if got.Label != tc.wantLabel {
+				t.Errorf("Label = %q, want %q", got.Label, tc.wantLabel)
+			}
+			if got.Publisher != tc.wantPublisher {
+				t.Errorf("Publisher = %q, want %q", got.Publisher, tc.wantPublisher)
+			}
+		})
+	}
+}
+
+//nolint:testpackage // exercises the unexported resolveBillingAccount directly.
+func TestResolveBillingAccount(t *testing.T) {
+	t.Parallel()
+
+	t.Run("centralized", func(t *testing.T) {
+		t.Parallel()
+		got := resolveBillingAccount(database.CredentialKindCentralized, "dev.coder.com", "anthropic", "user-id", "callum", "Anthropic")
+		if got.ID != "dev.coder.com" {
+			t.Errorf("ID = %q", got.ID)
+		}
+		if got.Type != "Coder Deployment" {
+			t.Errorf("Type = %q", got.Type)
+		}
+	})
+
+	t.Run("byok", func(t *testing.T) {
+		t.Parallel()
+		got := resolveBillingAccount(database.CredentialKindByok, "dev.coder.com", "agents-anthropic", "a49e1179-f7a9-4bb9-996c-5ad441f9f2fd", "ibetitsmike", "Anthropic")
+		wantID := "byok:agents-anthropic:a49e1179-f7a9-4bb9-996c-5ad441f9f2fd"
+		if got.ID != wantID {
+			t.Errorf("ID = %q, want %q", got.ID, wantID)
+		}
+		wantName := "ibetitsmike (BYOK, Anthropic)"
+		if got.Name != wantName {
+			t.Errorf("Name = %q, want %q", got.Name, wantName)
+		}
+		if got.Type != "User Provider Account" {
+			t.Errorf("Type = %q", got.Type)
+		}
+	})
+}
+
+//nolint:testpackage // exercises the unexported unitPrice/lineCost directly.
+func TestUnitPriceAndLineCost(t *testing.T) {
+	t.Parallel()
+
+	if unitPrice(nil) != nil {
+		t.Fatal("expected nil unit price for nil priceMicros")
+	}
+
+	priceMicros := int64(5_000_000)
+	price := unitPrice(&priceMicros)
+	if price == nil {
+		t.Fatal("expected non-nil unit price")
+	}
+	// Asserted at 12 places (row.go's decimalString/decimalStringPtr format
+	// width): price_micros is USD-per-token to exactly 12 decimal places
+	// (micro-USD per million tokens = 1e-12 USD per token per unit), which
+	// is the real precision floor of the underlying storage, not an
+	// arbitrary width.
+	if got, want := price.StringFixed(12), "0.000005000000"; got != want {
+		t.Errorf("unit price = %s, want %s", got, want)
+	}
+
+	cost := lineCost(2131, price)
+	if got, want := cost.StringFixed(12), "0.010655000000"; got != want {
+		t.Errorf("cost = %s, want %s", got, want)
+	}
+
+	// Unpriced: zero cost, never a NULL/zero-for-unknown unit price.
+	unpriced := lineCost(100, nil)
+	if got, want := unpriced.StringFixed(12), "0.000000000000"; got != want {
+		t.Errorf("unpriced cost = %s, want %s", got, want)
+	}
+
+	// Regression test for the decimal-widening fix: at the old 10-place
+	// width, any price below $0.0001/M silently truncated to
+	// "0.0000000000", indistinguishable from exactly free. price_micros
+	// values below 100 (i.e. below $0.0001/M) are exactly the values that
+	// need the 11th/12th decimal place to render as nonzero.
+	tinyPriceMicros := int64(1) // $0.000001/M
+	tinyPrice := unitPrice(&tinyPriceMicros)
+	if tinyPrice == nil {
+		t.Fatal("expected non-nil unit price")
+	}
+	if got, want := tinyPrice.StringFixed(12), "0.000000000001"; got != want {
+		t.Errorf("tiny unit price = %s, want %s (must not silently render as free)", got, want)
+	}
+}
+
+//nolint:testpackage // exercises the unexported skuID/skuPriceID directly.
+func TestSkuID(t *testing.T) {
+	t.Parallel()
+
+	sku := skuID("anthropic", "claude-haiku-4-5", TokenTypeInput)
+	if want := "anthropic/claude-haiku-4-5/InputTokens"; sku != want {
+		t.Errorf("SkuID = %q, want %q", sku, want)
+	}
+	skuPrice := skuPriceID(sku)
+	if want := "anthropic/claude-haiku-4-5/InputTokens/unversioned"; skuPrice != want {
+		t.Errorf("SkuPriceID = %q, want %q", skuPrice, want)
+	}
+}

--- a/coderd/aibridge/focus/row.go
+++ b/coderd/aibridge/focus/row.go
@@ -1,0 +1,287 @@
+package focus
+
+import (
+	"encoding/json"
+	"fmt"
+	"time"
+
+	"github.com/shopspring/decimal"
+)
+
+// FocusVersion and MappingVersion are surfaced both as response headers
+// (Export manifest) and available to callers that want to stamp a manifest
+// document later. MappingVersion changes whenever a column is renamed, a
+// required-column's semantics change, or a cost calculation changes;
+// changes that only add optional columns do not need to bump it.
+const (
+	FocusVersion = "1.2"
+	// MappingVersion history:
+	//   "1" -> "2": the M2/M3 fixes changed the emitted values of
+	//   ResourceId (rollup synthetic ID hash key corrected to cover every
+	//   GROUP BY dimension) and BillingPeriodStart/End (now derived from a
+	//   record's start rather than its end) for rolled-up rows.
+	//   "2" -> "3": every money/price column's decimal string width widened
+	//   from 10 to 12 places (decimalString/decimalStringPtr), the exact
+	//   precision floor of the underlying price_micros storage; values that
+	//   fit in 10 places are unchanged, but any price below $0.0001/M now
+	//   renders as a nonzero string instead of silently truncating to
+	//   "0.0000000000".
+	//   "3" -> "4": BillingPeriodStart/End is now derived from a dedicated
+	//   UsageRecord.BillingPeriodAnchor (token_usages.created_at at raw
+	//   grain, the rollup bucket's start at a rolled-up grain), matching the
+	//   AI Gateway to FOCUS Mapping table's documented source column,
+	//   instead of reusing StartedAt (the request's start). Changes the
+	//   emitted BillingPeriodStart/End for the narrow edge case of a raw
+	//   response whose request started in one calendar month but was
+	//   recorded in the next.
+	//   "4" -> "5": rollupGroupKeyExcludedFields (query.go) now also
+	//   excludes InitiatorUsername, GroupName, and VendorDisplayName from a
+	//   rolled-up row's synthetic ResourceId hash key, since each is a
+	//   mutable display label functionally redundant with an ID already in
+	//   the key. Renaming a user, group, or provider display name no longer
+	//   changes that row's ResourceId.
+	// Each of these is exactly the class of change this constant's own doc
+	// comment says must bump it.
+	MappingVersion = "5"
+)
+
+// Row is one FOCUS v1.2 export row: every required/conditional/recommended
+// FOCUS column the mapping supports, plus Coder's x_ custom columns. Decimal
+// money and price values are pre-formatted strings (StringFixed(12)) rather
+// than a numeric type, since that is both the FOCUS-recommended
+// representation and the shape parquet-go can write without a custom decimal
+// converter.
+//
+// Field order here is also serialization order: Header (csv.go) and the
+// parquet schema derived from these tags must stay in the same order the
+// fields are declared in.
+type Row struct {
+	BilledCost          string    `parquet:"BilledCost"`
+	BillingAccountID    string    `parquet:"BillingAccountId"`
+	BillingAccountName  string    `parquet:"BillingAccountName"`
+	BillingAccountType  string    `parquet:"BillingAccountType"`
+	BillingCurrency     string    `parquet:"BillingCurrency"`
+	BillingPeriodEnd    time.Time `parquet:"BillingPeriodEnd,timestamp(microsecond)"`
+	BillingPeriodStart  time.Time `parquet:"BillingPeriodStart,timestamp(microsecond)"`
+	ChargeCategory      string    `parquet:"ChargeCategory"`
+	ChargeClass         *string   `parquet:"ChargeClass,optional"`
+	ChargeDescription   string    `parquet:"ChargeDescription"`
+	ChargeFrequency     string    `parquet:"ChargeFrequency"`
+	ChargePeriodEnd     time.Time `parquet:"ChargePeriodEnd,timestamp(microsecond)"`
+	ChargePeriodStart   time.Time `parquet:"ChargePeriodStart,timestamp(microsecond)"`
+	ConsumedQuantity    int64     `parquet:"ConsumedQuantity"`
+	ConsumedUnit        string    `parquet:"ConsumedUnit"`
+	ContractedCost      string    `parquet:"ContractedCost"`
+	ContractedUnitPrice *string   `parquet:"ContractedUnitPrice,optional"`
+	EffectiveCost       string    `parquet:"EffectiveCost"`
+	InvoiceIssuerName   string    `parquet:"InvoiceIssuerName"`
+	ListCost            string    `parquet:"ListCost"`
+	ListUnitPrice       *string   `parquet:"ListUnitPrice,optional"`
+	PricingCategory     string    `parquet:"PricingCategory"`
+	PricingQuantity     int64     `parquet:"PricingQuantity"`
+	PricingUnit         string    `parquet:"PricingUnit"`
+	ProviderName        string    `parquet:"ProviderName"`
+	PublisherName       string    `parquet:"PublisherName"`
+	ResourceID          *string   `parquet:"ResourceId,optional"`
+	ResourceName        string    `parquet:"ResourceName"`
+	ResourceType        string    `parquet:"ResourceType"`
+	ServiceCategory     string    `parquet:"ServiceCategory"`
+	ServiceName         string    `parquet:"ServiceName"`
+	ServiceSubcategory  string    `parquet:"ServiceSubcategory"`
+	SkuID               string    `parquet:"SkuId"`
+	SkuPriceID          string    `parquet:"SkuPriceId"`
+	SubAccountID        *string   `parquet:"SubAccountId,optional"`
+	SubAccountName      *string   `parquet:"SubAccountName,optional"`
+	SubAccountType      string    `parquet:"SubAccountType"`
+	Tags                string    `parquet:"Tags"` // JSON object, scalar values only
+
+	// Custom (x_) columns. Per the FOCUS spec's extension convention, every
+	// custom column carries the x_ prefix.
+	XProviderResponseID *string `parquet:"x_ProviderResponseId,optional"`
+	XInterceptionID     *string `parquet:"x_InterceptionId,optional"`
+	XSessionID          *string `parquet:"x_SessionId,optional"`
+	XInitiatorID        string  `parquet:"x_InitiatorId"`
+	XCredentialKind     string  `parquet:"x_CredentialKind"`
+	XWireProtocol       string  `parquet:"x_WireProtocol"`
+	XProviderInstance   string  `parquet:"x_ProviderInstance"`
+	XClientTool         string  `parquet:"x_ClientTool"`
+	XErrorType          *string `parquet:"x_ErrorType,optional"`
+	XPricingStatus      string  `parquet:"x_PricingStatus"`
+	XTokenType          string  `parquet:"x_TokenType"`
+	// XRowCount is the number of raw aibridge_token_usages rows folded into
+	// this row. Always 1 at raw granularity; >= 1 when the export was
+	// requested at a rolled-up granularity.
+	XRowCount int64 `parquet:"x_RowCount"`
+}
+
+// MapUsageRecord fans a UsageRecord out into one Row per non-zero token type,
+// per the AI Gateway to FOCUS Mapping table. deploymentID is api.AccessURL.Host.
+func MapUsageRecord(rec UsageRecord, deploymentID string) []Row {
+	billingAccount := resolveBillingAccount(rec.Credential, deploymentID, rec.ProviderInstance, rec.InitiatorID.String(), rec.InitiatorUsername, rec.Vendor)
+
+	// BillingPeriodStart/End are derived from rec.BillingPeriodAnchor
+	// (token_usages.created_at at raw grain, the rollup bucket's start at a
+	// rolled-up grain), per the AI Gateway to FOCUS Mapping table, never from
+	// StartedAt (the request's start, not when it was recorded/priced) or
+	// EndedAt/bucket end: an exclusive bucket end lands on the first instant
+	// of the next UTC calendar day, so for the final bucket of any month that
+	// instant is already in the following month, and deriving the billing
+	// period from it would misattribute that bucket's spend to the wrong
+	// month on every export, every month (see MaxGranularitySeconds for the
+	// related, larger-granularity version of this same trade-off).
+	periodStart, periodEnd := billingPeriod(rec.BillingPeriodAnchor)
+
+	tags := buildTags(rec.InitiatorUsername, rec.ClientTool)
+
+	var subAccountID, subAccountName *string
+	if rec.BudgetGroup != nil {
+		id := rec.BudgetGroup.ID.String()
+		name := rec.BudgetGroup.Name
+		subAccountID, subAccountName = &id, &name
+	}
+
+	rows := make([]Row, 0, len(rec.Usage))
+	for _, usage := range rec.Usage {
+		price := unitPrice(usage.UnitPriceMicros)
+		cost := lineCost(usage.Tokens, price)
+		pricingStatus := "unpriced"
+		if price != nil {
+			pricingStatus = "priced"
+		}
+
+		sku := skuID(rec.VendorTypeRaw, rec.Model, usage.Type)
+
+		row := Row{
+			// BilledCost is intentionally always "0", not StringFixed(12)
+			// like the other money columns and not the standard-FOCUS-null
+			// "no billed cost recorded": Phase 1 has no invoiced/billed
+			// figure distinct from EffectiveCost, and 0 is the deliberate,
+			// standard placeholder for that until a real billed-cost
+			// pipeline exists, not a stray zero measurement.
+			BilledCost:          "0",
+			BillingAccountID:    billingAccount.ID,
+			BillingAccountName:  billingAccount.Name,
+			BillingAccountType:  billingAccount.Type,
+			BillingCurrency:     "USD",
+			BillingPeriodStart:  periodStart,
+			BillingPeriodEnd:    periodEnd,
+			ChargeCategory:      "Usage",
+			ChargeClass:         nil,
+			ChargeDescription:   chargeDescription(rec.Model, usage.Type),
+			ChargeFrequency:     "Usage-Based",
+			ChargePeriodStart:   rec.StartedAt,
+			ChargePeriodEnd:     rec.EndedAt,
+			ConsumedQuantity:    usage.Tokens,
+			ConsumedUnit:        "Tokens",
+			ContractedCost:      decimalString(cost),
+			ContractedUnitPrice: decimalStringPtr(price),
+			EffectiveCost:       decimalString(cost),
+			InvoiceIssuerName:   rec.Vendor,
+			ListCost:            decimalString(cost),
+			ListUnitPrice:       decimalStringPtr(price),
+			PricingCategory:     "Standard",
+			PricingQuantity:     usage.Tokens,
+			PricingUnit:         "Tokens",
+			ProviderName:        rec.Vendor,
+			PublisherName:       rec.Publisher,
+			ResourceID:          strPtr(rec.TokenUsageID.String()),
+			ResourceName:        rec.Model,
+			ResourceType:        "LLM Model",
+			ServiceCategory:     "AI and Machine Learning",
+			ServiceName:         rec.Vendor,
+			ServiceSubcategory:  "Generative AI",
+			SkuID:               sku,
+			SkuPriceID:          skuPriceID(sku),
+			SubAccountID:        subAccountID,
+			SubAccountName:      subAccountName,
+			SubAccountType:      "Coder Budget Group",
+			Tags:                tags,
+
+			XProviderResponseID: emptyToNil(rec.ResponseID),
+			XInterceptionID:     uuidToNilablePtr(rec.InterceptionID),
+			XSessionID:          emptyToNil(rec.SessionID),
+			XInitiatorID:        rec.InitiatorID.String(),
+			XCredentialKind:     string(rec.Credential),
+			XWireProtocol:       rec.WireProtocol,
+			XProviderInstance:   rec.ProviderInstance,
+			XClientTool:         rec.ClientTool,
+			XErrorType:          rec.ErrorType,
+			XPricingStatus:      pricingStatus,
+			XTokenType:          string(usage.Type),
+			XRowCount:           rec.RowCount,
+		}
+		rows = append(rows, row)
+	}
+	return rows
+}
+
+// billingPeriod truncates t to its UTC calendar month start/end.
+func billingPeriod(t time.Time) (start, end time.Time) {
+	t = t.UTC()
+	start = time.Date(t.Year(), t.Month(), 1, 0, 0, 0, 0, time.UTC)
+	end = start.AddDate(0, 1, 0)
+	return start, end
+}
+
+// buildTags returns the FOCUS Tags JSON object: exactly the username and
+// client dimensions today. Provider-defined keys keep the coder./aibridge.
+// prefixes; workspace/team/project keys are omitted entirely rather than
+// emitted with a null value, since no resolution mechanism for them exists
+// (see the parent RFC's Attribution gaps).
+func buildTags(username, clientTool string) string {
+	tags := map[string]string{
+		"coder.username":  username,
+		"aibridge.client": clientTool,
+	}
+	b, err := json.Marshal(tags)
+	if err != nil {
+		// map[string]string can never fail to marshal.
+		panic(fmt.Sprintf("marshal FOCUS tags: %v", err))
+	}
+	return string(b)
+}
+
+func decimalStringPtr(d *decimal.Decimal) *string {
+	if d == nil {
+		return nil
+	}
+	s := d.StringFixed(12)
+	return &s
+}
+
+func decimalString(d decimal.Decimal) string {
+	return d.StringFixed(12)
+}
+
+func strPtr(s string) *string {
+	return &s
+}
+
+// emptyToNil maps an empty string to nil. Used for x_ProviderResponseId and
+// x_SessionId, whose NULL therefore has two distinct causes conflated into
+// one encoding: a rollup bucket folding more than one distinct underlying
+// value (see loadRollupUsageRecords in query.go), or a raw, single-response
+// record whose underlying provider_response_id/session_id was itself empty.
+// dto.go documents NULL here as meaning "ambiguous", which is only true in
+// the first case; low-impact today since both cases legitimately have no
+// single well-defined value to report, but a future consumer that expects
+// NULL to mean specifically "rolled up" would be misled by the second case.
+func emptyToNil(s string) *string {
+	if s == "" {
+		return nil
+	}
+	return &s
+}
+
+// zeroUUID is the string form of the uuid.Nil zero value, used to detect an
+// unset uuid.UUID (interception ID, in rollup rows where it wasn't uniquely
+// determined) without importing google/uuid here just for a comparison.
+const zeroUUID = "00000000-0000-0000-0000-000000000000"
+
+func uuidToNilablePtr(id fmt.Stringer) *string {
+	s := id.String()
+	if s == "" || s == zeroUUID {
+		return nil
+	}
+	return &s
+}

--- a/coderd/aibridge/focus/row_alignment_test.go
+++ b/coderd/aibridge/focus/row_alignment_test.go
@@ -1,0 +1,37 @@
+package focus_test
+
+import (
+	"reflect"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/coder/coder/v2/coderd/aibridge/focus"
+)
+
+// TestRowHeaderParquetTagAlignment pins the contract that csv_test.go's
+// length-only check does not: every focus.Row field, in declaration order,
+// must have a parquet tag whose name exactly matches the Header entry at the
+// same position. csv_test.go only asserts len(cells) == len(Header), which
+// stays green if a field is added to Row and the wrong (or a
+// differently-cased) name is added to Header, or if the two lists drift out
+// of order relative to each other. A silently misspelled or misordered tag
+// breaks every downstream FOCUS consumer with no local symptom, since CSV
+// and Parquet output would both still "look like" a valid FOCUS document.
+func TestRowHeaderParquetTagAlignment(t *testing.T) {
+	t.Parallel()
+
+	rt := reflect.TypeOf(focus.Row{})
+	require.Equal(t, rt.NumField(), len(focus.Header),
+		"focus.Row has a different number of fields than focus.Header has entries")
+
+	for i := range rt.NumField() {
+		field := rt.Field(i)
+		tag, _, _ := strings.Cut(field.Tag.Get("parquet"), ",")
+		require.NotEmpty(t, tag, "field %s has no parquet tag", field.Name)
+		require.Equal(t, focus.Header[i], tag,
+			"focus.Row field %d (%s) has parquet tag %q but Header[%d] is %q; csv.go's cell order, row.go's field order, and the parquet tags must all agree",
+			i, field.Name, tag, i, focus.Header[i])
+	}
+}

--- a/coderd/aibridge/focus/row_test.go
+++ b/coderd/aibridge/focus/row_test.go
@@ -1,0 +1,294 @@
+package focus_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+
+	"github.com/coder/coder/v2/coderd/aibridge/focus"
+	"github.com/coder/coder/v2/coderd/database"
+)
+
+// TestMapUsageRecord_StreamingFanOutNoGroup mirrors the parent RFC's Example
+// 1: one interception, two token_usages rows sharing a provider_response_id,
+// no budget group (SubAccountId/Name null).
+func TestMapUsageRecord_StreamingFanOutNoGroup(t *testing.T) {
+	t.Parallel()
+
+	inputPrice := int64(1_000_000)
+	outputPrice := int64(5_000_000)
+	cacheWritePrice := int64(1_250_000)
+
+	rec := focus.UsageRecord{
+		TokenUsageID:        uuid.MustParse("d1739bba-6711-4bc7-aa46-b9e32bfaa451"),
+		ResponseID:          "msg_01Bk9iY843EAmrQYyYVgVZmP",
+		InterceptionID:      uuid.MustParse("edeea219-190d-4494-b2f1-0f5746639178"),
+		SessionID:           "edeea219-190d-4494-b2f1-0f5746639178",
+		ClientTool:          "Mux",
+		StartedAt:           time.Date(2026, 6, 19, 22, 58, 41, 374962000, time.UTC),
+		EndedAt:             time.Date(2026, 6, 19, 22, 58, 42, 674767000, time.UTC),
+		BillingPeriodAnchor: time.Date(2026, 6, 19, 22, 58, 42, 667943000, time.UTC), // token_usages.created_at
+		InitiatorID:         uuid.MustParse("a26a1adc-48a9-4823-a58d-8e0b7e9c60f2"),
+		InitiatorUsername:   "callum",
+		BudgetGroup:         nil,
+		Model:               "claude-haiku-4-5",
+		Vendor:              "Anthropic",
+		VendorTypeRaw:       "anthropic",
+		Publisher:           "Anthropic",
+		WireProtocol:        "anthropic",
+		ProviderInstance:    "anthropic",
+		Credential:          database.CredentialKindCentralized,
+		BillingAccount: focus.BillingAccount{
+			ID: "dev.coder.com", Name: "Coder Dogfood (dev.coder.com)", Type: "Coder Deployment",
+		},
+		Usage: []focus.TokenUsage{
+			{Type: focus.TokenTypeInput, Tokens: 3, UnitPriceMicros: &inputPrice},
+			{Type: focus.TokenTypeOutput, Tokens: 51, UnitPriceMicros: &outputPrice},
+			{Type: focus.TokenTypeCacheWrite, Tokens: 9278, UnitPriceMicros: &cacheWritePrice},
+		},
+		RowCount: 1,
+	}
+
+	rows := focus.MapUsageRecord(rec, "dev.coder.com")
+	if len(rows) != 3 {
+		t.Fatalf("got %d rows, want 3", len(rows))
+	}
+
+	input := rows[0]
+	if input.ResourceID == nil || *input.ResourceID != "d1739bba-6711-4bc7-aa46-b9e32bfaa451" {
+		t.Errorf("ResourceID = %v", input.ResourceID)
+	}
+	if input.ChargeDescription != "claude-haiku-4-5 - Input tokens" {
+		t.Errorf("ChargeDescription = %q", input.ChargeDescription)
+	}
+	if input.ConsumedQuantity != 3 || input.PricingQuantity != 3 {
+		t.Errorf("quantity = %d/%d", input.ConsumedQuantity, input.PricingQuantity)
+	}
+	if input.ListUnitPrice == nil || *input.ListUnitPrice != "0.000001000000" {
+		t.Errorf("ListUnitPrice = %v", input.ListUnitPrice)
+	}
+	if input.ListCost != "0.000003000000" {
+		t.Errorf("ListCost = %q", input.ListCost)
+	}
+	if input.SkuID != "anthropic/claude-haiku-4-5/InputTokens" {
+		t.Errorf("SkuID = %q", input.SkuID)
+	}
+	if input.SubAccountID != nil || input.SubAccountName != nil {
+		t.Errorf("expected nil SubAccountID/Name, got %v/%v", input.SubAccountID, input.SubAccountName)
+	}
+	if input.Tags != `{"aibridge.client":"Mux","coder.username":"callum"}` {
+		t.Errorf("Tags = %q", input.Tags)
+	}
+	if input.BillingPeriodStart != time.Date(2026, 6, 1, 0, 0, 0, 0, time.UTC) {
+		t.Errorf("BillingPeriodStart = %v", input.BillingPeriodStart)
+	}
+	if input.BillingPeriodEnd != time.Date(2026, 7, 1, 0, 0, 0, 0, time.UTC) {
+		t.Errorf("BillingPeriodEnd = %v", input.BillingPeriodEnd)
+	}
+
+	cacheWrite := rows[2]
+	if cacheWrite.ListCost != "0.011597500000" {
+		t.Errorf("cache write ListCost = %q, want 0.011597500000", cacheWrite.ListCost)
+	}
+}
+
+// TestMapUsageRecord_OpenAICompatUnpriced mirrors Example 2: three token
+// types, all unpriced, with a budget group present.
+func TestMapUsageRecord_OpenAICompatUnpriced(t *testing.T) {
+	t.Parallel()
+
+	rec := focus.UsageRecord{
+		TokenUsageID:        uuid.MustParse("12c19969-e2a4-4965-a2be-34063313fbcb"),
+		ResponseID:          "chatcmpl-724dccfa3f9944619005441f2f21db47",
+		InterceptionID:      uuid.MustParse("1d152081-a0ce-479a-b1a4-b6705a23988f"),
+		SessionID:           "1d152081-a0ce-479a-b1a4-b6705a23988f",
+		ClientTool:          "Unknown",
+		StartedAt:           time.Date(2026, 8, 12, 11, 37, 59, 868000000, time.UTC),
+		EndedAt:             time.Date(2026, 8, 12, 11, 38, 0, 473000000, time.UTC),
+		BillingPeriodAnchor: time.Date(2026, 8, 12, 11, 38, 0, 473382000, time.UTC), // token_usages.created_at
+		InitiatorID:         uuid.MustParse("a49e1179-f7a9-4bb9-996c-5ad441f9f2fd"),
+		InitiatorUsername:   "ibetitsmike",
+		BudgetGroup: &focus.BudgetGroup{
+			ID:   uuid.MustParse("3ea6ae38-ff77-446a-ad06-fb1ba0c9e1b1"),
+			Name: "Vibes",
+		},
+		Model:            "poolside/laguna-xs-2.1",
+		Vendor:           "Poolside",
+		VendorTypeRaw:    "openai-compat",
+		Publisher:        "Poolside",
+		WireProtocol:     "openai",
+		ProviderInstance: "openaicompa-poolside",
+		Credential:       database.CredentialKindCentralized,
+		Usage: []focus.TokenUsage{
+			{Type: focus.TokenTypeInput, Tokens: 118},
+			{Type: focus.TokenTypeOutput, Tokens: 2},
+			{Type: focus.TokenTypeCacheRead, Tokens: 16},
+		},
+		RowCount: 1,
+	}
+
+	rows := focus.MapUsageRecord(rec, "dev.coder.com")
+	if len(rows) != 3 {
+		t.Fatalf("got %d rows, want 3", len(rows))
+	}
+	for _, row := range rows {
+		if row.XPricingStatus != "unpriced" {
+			t.Errorf("x_PricingStatus = %q, want unpriced", row.XPricingStatus)
+		}
+		if row.ListUnitPrice != nil {
+			t.Errorf("ListUnitPrice = %v, want nil", row.ListUnitPrice)
+		}
+		if row.ListCost != "0.000000000000" {
+			t.Errorf("ListCost = %q, want 0", row.ListCost)
+		}
+	}
+	if got := *rows[0].SubAccountID; got != "3ea6ae38-ff77-446a-ad06-fb1ba0c9e1b1" {
+		t.Errorf("SubAccountID = %q", got)
+	}
+	if got := *rows[0].SubAccountName; got != "Vibes" {
+		t.Errorf("SubAccountName = %q", got)
+	}
+}
+
+// TestMapUsageRecord_BYOK mirrors Example 3: BYOK BillingAccount identity.
+func TestMapUsageRecord_BYOK(t *testing.T) {
+	t.Parallel()
+
+	inputPrice := int64(5_000_000)
+	outputPrice := int64(25_000_000)
+
+	rec := focus.UsageRecord{
+		TokenUsageID:        uuid.MustParse("0e929f6f-a216-41e1-a1a8-c46045b1cb59"),
+		StartedAt:           time.Date(2026, 8, 12, 16, 51, 20, 674414000, time.UTC),
+		EndedAt:             time.Date(2026, 8, 12, 16, 51, 22, 556077000, time.UTC),
+		BillingPeriodAnchor: time.Date(2026, 8, 12, 16, 51, 22, 556134000, time.UTC), // token_usages.created_at
+		InitiatorID:         uuid.MustParse("a49e1179-f7a9-4bb9-996c-5ad441f9f2fd"),
+		InitiatorUsername:   "ibetitsmike",
+		Model:               "claude-opus-4-8",
+		Vendor:              "Anthropic",
+		VendorTypeRaw:       "anthropic",
+		Publisher:           "Anthropic",
+		WireProtocol:        "anthropic",
+		ProviderInstance:    "agents-anthropic",
+		Credential:          database.CredentialKindByok,
+		Usage: []focus.TokenUsage{
+			{Type: focus.TokenTypeInput, Tokens: 2131, UnitPriceMicros: &inputPrice},
+			{Type: focus.TokenTypeOutput, Tokens: 40, UnitPriceMicros: &outputPrice},
+		},
+		RowCount: 1,
+	}
+
+	rows := focus.MapUsageRecord(rec, "dev.coder.com")
+	if len(rows) != 2 {
+		t.Fatalf("got %d rows, want 2", len(rows))
+	}
+	want := "byok:agents-anthropic:a49e1179-f7a9-4bb9-996c-5ad441f9f2fd"
+	if rows[0].BillingAccountID != want {
+		t.Errorf("BillingAccountID = %q, want %q", rows[0].BillingAccountID, want)
+	}
+	if rows[0].BillingAccountType != "User Provider Account" {
+		t.Errorf("BillingAccountType = %q", rows[0].BillingAccountType)
+	}
+	if rows[0].ListCost != "0.010655000000" {
+		t.Errorf("ListCost = %q, want 0.010655000000", rows[0].ListCost)
+	}
+}
+
+// TestMapUsageRecord_ResellerDivergence mirrors Example 4: ProviderName
+// (Vercel) diverges from PublisherName (DeepSeek).
+func TestMapUsageRecord_ResellerDivergence(t *testing.T) {
+	t.Parallel()
+
+	inputPrice := int64(130_000)
+
+	rec := focus.UsageRecord{
+		TokenUsageID:        uuid.MustParse("8e0e030b-c6cb-4d1a-8402-94c2fcc1c439"),
+		StartedAt:           time.Now(),
+		EndedAt:             time.Now(),
+		BillingPeriodAnchor: time.Now(),
+		InitiatorID:         uuid.New(),
+		Model:               "deepseek/deepseek-v4-flash-0731",
+		Vendor:              "Vercel",
+		VendorTypeRaw:       "vercel",
+		Publisher:           "DeepSeek",
+		WireProtocol:        "openai",
+		ProviderInstance:    "agents-vercel",
+		Credential:          database.CredentialKindCentralized,
+		Usage: []focus.TokenUsage{
+			{Type: focus.TokenTypeInput, Tokens: 815, UnitPriceMicros: &inputPrice},
+		},
+		RowCount: 1,
+	}
+
+	rows := focus.MapUsageRecord(rec, "dev.coder.com")
+	if len(rows) != 1 {
+		t.Fatalf("got %d rows, want 1", len(rows))
+	}
+	row := rows[0]
+	if row.ProviderName != "Vercel" {
+		t.Errorf("ProviderName = %q, want Vercel", row.ProviderName)
+	}
+	if row.PublisherName != "DeepSeek" {
+		t.Errorf("PublisherName = %q, want DeepSeek", row.PublisherName)
+	}
+	if row.InvoiceIssuerName != "Vercel" {
+		t.Errorf("InvoiceIssuerName = %q, want Vercel (the vendor still issues the invoice)", row.InvoiceIssuerName)
+	}
+	if row.SkuID != "vercel/deepseek/deepseek-v4-flash-0731/InputTokens" {
+		t.Errorf("SkuID = %q", row.SkuID)
+	}
+}
+
+// TestMapUsageRecord_RollupOmitsAmbiguousIdentifiers exercises a synthetic
+// rolled-up UsageRecord (as loadRollupUsageRecords would produce for a bucket
+// spanning more than one response), confirming the response-level
+// identifiers are omitted and x_RowCount reflects the fold.
+func TestMapUsageRecord_RollupOmitsAmbiguousIdentifiers(t *testing.T) {
+	t.Parallel()
+
+	rec := focus.UsageRecord{
+		TokenUsageID:        uuid.New(), // synthetic
+		ResponseID:          "",         // ambiguous: omitted
+		InterceptionID:      uuid.Nil,   // ambiguous: omitted
+		SessionID:           "",
+		ClientTool:          "Coder Agents",
+		StartedAt:           time.Date(2026, 8, 12, 16, 0, 0, 0, time.UTC),
+		EndedAt:             time.Date(2026, 8, 12, 17, 0, 0, 0, time.UTC),
+		BillingPeriodAnchor: time.Date(2026, 8, 12, 16, 0, 0, 0, time.UTC), // bucket start
+		InitiatorID:         uuid.New(),
+		InitiatorUsername:   "callum",
+		Model:               "claude-haiku-4-5",
+		Vendor:              "Anthropic",
+		VendorTypeRaw:       "anthropic",
+		Publisher:           "Anthropic",
+		WireProtocol:        "anthropic",
+		ProviderInstance:    "anthropic",
+		Credential:          database.CredentialKindCentralized,
+		Usage: []focus.TokenUsage{
+			{Type: focus.TokenTypeInput, Tokens: 500},
+		},
+		RowCount: 7,
+	}
+
+	rows := focus.MapUsageRecord(rec, "dev.coder.com")
+	if len(rows) != 1 {
+		t.Fatalf("got %d rows, want 1", len(rows))
+	}
+	row := rows[0]
+	if row.XProviderResponseID != nil {
+		t.Errorf("x_ProviderResponseId = %v, want nil", row.XProviderResponseID)
+	}
+	if row.XInterceptionID != nil {
+		t.Errorf("x_InterceptionId = %v, want nil", row.XInterceptionID)
+	}
+	if row.XSessionID != nil {
+		t.Errorf("x_SessionId = %v, want nil", row.XSessionID)
+	}
+	if row.XRowCount != 7 {
+		t.Errorf("x_RowCount = %d, want 7", row.XRowCount)
+	}
+	if row.ChargePeriodStart != rec.StartedAt || row.ChargePeriodEnd != rec.EndedAt {
+		t.Errorf("charge period = %v..%v, want bucket boundaries", row.ChargePeriodStart, row.ChargePeriodEnd)
+	}
+}

--- a/coderd/aibridgedserver/cost.go
+++ b/coderd/aibridgedserver/cost.go
@@ -199,6 +199,12 @@ func validateTotalCost(total decimal.Decimal) error {
 //
 // Each category is divided and truncated on its own, which makes a per-category breakdown
 // recomputed from the snapshotted price columns add up to the stored cost.
+//
+// This truncated, whole-micro-USD figure is NOT the authoritative cost for
+// the FOCUS export (coderd/aibridge/focus): that package's lineCost
+// recomputes from the same snapshotted prices at full decimal precision, by
+// design, and is expected to diverge from this function's output by a small
+// systematic delta. See lineCost's doc comment for the reconciliation notes.
 func tokenCost(tokens int64, pricePerMillion sql.NullInt64) decimal.Decimal {
 	if !pricePerMillion.Valid {
 		return decimal.Zero

--- a/coderd/apidoc/docs.go
+++ b/coderd/apidoc/docs.go
@@ -246,6 +246,73 @@ const docTemplate = `{
                 }
             }
         },
+        "/api/experimental/organizations/{organization}/ai/spend/export/focus": {
+            "get": {
+                "description": "Returns AI Gateway usage and cost for the organization as a FOCUS v1.2-shaped CSV or Parquet document, rolled up into hourly fixed-width time buckets by default, or at raw, unrolled per-response, per-token-type granularity, or a different rollup width, when the granularity query parameter is set.\nThe optional period_start and period_end query parameters bound the period and are interpreted as UTC, exactly as for the existing /export endpoint (see its own description for defaults and validation).\nThe optional format query parameter selects \"csv\" (default) or \"parquet\".\nThe optional granularity query parameter, in seconds, selects the row grain: 0 requests raw, unrolled per-response grain; a positive value (default 3600, i.e. hourly) rolls responses up into fixed-width UTC time buckets of that many seconds, up to a maximum of 86400 (one day).\nThis endpoint is experimental: it lives under /api/experimental and is gated behind the \"focus-export\" experiment (CODER_EXPERIMENTS=focus-export), off by default. Its FOCUS column set and semantics may still change.\nRequires organization-level administrator permissions.",
+                "produces": [
+                    "text/csv",
+                    "application/vnd.apache.parquet"
+                ],
+                "tags": [
+                    "Enterprise"
+                ],
+                "summary": "Export organization AI spend in FOCUS format",
+                "operationId": "export-organization-ai-focus",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "format": "uuid",
+                        "description": "Organization ID",
+                        "name": "organization",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "format": "date-time",
+                        "description": "Inclusive lower bound (RFC3339)",
+                        "name": "period_start",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "format": "date-time",
+                        "description": "Exclusive upper bound (RFC3339)",
+                        "name": "period_end",
+                        "in": "query"
+                    },
+                    {
+                        "enum": [
+                            "csv",
+                            "parquet"
+                        ],
+                        "type": "string",
+                        "description": "Export format",
+                        "name": "format",
+                        "in": "query"
+                    },
+                    {
+                        "type": "integer",
+                        "description": "Rollup bucket width in seconds. 0 for raw, unrolled per-response grain. Defaults to 3600 (hourly)",
+                        "name": "granularity",
+                        "in": "query"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK"
+                    }
+                },
+                "security": [
+                    {
+                        "CoderSessionToken": []
+                    }
+                ],
+                "x-apidocgen": {
+                    "skip": true
+                }
+            }
+        },
         "/api/experimental/users/{user}/skills": {
             "get": {
                 "produces": [
@@ -23336,7 +23403,8 @@ const docTemplate = `{
                 "ai-gateway-seat-exclusion",
                 "chat-advisor",
                 "chat-virtual-desktop",
-                "agent-lifecycle-hooks"
+                "agent-lifecycle-hooks",
+                "focus-export"
             ],
             "x-enum-comments": {
                 "ExperimentAIGatewaySeatExclusion": "Excludes AI Gateway (AI Bridge) usage from AI Governance seat consumption.",
@@ -23345,6 +23413,7 @@ const docTemplate = `{
                 "ExperimentChatAdvisor": "Enables the advisor tool for root agent chats.",
                 "ExperimentChatVirtualDesktop": "Enables virtual desktop and computer use provider for agents.",
                 "ExperimentExample": "This isn't used for anything.",
+                "ExperimentFOCUSExport": "Enables the experimental FOCUS-format AI Gateway spend export endpoint.",
                 "ExperimentMCPServerHTTP": "Enables the MCP HTTP server functionality.",
                 "ExperimentMCPToolSearch": "Defers MCP tool schemas behind a searchable catalog in agent chats.",
                 "ExperimentNATSPubsub": "Enables embedded NATS pubsub.",
@@ -23368,7 +23437,8 @@ const docTemplate = `{
                 "Excludes AI Gateway (AI Bridge) usage from AI Governance seat consumption.",
                 "Enables the advisor tool for root agent chats.",
                 "Enables virtual desktop and computer use provider for agents.",
-                "Enables chat lifecycle hook webhooks for agent chats."
+                "Enables chat lifecycle hook webhooks for agent chats.",
+                "Enables the experimental FOCUS-format AI Gateway spend export endpoint."
             ],
             "x-enum-varnames": [
                 "ExperimentExample",
@@ -23384,7 +23454,8 @@ const docTemplate = `{
                 "ExperimentAIGatewaySeatExclusion",
                 "ExperimentChatAdvisor",
                 "ExperimentChatVirtualDesktop",
-                "ExperimentAgentLifecycleHooks"
+                "ExperimentAgentLifecycleHooks",
+                "ExperimentFOCUSExport"
             ]
         },
         "codersdk.ExternalAPIKeyScopes": {

--- a/coderd/apidoc/swagger.json
+++ b/coderd/apidoc/swagger.json
@@ -211,6 +211,65 @@
 				}
 			}
 		},
+		"/api/experimental/organizations/{organization}/ai/spend/export/focus": {
+			"get": {
+				"description": "Returns AI Gateway usage and cost for the organization as a FOCUS v1.2-shaped CSV or Parquet document, rolled up into hourly fixed-width time buckets by default, or at raw, unrolled per-response, per-token-type granularity, or a different rollup width, when the granularity query parameter is set.\nThe optional period_start and period_end query parameters bound the period and are interpreted as UTC, exactly as for the existing /export endpoint (see its own description for defaults and validation).\nThe optional format query parameter selects \"csv\" (default) or \"parquet\".\nThe optional granularity query parameter, in seconds, selects the row grain: 0 requests raw, unrolled per-response grain; a positive value (default 3600, i.e. hourly) rolls responses up into fixed-width UTC time buckets of that many seconds, up to a maximum of 86400 (one day).\nThis endpoint is experimental: it lives under /api/experimental and is gated behind the \"focus-export\" experiment (CODER_EXPERIMENTS=focus-export), off by default. Its FOCUS column set and semantics may still change.\nRequires organization-level administrator permissions.",
+				"produces": ["text/csv", "application/vnd.apache.parquet"],
+				"tags": ["Enterprise"],
+				"summary": "Export organization AI spend in FOCUS format",
+				"operationId": "export-organization-ai-focus",
+				"parameters": [
+					{
+						"type": "string",
+						"format": "uuid",
+						"description": "Organization ID",
+						"name": "organization",
+						"in": "path",
+						"required": true
+					},
+					{
+						"type": "string",
+						"format": "date-time",
+						"description": "Inclusive lower bound (RFC3339)",
+						"name": "period_start",
+						"in": "query"
+					},
+					{
+						"type": "string",
+						"format": "date-time",
+						"description": "Exclusive upper bound (RFC3339)",
+						"name": "period_end",
+						"in": "query"
+					},
+					{
+						"enum": ["csv", "parquet"],
+						"type": "string",
+						"description": "Export format",
+						"name": "format",
+						"in": "query"
+					},
+					{
+						"type": "integer",
+						"description": "Rollup bucket width in seconds. 0 for raw, unrolled per-response grain. Defaults to 3600 (hourly)",
+						"name": "granularity",
+						"in": "query"
+					}
+				],
+				"responses": {
+					"200": {
+						"description": "OK"
+					}
+				},
+				"security": [
+					{
+						"CoderSessionToken": []
+					}
+				],
+				"x-apidocgen": {
+					"skip": true
+				}
+			}
+		},
 		"/api/experimental/users/{user}/skills": {
 			"get": {
 				"produces": ["application/json"],
@@ -21236,7 +21295,8 @@
 				"ai-gateway-seat-exclusion",
 				"chat-advisor",
 				"chat-virtual-desktop",
-				"agent-lifecycle-hooks"
+				"agent-lifecycle-hooks",
+				"focus-export"
 			],
 			"x-enum-comments": {
 				"ExperimentAIGatewaySeatExclusion": "Excludes AI Gateway (AI Bridge) usage from AI Governance seat consumption.",
@@ -21245,6 +21305,7 @@
 				"ExperimentChatAdvisor": "Enables the advisor tool for root agent chats.",
 				"ExperimentChatVirtualDesktop": "Enables virtual desktop and computer use provider for agents.",
 				"ExperimentExample": "This isn't used for anything.",
+				"ExperimentFOCUSExport": "Enables the experimental FOCUS-format AI Gateway spend export endpoint.",
 				"ExperimentMCPServerHTTP": "Enables the MCP HTTP server functionality.",
 				"ExperimentMCPToolSearch": "Defers MCP tool schemas behind a searchable catalog in agent chats.",
 				"ExperimentNATSPubsub": "Enables embedded NATS pubsub.",
@@ -21268,7 +21329,8 @@
 				"Excludes AI Gateway (AI Bridge) usage from AI Governance seat consumption.",
 				"Enables the advisor tool for root agent chats.",
 				"Enables virtual desktop and computer use provider for agents.",
-				"Enables chat lifecycle hook webhooks for agent chats."
+				"Enables chat lifecycle hook webhooks for agent chats.",
+				"Enables the experimental FOCUS-format AI Gateway spend export endpoint."
 			],
 			"x-enum-varnames": [
 				"ExperimentExample",
@@ -21284,7 +21346,8 @@
 				"ExperimentAIGatewaySeatExclusion",
 				"ExperimentChatAdvisor",
 				"ExperimentChatVirtualDesktop",
-				"ExperimentAgentLifecycleHooks"
+				"ExperimentAgentLifecycleHooks",
+				"ExperimentFOCUSExport"
 			]
 		},
 		"codersdk.ExternalAPIKeyScopes": {

--- a/coderd/database/dbauthz/dbauthz.go
+++ b/coderd/database/dbauthz/dbauthz.go
@@ -4380,6 +4380,14 @@ func (q *querier) GetOldUnlinkedChatFileIDs(ctx context.Context, arg database.Ge
 	return q.db.GetOldUnlinkedChatFileIDs(ctx, arg)
 }
 
+func (q *querier) GetOrganizationAIFOCUSUsage(ctx context.Context, arg database.GetOrganizationAIFOCUSUsageParams) ([]database.GetOrganizationAIFOCUSUsageRow, error) {
+	return fetchWithPostFilter(q.auth, policy.ActionRead, q.db.GetOrganizationAIFOCUSUsage)(ctx, arg)
+}
+
+func (q *querier) GetOrganizationAIFOCUSUsageRollup(ctx context.Context, arg database.GetOrganizationAIFOCUSUsageRollupParams) ([]database.GetOrganizationAIFOCUSUsageRollupRow, error) {
+	return fetchWithPostFilter(q.auth, policy.ActionRead, q.db.GetOrganizationAIFOCUSUsageRollup)(ctx, arg)
+}
+
 func (q *querier) GetOrganizationByID(ctx context.Context, id uuid.UUID) (database.Organization, error) {
 	return fetch(q.log, q.auth, q.db.GetOrganizationByID)(ctx, id)
 }

--- a/coderd/database/dbauthz/dbauthz_test.go
+++ b/coderd/database/dbauthz/dbauthz_test.go
@@ -7075,6 +7075,39 @@ func (s *MethodTestSuite) TestAIBridge() {
 			Returns([]database.ExportOrganizationAISpendRow{row1, row2})
 	}))
 
+	s.Run("GetOrganizationAIFOCUSUsage", s.Mocked(func(dbm *dbmock.MockStore, faker *gofakeit.Faker, check *expects) {
+		org := testutil.Fake(s.T(), faker, database.Organization{})
+		row1 := testutil.Fake(s.T(), faker, database.GetOrganizationAIFOCUSUsageRow{OrganizationID: org.ID})
+		row2 := testutil.Fake(s.T(), faker, database.GetOrganizationAIFOCUSUsageRow{OrganizationID: org.ID})
+		arg := database.GetOrganizationAIFOCUSUsageParams{
+			OrganizationID: org.ID,
+			PeriodStart:    time.Now().UTC().Truncate(24 * time.Hour),
+			PeriodEnd:      time.Now().UTC(),
+		}
+		dbm.EXPECT().GetOrganizationAIFOCUSUsage(gomock.Any(), arg).
+			Return([]database.GetOrganizationAIFOCUSUsageRow{row1, row2}, nil).AnyTimes()
+		check.Args(arg).
+			Asserts(row1, policy.ActionRead, row2, policy.ActionRead).
+			Returns([]database.GetOrganizationAIFOCUSUsageRow{row1, row2})
+	}))
+
+	s.Run("GetOrganizationAIFOCUSUsageRollup", s.Mocked(func(dbm *dbmock.MockStore, faker *gofakeit.Faker, check *expects) {
+		org := testutil.Fake(s.T(), faker, database.Organization{})
+		row1 := testutil.Fake(s.T(), faker, database.GetOrganizationAIFOCUSUsageRollupRow{OrganizationID: org.ID})
+		row2 := testutil.Fake(s.T(), faker, database.GetOrganizationAIFOCUSUsageRollupRow{OrganizationID: org.ID})
+		arg := database.GetOrganizationAIFOCUSUsageRollupParams{
+			GranularitySeconds: 3600,
+			OrganizationID:     org.ID,
+			PeriodStart:        time.Now().UTC().Truncate(24 * time.Hour),
+			PeriodEnd:          time.Now().UTC(),
+		}
+		dbm.EXPECT().GetOrganizationAIFOCUSUsageRollup(gomock.Any(), arg).
+			Return([]database.GetOrganizationAIFOCUSUsageRollupRow{row1, row2}, nil).AnyTimes()
+		check.Args(arg).
+			Asserts(row1, policy.ActionRead, row2, policy.ActionRead).
+			Returns([]database.GetOrganizationAIFOCUSUsageRollupRow{row1, row2})
+	}))
+
 	s.Run("GetGroupAIBudget", s.Mocked(func(dbm *dbmock.MockStore, faker *gofakeit.Faker, check *expects) {
 		g := testutil.Fake(s.T(), faker, database.Group{})
 		b := testutil.Fake(s.T(), faker, database.GroupAIBudget{GroupID: g.ID})

--- a/coderd/database/dbmetrics/querymetrics.go
+++ b/coderd/database/dbmetrics/querymetrics.go
@@ -2585,6 +2585,22 @@ func (m queryMetricsStore) GetOldUnlinkedChatFileIDs(ctx context.Context, arg da
 	return r0, r1
 }
 
+func (m queryMetricsStore) GetOrganizationAIFOCUSUsage(ctx context.Context, arg database.GetOrganizationAIFOCUSUsageParams) ([]database.GetOrganizationAIFOCUSUsageRow, error) {
+	start := time.Now()
+	r0, r1 := m.s.GetOrganizationAIFOCUSUsage(ctx, arg)
+	m.queryLatencies.WithLabelValues("GetOrganizationAIFOCUSUsage").Observe(time.Since(start).Seconds())
+	m.queryCounts.WithLabelValues(httpmw.ExtractHTTPRoute(ctx), httpmw.ExtractHTTPMethod(ctx), "GetOrganizationAIFOCUSUsage").Inc()
+	return r0, r1
+}
+
+func (m queryMetricsStore) GetOrganizationAIFOCUSUsageRollup(ctx context.Context, arg database.GetOrganizationAIFOCUSUsageRollupParams) ([]database.GetOrganizationAIFOCUSUsageRollupRow, error) {
+	start := time.Now()
+	r0, r1 := m.s.GetOrganizationAIFOCUSUsageRollup(ctx, arg)
+	m.queryLatencies.WithLabelValues("GetOrganizationAIFOCUSUsageRollup").Observe(time.Since(start).Seconds())
+	m.queryCounts.WithLabelValues(httpmw.ExtractHTTPRoute(ctx), httpmw.ExtractHTTPMethod(ctx), "GetOrganizationAIFOCUSUsageRollup").Inc()
+	return r0, r1
+}
+
 func (m queryMetricsStore) GetOrganizationByID(ctx context.Context, id uuid.UUID) (database.Organization, error) {
 	start := time.Now()
 	r0, r1 := m.s.GetOrganizationByID(ctx, id)

--- a/coderd/database/dbmock/dbmock.go
+++ b/coderd/database/dbmock/dbmock.go
@@ -4845,6 +4845,36 @@ func (mr *MockStoreMockRecorder) GetOldUnlinkedChatFileIDs(ctx, arg any) *gomock
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetOldUnlinkedChatFileIDs", reflect.TypeOf((*MockStore)(nil).GetOldUnlinkedChatFileIDs), ctx, arg)
 }
 
+// GetOrganizationAIFOCUSUsage mocks base method.
+func (m *MockStore) GetOrganizationAIFOCUSUsage(ctx context.Context, arg database.GetOrganizationAIFOCUSUsageParams) ([]database.GetOrganizationAIFOCUSUsageRow, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetOrganizationAIFOCUSUsage", ctx, arg)
+	ret0, _ := ret[0].([]database.GetOrganizationAIFOCUSUsageRow)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetOrganizationAIFOCUSUsage indicates an expected call of GetOrganizationAIFOCUSUsage.
+func (mr *MockStoreMockRecorder) GetOrganizationAIFOCUSUsage(ctx, arg any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetOrganizationAIFOCUSUsage", reflect.TypeOf((*MockStore)(nil).GetOrganizationAIFOCUSUsage), ctx, arg)
+}
+
+// GetOrganizationAIFOCUSUsageRollup mocks base method.
+func (m *MockStore) GetOrganizationAIFOCUSUsageRollup(ctx context.Context, arg database.GetOrganizationAIFOCUSUsageRollupParams) ([]database.GetOrganizationAIFOCUSUsageRollupRow, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetOrganizationAIFOCUSUsageRollup", ctx, arg)
+	ret0, _ := ret[0].([]database.GetOrganizationAIFOCUSUsageRollupRow)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetOrganizationAIFOCUSUsageRollup indicates an expected call of GetOrganizationAIFOCUSUsageRollup.
+func (mr *MockStoreMockRecorder) GetOrganizationAIFOCUSUsageRollup(ctx, arg any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetOrganizationAIFOCUSUsageRollup", reflect.TypeOf((*MockStore)(nil).GetOrganizationAIFOCUSUsageRollup), ctx, arg)
+}
+
 // GetOrganizationByID mocks base method.
 func (m *MockStore) GetOrganizationByID(ctx context.Context, id uuid.UUID) (database.Organization, error) {
 	m.ctrl.T.Helper()

--- a/coderd/database/modelmethods.go
+++ b/coderd/database/modelmethods.go
@@ -444,6 +444,14 @@ func (r ExportOrganizationAISpendRow) RBACObject() rbac.Object {
 	return rbac.ResourceGroupMember.WithID(r.UserID).InOrg(r.OrganizationID).WithOwner(r.UserID.String())
 }
 
+func (r GetOrganizationAIFOCUSUsageRow) RBACObject() rbac.Object {
+	return rbac.ResourceGroupMember.WithID(r.InitiatorID).InOrg(r.OrganizationID).WithOwner(r.InitiatorID.String())
+}
+
+func (r GetOrganizationAIFOCUSUsageRollupRow) RBACObject() rbac.Object {
+	return rbac.ResourceGroupMember.WithID(r.InitiatorID).InOrg(r.OrganizationID).WithOwner(r.InitiatorID.String())
+}
+
 // PrebuiltWorkspaceResource defines the interface for types that can be identified as prebuilt workspaces
 // and converted to their corresponding prebuilt workspace RBAC object.
 type PrebuiltWorkspaceResource interface {

--- a/coderd/database/querier.go
+++ b/coderd/database/querier.go
@@ -714,6 +714,40 @@ type sqlcQuerier interface {
 	GetOAuth2ProviderAppsByUserID(ctx context.Context, userID uuid.UUID) ([]GetOAuth2ProviderAppsByUserIDRow, error)
 	// Locks candidate rows against foreign-key inserts for the transaction.
 	GetOldUnlinkedChatFileIDs(ctx context.Context, arg GetOldUnlinkedChatFileIDsParams) ([]uuid.UUID, error)
+	// Returns raw AI Gateway usage joined for FOCUS-format export over
+	// [period_start, period_end), scoped to @organization_id through the token
+	// usage's effective group, the only tenant-isolation signal that exists for
+	// aibridge data today. A token usage row with a NULL effective_group_id has
+	// no organization signal at all and is excluded here, same trade-off
+	// ExportOrganizationAISpend already accepts. One row per token usage
+	// (priced provider response); the caller fans this out into one FOCUS row
+	// per non-zero token type. Used when the export is requested at raw,
+	// unrolled granularity (granularity_seconds <= 0).
+	GetOrganizationAIFOCUSUsage(ctx context.Context, arg GetOrganizationAIFOCUSUsageParams) ([]GetOrganizationAIFOCUSUsageRow, error)
+	// Same source, joins, and tenant-scoping as GetOrganizationAIFOCUSUsage, but
+	// rolled up into fixed-width time buckets of @granularity_seconds seconds,
+	// anchored to the UNIX epoch in UTC (e.g. 3600 produces buckets aligned to
+	// the top of each UTC hour). Only used when granularity_seconds > 0; the
+	// caller is responsible for routing to the raw query otherwise, and for
+	// bounding granularity_seconds to at most one day (see
+	// focus.MaxGranularitySeconds). That bound does not, by itself, keep a
+	// bucket within one calendar month: the last bucket of every month still
+	// straddles the month boundary at any granularity. Callers derive the FOCUS
+	// BillingPeriodStart/End from each row's bucket_start, never from a
+	// bucket's exclusive end, to avoid attributing a bucket's spend to the
+	// wrong (later) month.
+	// Every column the FOCUS Row still needs to report distinctly is part of the
+	// GROUP BY key, so a bucket only ever merges rows that would otherwise be
+	// identical FOCUS rows except for quantity; nothing is summed across a
+	// dimension the export still promises to preserve. The three response-level
+	// identifiers (interception, session, provider response) have no single
+	// well-defined value once more than one distinct value is merged into a
+	// bucket; each is returned alongside a COUNT(DISTINCT ...) so the caller can
+	// treat the *_min value as authoritative only when its matching
+	// *_distinct_count equals 1, and drop it otherwise rather than reporting an
+	// arbitrary pick. row_count tells the caller how many raw token-usage rows a
+	// bucket represents.
+	GetOrganizationAIFOCUSUsageRollup(ctx context.Context, arg GetOrganizationAIFOCUSUsageRollupParams) ([]GetOrganizationAIFOCUSUsageRollupRow, error)
 	GetOrganizationByID(ctx context.Context, id uuid.UUID) (Organization, error)
 	GetOrganizationByName(ctx context.Context, arg GetOrganizationByNameParams) (Organization, error)
 	// Returns AI spend limits and aggregate spend for groups in @group_ids that

--- a/coderd/database/queries.sql.go
+++ b/coderd/database/queries.sql.go
@@ -3178,6 +3178,349 @@ func (q *sqlQuerier) GetHighestGroupAIBudgetByUser(ctx context.Context, userID u
 	return i, err
 }
 
+const getOrganizationAIFOCUSUsage = `-- name: GetOrganizationAIFOCUSUsage :many
+SELECT
+	tu.id AS token_usage_id,
+	tu.provider_response_id,
+	tu.interception_id,
+	ai.session_id,
+	ai.client AS client_tool,
+	ai.error_type,
+	ai.started_at,
+	COALESCE(ai.ended_at, tu.created_at) AS ended_at,
+	tu.created_at,
+	ai.initiator_id,
+	users.username AS initiator_username,
+	tu.effective_group_id,
+	groups.name AS group_name,
+	groups.organization_id AS organization_id,
+	ai.model,
+	ai.provider AS wire_protocol,
+	ai.provider_name AS provider_instance,
+	ai.credential_kind,
+	provider.type AS vendor_type,
+	provider.display_name AS vendor_display_name,
+	tu.input_tokens,
+	tu.output_tokens,
+	tu.cache_read_input_tokens,
+	tu.cache_write_input_tokens,
+	tu.input_price_micros,
+	tu.output_price_micros,
+	tu.cache_read_price_micros,
+	tu.cache_write_price_micros
+FROM aibridge_token_usages tu
+JOIN aibridge_interceptions ai ON ai.id = tu.interception_id
+JOIN users ON users.id = ai.initiator_id
+JOIN groups ON groups.id = tu.effective_group_id
+LEFT JOIN ai_providers provider ON provider.name = ai.provider_name AND provider.deleted = false
+WHERE groups.organization_id = $1
+	AND tu.created_at >= $2::timestamptz
+	AND tu.created_at < $3::timestamptz
+ORDER BY tu.created_at, tu.id
+`
+
+type GetOrganizationAIFOCUSUsageParams struct {
+	OrganizationID uuid.UUID `db:"organization_id" json:"organization_id"`
+	PeriodStart    time.Time `db:"period_start" json:"period_start"`
+	PeriodEnd      time.Time `db:"period_end" json:"period_end"`
+}
+
+type GetOrganizationAIFOCUSUsageRow struct {
+	TokenUsageID          uuid.UUID                         `db:"token_usage_id" json:"token_usage_id"`
+	ProviderResponseID    string                            `db:"provider_response_id" json:"provider_response_id"`
+	InterceptionID        uuid.UUID                         `db:"interception_id" json:"interception_id"`
+	SessionID             string                            `db:"session_id" json:"session_id"`
+	ClientTool            sql.NullString                    `db:"client_tool" json:"client_tool"`
+	ErrorType             NullAIBridgeInterceptionErrorType `db:"error_type" json:"error_type"`
+	StartedAt             time.Time                         `db:"started_at" json:"started_at"`
+	EndedAt               time.Time                         `db:"ended_at" json:"ended_at"`
+	CreatedAt             time.Time                         `db:"created_at" json:"created_at"`
+	InitiatorID           uuid.UUID                         `db:"initiator_id" json:"initiator_id"`
+	InitiatorUsername     string                            `db:"initiator_username" json:"initiator_username"`
+	EffectiveGroupID      uuid.NullUUID                     `db:"effective_group_id" json:"effective_group_id"`
+	GroupName             string                            `db:"group_name" json:"group_name"`
+	OrganizationID        uuid.UUID                         `db:"organization_id" json:"organization_id"`
+	Model                 string                            `db:"model" json:"model"`
+	WireProtocol          string                            `db:"wire_protocol" json:"wire_protocol"`
+	ProviderInstance      string                            `db:"provider_instance" json:"provider_instance"`
+	CredentialKind        CredentialKind                    `db:"credential_kind" json:"credential_kind"`
+	VendorType            NullAIProviderType                `db:"vendor_type" json:"vendor_type"`
+	VendorDisplayName     sql.NullString                    `db:"vendor_display_name" json:"vendor_display_name"`
+	InputTokens           int64                             `db:"input_tokens" json:"input_tokens"`
+	OutputTokens          int64                             `db:"output_tokens" json:"output_tokens"`
+	CacheReadInputTokens  int64                             `db:"cache_read_input_tokens" json:"cache_read_input_tokens"`
+	CacheWriteInputTokens int64                             `db:"cache_write_input_tokens" json:"cache_write_input_tokens"`
+	InputPriceMicros      sql.NullInt64                     `db:"input_price_micros" json:"input_price_micros"`
+	OutputPriceMicros     sql.NullInt64                     `db:"output_price_micros" json:"output_price_micros"`
+	CacheReadPriceMicros  sql.NullInt64                     `db:"cache_read_price_micros" json:"cache_read_price_micros"`
+	CacheWritePriceMicros sql.NullInt64                     `db:"cache_write_price_micros" json:"cache_write_price_micros"`
+}
+
+// Returns raw AI Gateway usage joined for FOCUS-format export over
+// [period_start, period_end), scoped to @organization_id through the token
+// usage's effective group, the only tenant-isolation signal that exists for
+// aibridge data today. A token usage row with a NULL effective_group_id has
+// no organization signal at all and is excluded here, same trade-off
+// ExportOrganizationAISpend already accepts. One row per token usage
+// (priced provider response); the caller fans this out into one FOCUS row
+// per non-zero token type. Used when the export is requested at raw,
+// unrolled granularity (granularity_seconds <= 0).
+func (q *sqlQuerier) GetOrganizationAIFOCUSUsage(ctx context.Context, arg GetOrganizationAIFOCUSUsageParams) ([]GetOrganizationAIFOCUSUsageRow, error) {
+	rows, err := q.db.QueryContext(ctx, getOrganizationAIFOCUSUsage, arg.OrganizationID, arg.PeriodStart, arg.PeriodEnd)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var items []GetOrganizationAIFOCUSUsageRow
+	for rows.Next() {
+		var i GetOrganizationAIFOCUSUsageRow
+		if err := rows.Scan(
+			&i.TokenUsageID,
+			&i.ProviderResponseID,
+			&i.InterceptionID,
+			&i.SessionID,
+			&i.ClientTool,
+			&i.ErrorType,
+			&i.StartedAt,
+			&i.EndedAt,
+			&i.CreatedAt,
+			&i.InitiatorID,
+			&i.InitiatorUsername,
+			&i.EffectiveGroupID,
+			&i.GroupName,
+			&i.OrganizationID,
+			&i.Model,
+			&i.WireProtocol,
+			&i.ProviderInstance,
+			&i.CredentialKind,
+			&i.VendorType,
+			&i.VendorDisplayName,
+			&i.InputTokens,
+			&i.OutputTokens,
+			&i.CacheReadInputTokens,
+			&i.CacheWriteInputTokens,
+			&i.InputPriceMicros,
+			&i.OutputPriceMicros,
+			&i.CacheReadPriceMicros,
+			&i.CacheWritePriceMicros,
+		); err != nil {
+			return nil, err
+		}
+		items = append(items, i)
+	}
+	if err := rows.Close(); err != nil {
+		return nil, err
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
+const getOrganizationAIFOCUSUsageRollup = `-- name: GetOrganizationAIFOCUSUsageRollup :many
+SELECT
+	(to_timestamp(floor(extract(epoch FROM tu.created_at) / $1::bigint) * $1::bigint))::timestamptz AS bucket_start,
+	ai.initiator_id,
+	users.username AS initiator_username,
+	tu.effective_group_id,
+	groups.name AS group_name,
+	groups.organization_id AS organization_id,
+	ai.model,
+	ai.provider AS wire_protocol,
+	ai.provider_name AS provider_instance,
+	ai.credential_kind,
+	provider.type AS vendor_type,
+	provider.display_name AS vendor_display_name,
+	ai.client AS client_tool,
+	ai.error_type,
+	tu.input_price_micros,
+	tu.output_price_micros,
+	tu.cache_read_price_micros,
+	tu.cache_write_price_micros,
+	-- MIN(...)/COUNT(DISTINCT ...) here relies on interception_id,
+	-- session_id, and provider_response_id all being NOT NULL columns: a
+	-- SQL MIN()/COUNT(DISTINCT) silently ignores NULL inputs, which would
+	-- silently pick a value out of an ambiguous bucket instead of leaving
+	-- distinct_count able to signal ambiguity. If any of the three ever
+	-- becomes nullable, this collapse must be revisited.
+	MIN(tu.interception_id::text)::uuid AS interception_id_min,
+	COUNT(DISTINCT tu.interception_id)::BIGINT AS interception_id_distinct_count,
+	MIN(ai.session_id)::text AS session_id_min,
+	COUNT(DISTINCT ai.session_id)::BIGINT AS session_id_distinct_count,
+	MIN(tu.provider_response_id)::text AS provider_response_id_min,
+	COUNT(DISTINCT tu.provider_response_id)::BIGINT AS provider_response_id_distinct_count,
+	COUNT(*)::BIGINT AS row_count,
+	COALESCE(SUM(tu.input_tokens), 0)::BIGINT AS input_tokens,
+	COALESCE(SUM(tu.output_tokens), 0)::BIGINT AS output_tokens,
+	COALESCE(SUM(tu.cache_read_input_tokens), 0)::BIGINT AS cache_read_input_tokens,
+	COALESCE(SUM(tu.cache_write_input_tokens), 0)::BIGINT AS cache_write_input_tokens
+FROM aibridge_token_usages tu
+JOIN aibridge_interceptions ai ON ai.id = tu.interception_id
+JOIN users ON users.id = ai.initiator_id
+JOIN groups ON groups.id = tu.effective_group_id
+LEFT JOIN ai_providers provider ON provider.name = ai.provider_name AND provider.deleted = false
+WHERE groups.organization_id = $2
+	AND tu.created_at >= $3::timestamptz
+	AND tu.created_at < $4::timestamptz
+GROUP BY
+	to_timestamp(floor(extract(epoch FROM tu.created_at) / $1::bigint) * $1::bigint),
+	ai.initiator_id,
+	users.username,
+	tu.effective_group_id,
+	groups.name,
+	groups.organization_id,
+	ai.model,
+	ai.provider,
+	ai.provider_name,
+	ai.credential_kind,
+	provider.type,
+	provider.display_name,
+	ai.client,
+	ai.error_type,
+	tu.input_price_micros,
+	tu.output_price_micros,
+	tu.cache_read_price_micros,
+	tu.cache_write_price_micros
+ORDER BY
+	bucket_start,
+	ai.initiator_id,
+	users.username,
+	tu.effective_group_id,
+	groups.name,
+	ai.model,
+	ai.provider,
+	ai.provider_name,
+	ai.credential_kind,
+	provider.type,
+	provider.display_name,
+	ai.client,
+	ai.error_type,
+	tu.input_price_micros,
+	tu.output_price_micros,
+	tu.cache_read_price_micros,
+	tu.cache_write_price_micros
+`
+
+type GetOrganizationAIFOCUSUsageRollupParams struct {
+	GranularitySeconds int64     `db:"granularity_seconds" json:"granularity_seconds"`
+	OrganizationID     uuid.UUID `db:"organization_id" json:"organization_id"`
+	PeriodStart        time.Time `db:"period_start" json:"period_start"`
+	PeriodEnd          time.Time `db:"period_end" json:"period_end"`
+}
+
+type GetOrganizationAIFOCUSUsageRollupRow struct {
+	BucketStart                     time.Time                         `db:"bucket_start" json:"bucket_start"`
+	InitiatorID                     uuid.UUID                         `db:"initiator_id" json:"initiator_id"`
+	InitiatorUsername               string                            `db:"initiator_username" json:"initiator_username"`
+	EffectiveGroupID                uuid.NullUUID                     `db:"effective_group_id" json:"effective_group_id"`
+	GroupName                       string                            `db:"group_name" json:"group_name"`
+	OrganizationID                  uuid.UUID                         `db:"organization_id" json:"organization_id"`
+	Model                           string                            `db:"model" json:"model"`
+	WireProtocol                    string                            `db:"wire_protocol" json:"wire_protocol"`
+	ProviderInstance                string                            `db:"provider_instance" json:"provider_instance"`
+	CredentialKind                  CredentialKind                    `db:"credential_kind" json:"credential_kind"`
+	VendorType                      NullAIProviderType                `db:"vendor_type" json:"vendor_type"`
+	VendorDisplayName               sql.NullString                    `db:"vendor_display_name" json:"vendor_display_name"`
+	ClientTool                      sql.NullString                    `db:"client_tool" json:"client_tool"`
+	ErrorType                       NullAIBridgeInterceptionErrorType `db:"error_type" json:"error_type"`
+	InputPriceMicros                sql.NullInt64                     `db:"input_price_micros" json:"input_price_micros"`
+	OutputPriceMicros               sql.NullInt64                     `db:"output_price_micros" json:"output_price_micros"`
+	CacheReadPriceMicros            sql.NullInt64                     `db:"cache_read_price_micros" json:"cache_read_price_micros"`
+	CacheWritePriceMicros           sql.NullInt64                     `db:"cache_write_price_micros" json:"cache_write_price_micros"`
+	InterceptionIDMin               uuid.UUID                         `db:"interception_id_min" json:"interception_id_min"`
+	InterceptionIDDistinctCount     int64                             `db:"interception_id_distinct_count" json:"interception_id_distinct_count"`
+	SessionIDMin                    string                            `db:"session_id_min" json:"session_id_min"`
+	SessionIDDistinctCount          int64                             `db:"session_id_distinct_count" json:"session_id_distinct_count"`
+	ProviderResponseIDMin           string                            `db:"provider_response_id_min" json:"provider_response_id_min"`
+	ProviderResponseIDDistinctCount int64                             `db:"provider_response_id_distinct_count" json:"provider_response_id_distinct_count"`
+	RowCount                        int64                             `db:"row_count" json:"row_count"`
+	InputTokens                     int64                             `db:"input_tokens" json:"input_tokens"`
+	OutputTokens                    int64                             `db:"output_tokens" json:"output_tokens"`
+	CacheReadInputTokens            int64                             `db:"cache_read_input_tokens" json:"cache_read_input_tokens"`
+	CacheWriteInputTokens           int64                             `db:"cache_write_input_tokens" json:"cache_write_input_tokens"`
+}
+
+// Same source, joins, and tenant-scoping as GetOrganizationAIFOCUSUsage, but
+// rolled up into fixed-width time buckets of @granularity_seconds seconds,
+// anchored to the UNIX epoch in UTC (e.g. 3600 produces buckets aligned to
+// the top of each UTC hour). Only used when granularity_seconds > 0; the
+// caller is responsible for routing to the raw query otherwise, and for
+// bounding granularity_seconds to at most one day (see
+// focus.MaxGranularitySeconds). That bound does not, by itself, keep a
+// bucket within one calendar month: the last bucket of every month still
+// straddles the month boundary at any granularity. Callers derive the FOCUS
+// BillingPeriodStart/End from each row's bucket_start, never from a
+// bucket's exclusive end, to avoid attributing a bucket's spend to the
+// wrong (later) month.
+// Every column the FOCUS Row still needs to report distinctly is part of the
+// GROUP BY key, so a bucket only ever merges rows that would otherwise be
+// identical FOCUS rows except for quantity; nothing is summed across a
+// dimension the export still promises to preserve. The three response-level
+// identifiers (interception, session, provider response) have no single
+// well-defined value once more than one distinct value is merged into a
+// bucket; each is returned alongside a COUNT(DISTINCT ...) so the caller can
+// treat the *_min value as authoritative only when its matching
+// *_distinct_count equals 1, and drop it otherwise rather than reporting an
+// arbitrary pick. row_count tells the caller how many raw token-usage rows a
+// bucket represents.
+func (q *sqlQuerier) GetOrganizationAIFOCUSUsageRollup(ctx context.Context, arg GetOrganizationAIFOCUSUsageRollupParams) ([]GetOrganizationAIFOCUSUsageRollupRow, error) {
+	rows, err := q.db.QueryContext(ctx, getOrganizationAIFOCUSUsageRollup,
+		arg.GranularitySeconds,
+		arg.OrganizationID,
+		arg.PeriodStart,
+		arg.PeriodEnd,
+	)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var items []GetOrganizationAIFOCUSUsageRollupRow
+	for rows.Next() {
+		var i GetOrganizationAIFOCUSUsageRollupRow
+		if err := rows.Scan(
+			&i.BucketStart,
+			&i.InitiatorID,
+			&i.InitiatorUsername,
+			&i.EffectiveGroupID,
+			&i.GroupName,
+			&i.OrganizationID,
+			&i.Model,
+			&i.WireProtocol,
+			&i.ProviderInstance,
+			&i.CredentialKind,
+			&i.VendorType,
+			&i.VendorDisplayName,
+			&i.ClientTool,
+			&i.ErrorType,
+			&i.InputPriceMicros,
+			&i.OutputPriceMicros,
+			&i.CacheReadPriceMicros,
+			&i.CacheWritePriceMicros,
+			&i.InterceptionIDMin,
+			&i.InterceptionIDDistinctCount,
+			&i.SessionIDMin,
+			&i.SessionIDDistinctCount,
+			&i.ProviderResponseIDMin,
+			&i.ProviderResponseIDDistinctCount,
+			&i.RowCount,
+			&i.InputTokens,
+			&i.OutputTokens,
+			&i.CacheReadInputTokens,
+			&i.CacheWriteInputTokens,
+		); err != nil {
+			return nil, err
+		}
+		items = append(items, i)
+	}
+	if err := rows.Close(); err != nil {
+		return nil, err
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
 const getOrganizationGroupsAISpend = `-- name: GetOrganizationGroupsAISpend :many
 WITH queried_groups AS (
 	-- The requested groups that belong to the queried organization.

--- a/coderd/database/queries/aicostcontrol.sql
+++ b/coderd/database/queries/aicostcontrol.sql
@@ -488,6 +488,161 @@ GROUP BY
 	ai.provider_name
 ORDER BY ai.initiator_id, tu.effective_group_id, ai.provider, ai.provider_name, ai.model;
 
+-- name: GetOrganizationAIFOCUSUsage :many
+-- Returns raw AI Gateway usage joined for FOCUS-format export over
+-- [period_start, period_end), scoped to @organization_id through the token
+-- usage's effective group, the only tenant-isolation signal that exists for
+-- aibridge data today. A token usage row with a NULL effective_group_id has
+-- no organization signal at all and is excluded here, same trade-off
+-- ExportOrganizationAISpend already accepts. One row per token usage
+-- (priced provider response); the caller fans this out into one FOCUS row
+-- per non-zero token type. Used when the export is requested at raw,
+-- unrolled granularity (granularity_seconds <= 0).
+SELECT
+	tu.id AS token_usage_id,
+	tu.provider_response_id,
+	tu.interception_id,
+	ai.session_id,
+	ai.client AS client_tool,
+	ai.error_type,
+	ai.started_at,
+	COALESCE(ai.ended_at, tu.created_at) AS ended_at,
+	tu.created_at,
+	ai.initiator_id,
+	users.username AS initiator_username,
+	tu.effective_group_id,
+	groups.name AS group_name,
+	groups.organization_id AS organization_id,
+	ai.model,
+	ai.provider AS wire_protocol,
+	ai.provider_name AS provider_instance,
+	ai.credential_kind,
+	provider.type AS vendor_type,
+	provider.display_name AS vendor_display_name,
+	tu.input_tokens,
+	tu.output_tokens,
+	tu.cache_read_input_tokens,
+	tu.cache_write_input_tokens,
+	tu.input_price_micros,
+	tu.output_price_micros,
+	tu.cache_read_price_micros,
+	tu.cache_write_price_micros
+FROM aibridge_token_usages tu
+JOIN aibridge_interceptions ai ON ai.id = tu.interception_id
+JOIN users ON users.id = ai.initiator_id
+JOIN groups ON groups.id = tu.effective_group_id
+LEFT JOIN ai_providers provider ON provider.name = ai.provider_name AND provider.deleted = false
+WHERE groups.organization_id = @organization_id
+	AND tu.created_at >= @period_start::timestamptz
+	AND tu.created_at < @period_end::timestamptz
+ORDER BY tu.created_at, tu.id;
+
+-- name: GetOrganizationAIFOCUSUsageRollup :many
+-- Same source, joins, and tenant-scoping as GetOrganizationAIFOCUSUsage, but
+-- rolled up into fixed-width time buckets of @granularity_seconds seconds,
+-- anchored to the UNIX epoch in UTC (e.g. 3600 produces buckets aligned to
+-- the top of each UTC hour). Only used when granularity_seconds > 0; the
+-- caller is responsible for routing to the raw query otherwise, and for
+-- bounding granularity_seconds to at most one day (see
+-- focus.MaxGranularitySeconds). That bound does not, by itself, keep a
+-- bucket within one calendar month: the last bucket of every month still
+-- straddles the month boundary at any granularity. Callers derive the FOCUS
+-- BillingPeriodStart/End from each row's bucket_start, never from a
+-- bucket's exclusive end, to avoid attributing a bucket's spend to the
+-- wrong (later) month.
+-- Every column the FOCUS Row still needs to report distinctly is part of the
+-- GROUP BY key, so a bucket only ever merges rows that would otherwise be
+-- identical FOCUS rows except for quantity; nothing is summed across a
+-- dimension the export still promises to preserve. The three response-level
+-- identifiers (interception, session, provider response) have no single
+-- well-defined value once more than one distinct value is merged into a
+-- bucket; each is returned alongside a COUNT(DISTINCT ...) so the caller can
+-- treat the *_min value as authoritative only when its matching
+-- *_distinct_count equals 1, and drop it otherwise rather than reporting an
+-- arbitrary pick. row_count tells the caller how many raw token-usage rows a
+-- bucket represents.
+SELECT
+	(to_timestamp(floor(extract(epoch FROM tu.created_at) / @granularity_seconds::bigint) * @granularity_seconds::bigint))::timestamptz AS bucket_start,
+	ai.initiator_id,
+	users.username AS initiator_username,
+	tu.effective_group_id,
+	groups.name AS group_name,
+	groups.organization_id AS organization_id,
+	ai.model,
+	ai.provider AS wire_protocol,
+	ai.provider_name AS provider_instance,
+	ai.credential_kind,
+	provider.type AS vendor_type,
+	provider.display_name AS vendor_display_name,
+	ai.client AS client_tool,
+	ai.error_type,
+	tu.input_price_micros,
+	tu.output_price_micros,
+	tu.cache_read_price_micros,
+	tu.cache_write_price_micros,
+	-- MIN(...)/COUNT(DISTINCT ...) here relies on interception_id,
+	-- session_id, and provider_response_id all being NOT NULL columns: a
+	-- SQL MIN()/COUNT(DISTINCT) silently ignores NULL inputs, which would
+	-- silently pick a value out of an ambiguous bucket instead of leaving
+	-- distinct_count able to signal ambiguity. If any of the three ever
+	-- becomes nullable, this collapse must be revisited.
+	MIN(tu.interception_id::text)::uuid AS interception_id_min,
+	COUNT(DISTINCT tu.interception_id)::BIGINT AS interception_id_distinct_count,
+	MIN(ai.session_id)::text AS session_id_min,
+	COUNT(DISTINCT ai.session_id)::BIGINT AS session_id_distinct_count,
+	MIN(tu.provider_response_id)::text AS provider_response_id_min,
+	COUNT(DISTINCT tu.provider_response_id)::BIGINT AS provider_response_id_distinct_count,
+	COUNT(*)::BIGINT AS row_count,
+	COALESCE(SUM(tu.input_tokens), 0)::BIGINT AS input_tokens,
+	COALESCE(SUM(tu.output_tokens), 0)::BIGINT AS output_tokens,
+	COALESCE(SUM(tu.cache_read_input_tokens), 0)::BIGINT AS cache_read_input_tokens,
+	COALESCE(SUM(tu.cache_write_input_tokens), 0)::BIGINT AS cache_write_input_tokens
+FROM aibridge_token_usages tu
+JOIN aibridge_interceptions ai ON ai.id = tu.interception_id
+JOIN users ON users.id = ai.initiator_id
+JOIN groups ON groups.id = tu.effective_group_id
+LEFT JOIN ai_providers provider ON provider.name = ai.provider_name AND provider.deleted = false
+WHERE groups.organization_id = @organization_id
+	AND tu.created_at >= @period_start::timestamptz
+	AND tu.created_at < @period_end::timestamptz
+GROUP BY
+	to_timestamp(floor(extract(epoch FROM tu.created_at) / @granularity_seconds::bigint) * @granularity_seconds::bigint),
+	ai.initiator_id,
+	users.username,
+	tu.effective_group_id,
+	groups.name,
+	groups.organization_id,
+	ai.model,
+	ai.provider,
+	ai.provider_name,
+	ai.credential_kind,
+	provider.type,
+	provider.display_name,
+	ai.client,
+	ai.error_type,
+	tu.input_price_micros,
+	tu.output_price_micros,
+	tu.cache_read_price_micros,
+	tu.cache_write_price_micros
+ORDER BY
+	bucket_start,
+	ai.initiator_id,
+	users.username,
+	tu.effective_group_id,
+	groups.name,
+	ai.model,
+	ai.provider,
+	ai.provider_name,
+	ai.credential_kind,
+	provider.type,
+	provider.display_name,
+	ai.client,
+	ai.error_type,
+	tu.input_price_micros,
+	tu.output_price_micros,
+	tu.cache_read_price_micros,
+	tu.cache_write_price_micros;
+
 -- name: GetUnpricedAIModelsSince :many
 -- Returns the models used since the given time that hold no price, most used
 -- first. openai-compat providers cannot be priced, so their models are excluded.

--- a/codersdk/deployment.go
+++ b/codersdk/deployment.go
@@ -5174,6 +5174,7 @@ const (
 	ExperimentChatAdvisor               Experiment = "chat-advisor"                // Enables the advisor tool for root agent chats.
 	ExperimentChatVirtualDesktop        Experiment = "chat-virtual-desktop"        // Enables virtual desktop and computer use provider for agents.
 	ExperimentAgentLifecycleHooks       Experiment = "agent-lifecycle-hooks"       // Enables chat lifecycle hook webhooks for agent chats.
+	ExperimentFOCUSExport               Experiment = "focus-export"                // Enables the experimental FOCUS-format AI Gateway spend export endpoint.
 )
 
 func (e Experiment) DisplayName() string {
@@ -5204,6 +5205,8 @@ func (e Experiment) DisplayName() string {
 		return "Chat Virtual Desktop"
 	case ExperimentAgentLifecycleHooks:
 		return "Agent Lifecycle Hooks"
+	case ExperimentFOCUSExport:
+		return "FOCUS Export"
 	default:
 		// Split on hyphen and convert to title case
 		// e.g. "mcp-server-http" -> "Mcp Server Http"
@@ -5228,6 +5231,7 @@ var ExperimentsKnown = Experiments{
 	ExperimentChatAdvisor,
 	ExperimentChatVirtualDesktop,
 	ExperimentAgentLifecycleHooks,
+	ExperimentFOCUSExport,
 }
 
 // ExperimentsSafe should include all experiments that are safe for

--- a/docs/reference/api/schemas.md
+++ b/docs/reference/api/schemas.md
@@ -8856,9 +8856,9 @@ CreateWorkspaceRequest provides options for creating a new workspace. Only one o
 
 #### Enumerated Values
 
-| Value(s)                                                                                                                                                                                                                                                                                     |
-|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| `agent-lifecycle-hooks`, `ai-gateway-seat-exclusion`, `auto-fill-parameters`, `chat-advisor`, `chat-virtual-desktop`, `example`, `mcp-server-http`, `mcp-tool-search`, `nats_pubsub`, `notifications`, `oauth2`, `workspace-build-updates`, `workspace-capable-licensing`, `workspace-usage` |
+| Value(s)                                                                                                                                                                                                                                                                                                     |
+|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `agent-lifecycle-hooks`, `ai-gateway-seat-exclusion`, `auto-fill-parameters`, `chat-advisor`, `chat-virtual-desktop`, `example`, `focus-export`, `mcp-server-http`, `mcp-tool-search`, `nats_pubsub`, `notifications`, `oauth2`, `workspace-build-updates`, `workspace-capable-licensing`, `workspace-usage` |
 
 ## codersdk.ExternalAPIKeyScopes
 

--- a/enterprise/coderd/aibridge.go
+++ b/enterprise/coderd/aibridge.go
@@ -3,8 +3,10 @@ package coderd
 import (
 	"bytes"
 	"context"
+	"crypto/sha256"
 	"database/sql"
 	"encoding/csv"
+	"encoding/hex"
 	"errors"
 	"fmt"
 	"net/http"
@@ -20,6 +22,7 @@ import (
 	"github.com/coder/coder/v2/coderd"
 	agplaibridge "github.com/coder/coder/v2/coderd/aibridge"
 	"github.com/coder/coder/v2/coderd/aibridge/budget"
+	"github.com/coder/coder/v2/coderd/aibridge/focus"
 	"github.com/coder/coder/v2/coderd/audit"
 	"github.com/coder/coder/v2/coderd/database"
 	"github.com/coder/coder/v2/coderd/database/db2sdk"
@@ -1133,7 +1136,15 @@ func escapeCSVCell(value string) string {
 // together and are interpreted as UTC, and an explicit window must be non-empty,
 // span at most 31 days, and begin within the retention window. On invalid input
 // it writes the error response and returns ok=false.
-func (api *API) aiSpendExportPeriod(ctx context.Context, rw http.ResponseWriter, r *http.Request) (start, end time.Time, ok bool) {
+//
+// The caller owns parser: it must be a *httpapi.QueryParamParser shared with
+// every other query parameter the caller accepts (e.g. "format", "granularity"),
+// and the caller must call parser.ErrorExcessParams itself once every field has
+// been registered. This function only registers "period_start" and
+// "period_end" on it and never calls ErrorExcessParams, so that a caller with
+// additional accepted params does not have "period_start"/"period_end"
+// rejected as excess, and vice versa.
+func (api *API) aiSpendExportPeriod(ctx context.Context, rw http.ResponseWriter, r *http.Request, parser *httpapi.QueryParamParser) (start, end time.Time, ok bool) {
 	query := r.URL.Query()
 	hasStart := query.Has("period_start")
 	hasEnd := query.Has("period_end")
@@ -1168,10 +1179,8 @@ func (api *API) aiSpendExportPeriod(ctx context.Context, rw http.ResponseWriter,
 		return time.Time{}, time.Time{}, false
 	default:
 		// The caller asked for this period, so validate it.
-		parser := httpapi.NewQueryParamParser()
 		start = parser.Time3339Nano(query, time.Time{}, "period_start")
 		end = parser.Time3339Nano(query, time.Time{}, "period_end")
-		parser.ErrorExcessParams(query)
 		if len(parser.Errors) > 0 {
 			httpapi.Write(ctx, rw, http.StatusBadRequest, codersdk.Response{
 				Message:     "Query parameters have invalid values.",
@@ -1229,8 +1238,17 @@ func (api *API) exportOrganizationAISpend(rw http.ResponseWriter, r *http.Reques
 		return
 	}
 
-	periodStart, periodEnd, ok := api.aiSpendExportPeriod(ctx, rw, r)
+	periodParser := httpapi.NewQueryParamParser()
+	periodStart, periodEnd, ok := api.aiSpendExportPeriod(ctx, rw, r, periodParser)
 	if !ok {
+		return
+	}
+	periodParser.ErrorExcessParams(r.URL.Query())
+	if len(periodParser.Errors) > 0 {
+		httpapi.Write(ctx, rw, http.StatusBadRequest, codersdk.Response{
+			Message:     "Query parameters have invalid values.",
+			Validations: periodParser.Errors,
+		})
 		return
 	}
 	logger = logger.With(
@@ -1300,6 +1318,144 @@ func (api *API) exportOrganizationAISpend(rw http.ResponseWriter, r *http.Reques
 	rw.WriteHeader(http.StatusOK)
 	if _, err := rw.Write(buf.Bytes()); err != nil {
 		logger.Error(ctx, "failed to write AI spend export", slog.Error(err))
+	}
+}
+
+// maxFOCUSExportGranularitySeconds bounds the granularity query parameter to
+// at most one calendar day. See focus.MaxGranularitySeconds for why this cap
+// does not, by itself, keep a rollup bucket within a single calendar month.
+const maxFOCUSExportGranularitySeconds = focus.MaxGranularitySeconds
+
+// defaultFOCUSExportGranularitySeconds is applied when the caller omits the
+// granularity query parameter: hourly rollup, per the illustrative grouping
+// key in the parent RFC's Granularity section.
+const defaultFOCUSExportGranularitySeconds = 3600
+
+// @Summary Export organization AI spend in FOCUS format
+// @Description Returns AI Gateway usage and cost for the organization as a FOCUS v1.2-shaped CSV or Parquet document, rolled up into hourly fixed-width time buckets by default, or at raw, unrolled per-response, per-token-type granularity, or a different rollup width, when the granularity query parameter is set.
+// @Description The optional period_start and period_end query parameters bound the period and are interpreted as UTC, exactly as for the existing /export endpoint (see its own description for defaults and validation).
+// @Description The optional format query parameter selects "csv" (default) or "parquet".
+// @Description The optional granularity query parameter, in seconds, selects the row grain: 0 requests raw, unrolled per-response grain; a positive value (default 3600, i.e. hourly) rolls responses up into fixed-width UTC time buckets of that many seconds, up to a maximum of 86400 (one day).
+// @Description This endpoint is experimental: it lives under /api/experimental and is gated behind the "focus-export" experiment (CODER_EXPERIMENTS=focus-export), off by default. Its FOCUS column set and semantics may still change.
+// @Description Requires organization-level administrator permissions.
+// @ID export-organization-ai-focus
+// @Security CoderSessionToken
+// @Produce text/csv
+// @Produce application/vnd.apache.parquet
+// @Tags Enterprise
+// @Param organization path string true "Organization ID" format(uuid)
+// @Param period_start query string false "Inclusive lower bound (RFC3339)" format(date-time)
+// @Param period_end query string false "Exclusive upper bound (RFC3339)" format(date-time)
+// @Param format query string false "Export format" enums(csv,parquet)
+// @Param granularity query int false "Rollup bucket width in seconds. 0 for raw, unrolled per-response grain. Defaults to 3600 (hourly)"
+// @Success 200
+// @Router /api/experimental/organizations/{organization}/ai/spend/export/focus [get]
+// @x-apidocgen {"skip": true}
+func (api *API) exportOrganizationAIFOCUS(rw http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+	org := httpmw.OrganizationParam(r)
+	logger := api.Logger.With(slog.F("organization_id", org.ID))
+
+	// Same authorization decision as exportOrganizationAISpend: the export
+	// aggregates the whole organization, so require organization-wide read
+	// rather than letting a per-row filter narrow it to the caller.
+	if !api.Authorize(r, policy.ActionRead, rbac.ResourceGroupMember.InOrg(org.ID)) {
+		httpapi.Forbidden(rw)
+		return
+	}
+
+	query := r.URL.Query()
+	parser := httpapi.NewQueryParamParser()
+	format := parser.String(query, "csv", "format")
+	granularitySeconds := parser.Int64(query, defaultFOCUSExportGranularitySeconds, "granularity")
+
+	periodStart, periodEnd, ok := api.aiSpendExportPeriod(ctx, rw, r, parser)
+	if !ok {
+		return
+	}
+
+	parser.ErrorExcessParams(query)
+	if len(parser.Errors) > 0 {
+		httpapi.Write(ctx, rw, http.StatusBadRequest, codersdk.Response{
+			Message:     "Query parameters have invalid values.",
+			Validations: parser.Errors,
+		})
+		return
+	}
+	if format != "csv" && format != "parquet" {
+		httpapi.Write(ctx, rw, http.StatusBadRequest, codersdk.Response{
+			Message: "Query parameter \"format\" must be \"csv\" or \"parquet\".",
+		})
+		return
+	}
+	if granularitySeconds < 0 || granularitySeconds > maxFOCUSExportGranularitySeconds {
+		httpapi.Write(ctx, rw, http.StatusBadRequest, codersdk.Response{
+			Message: fmt.Sprintf("Query parameter \"granularity\" must be between 0 and %d seconds.", maxFOCUSExportGranularitySeconds),
+		})
+		return
+	}
+
+	logger = logger.With(
+		slog.F("period_start", periodStart),
+		slog.F("period_end", periodEnd),
+		slog.F("format", format),
+		slog.F("granularity_seconds", granularitySeconds),
+	)
+
+	records, err := focus.LoadUsageRecords(ctx, api.Database, org.ID, periodStart, periodEnd, granularitySeconds)
+	if err != nil {
+		logger.Error(ctx, "failed to load FOCUS usage records", slog.Error(err))
+		httpapi.InternalServerError(rw, err)
+		return
+	}
+
+	deploymentID := api.AccessURL.Host
+	rows := make([]focus.Row, 0, len(records))
+	for _, rec := range records {
+		rows = append(rows, focus.MapUsageRecord(rec, deploymentID)...)
+	}
+
+	var buf bytes.Buffer
+	var contentType string
+	switch format {
+	case "parquet":
+		if err := focus.WriteParquet(&buf, rows); err != nil {
+			logger.Error(ctx, "failed to write FOCUS parquet export", slog.Error(err))
+			httpapi.InternalServerError(rw, err)
+			return
+		}
+		contentType = "application/vnd.apache.parquet"
+	default:
+		if err := focus.WriteCSV(&buf, rows); err != nil {
+			logger.Error(ctx, "failed to write FOCUS csv export", slog.Error(err))
+			httpapi.InternalServerError(rw, err)
+			return
+		}
+		contentType = "text/csv; charset=utf-8"
+	}
+
+	// The handler already buffers the full body to set Content-Length before
+	// writing any headers, so the checksum is one additional pass over bytes
+	// already held, not an extra read of the underlying data (Export
+	// manifest, parent RFC).
+	checksum := sha256.Sum256(buf.Bytes())
+
+	filename := fmt.Sprintf("focus-export-%s-%s-to-%s.%s",
+		org.Name, periodStart.UTC().Format(time.DateOnly), periodEnd.UTC().Format(time.DateOnly), format)
+	rw.Header().Set("Content-Type", contentType)
+	rw.Header().Set("Content-Disposition", fmt.Sprintf("attachment; filename=%q", filename))
+	rw.Header().Set("Content-Length", strconv.Itoa(buf.Len()))
+	// Manifest-equivalent metadata for this one-shot pull (Export manifest,
+	// parent RFC): the full manifest.json is Phase 2 only.
+	rw.Header().Set("X-Coder-Focus-Version", focus.FocusVersion)
+	rw.Header().Set("X-Coder-Focus-Mapping-Version", focus.MappingVersion)
+	rw.Header().Set("X-Coder-Focus-Generated-At", time.Now().UTC().Format(time.RFC3339))
+	rw.Header().Set("X-Coder-Focus-Row-Count", strconv.Itoa(len(rows)))
+	rw.Header().Set("X-Coder-Focus-Checksum-Sha256", hex.EncodeToString(checksum[:]))
+	rw.Header().Set("X-Coder-Focus-Granularity-Seconds", strconv.FormatInt(granularitySeconds, 10))
+	rw.WriteHeader(http.StatusOK)
+	if _, err := rw.Write(buf.Bytes()); err != nil {
+		logger.Error(ctx, "failed to write FOCUS export", slog.Error(err))
 	}
 }
 

--- a/enterprise/coderd/coderd.go
+++ b/enterprise/coderd/coderd.go
@@ -347,6 +347,18 @@ func New(ctx context.Context, options *Options) (_ *API, err error) {
 			r.Get("/", api.listAIModelPrices)
 			r.Post("/", api.upsertAIModelPrices)
 		})
+		r.Route("/organizations/{organization}/ai/spend", func(r chi.Router) {
+			// Same feature gate as the stable /api/v2 export, plus the
+			// focus-export experiment: two independent signals that this
+			// endpoint's contract is not yet stable (see exportOrganizationAIFOCUS).
+			r.Use(
+				apiKeyMiddleware,
+				httpmw.ExtractOrganizationParam(api.Database),
+				api.RequireFeatureMW(codersdk.FeatureAIBridge),
+				httpmw.RequireExperiment(api.AGPL.Experiments, codersdk.ExperimentFOCUSExport),
+			)
+			r.Get("/export/focus", api.exportOrganizationAIFOCUS)
+		})
 	})
 
 	api.AGPL.APIHandler.Group(func(r chi.Router) {

--- a/enterprise/coderd/focus_export_test.go
+++ b/enterprise/coderd/focus_export_test.go
@@ -1,0 +1,336 @@
+package coderd_test
+
+import (
+	"bytes"
+	"context"
+	"database/sql"
+	"encoding/csv"
+	"fmt"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/parquet-go/parquet-go"
+	"github.com/stretchr/testify/require"
+
+	"github.com/coder/coder/v2/coderd/aibridge/focus"
+	"github.com/coder/coder/v2/coderd/coderdtest"
+	"github.com/coder/coder/v2/coderd/database"
+	"github.com/coder/coder/v2/coderd/database/dbgen"
+	"github.com/coder/coder/v2/coderd/database/dbtestutil"
+	"github.com/coder/coder/v2/coderd/rbac"
+	"github.com/coder/coder/v2/codersdk"
+	"github.com/coder/coder/v2/enterprise/coderd/coderdenttest"
+	"github.com/coder/coder/v2/enterprise/coderd/license"
+	"github.com/coder/coder/v2/testutil"
+	"github.com/coder/serpent"
+)
+
+// requestAIFocusExport issues a raw GET against the experimental FOCUS export
+// endpoint. There is no typed SDK method for it, since the route is
+// experimental (Phase One Draft, HTTP handler).
+func requestAIFocusExport(ctx context.Context, t *testing.T, client *codersdk.Client, orgID uuid.UUID, params map[string]string) *http.Response {
+	t.Helper()
+	res, err := client.Request(ctx, http.MethodGet,
+		fmt.Sprintf("/api/experimental/organizations/%s/ai/spend/export/focus", orgID),
+		nil,
+		func(r *http.Request) {
+			q := r.URL.Query()
+			for k, v := range params {
+				q.Set(k, v)
+			}
+			r.URL.RawQuery = q.Encode()
+		},
+	)
+	require.NoError(t, err)
+	return res
+}
+
+type focusExportTestOptions struct {
+	ExperimentEnabled bool
+	Features          license.Features
+	Database          database.Store
+}
+
+// setupAIFocusExportTest builds a deployment with FeatureAIBridge licensed
+// (unless overridden) and the focus-export experiment enabled (unless
+// overridden), returning an org admin client, a regular member client, and
+// the organization ID.
+func setupAIFocusExportTest(t *testing.T, opts focusExportTestOptions) (admin *codersdk.Client, member *codersdk.Client, orgID uuid.UUID) {
+	t.Helper()
+
+	dv := coderdtest.DeploymentValues(t)
+	dv.AI.BridgeConfig.Enabled = serpent.Bool(true)
+	if opts.ExperimentEnabled {
+		dv.Experiments = []string{string(codersdk.ExperimentFOCUSExport)}
+	}
+	features := opts.Features
+	if features == nil {
+		features = license.Features{
+			codersdk.FeatureTemplateRBAC: 1,
+			codersdk.FeatureAIBridge:     1,
+		}
+	}
+	coderdOpts := &coderdtest.Options{DeploymentValues: dv}
+	if opts.Database != nil {
+		coderdOpts.Database = opts.Database
+	}
+	ownerClient, owner := coderdenttest.New(t, &coderdenttest.Options{
+		Options:        coderdOpts,
+		LicenseOptions: &coderdenttest.LicenseOptions{Features: features},
+	})
+	adminClient, _ := coderdtest.CreateAnotherUser(t, ownerClient, owner.OrganizationID, rbac.RoleUserAdmin())
+	memberClient, _ := coderdtest.CreateAnotherUser(t, ownerClient, owner.OrganizationID)
+	return adminClient, memberClient, owner.OrganizationID
+}
+
+func TestExportOrganizationAIFocus(t *testing.T) {
+	t.Parallel()
+
+	t.Run("DisabledByDefault", func(t *testing.T) {
+		t.Parallel()
+		admin, _, orgID := setupAIFocusExportTest(t, focusExportTestOptions{ExperimentEnabled: false})
+		ctx := testutil.Context(t, testutil.WaitLong)
+
+		res := requestAIFocusExport(ctx, t, admin, orgID, nil)
+		defer res.Body.Close()
+		require.Equal(t, http.StatusForbidden, res.StatusCode)
+	})
+
+	t.Run("RequiresLicenseFeature", func(t *testing.T) {
+		t.Parallel()
+		admin, _, orgID := setupAIFocusExportTest(t, focusExportTestOptions{
+			ExperimentEnabled: true,
+			Features:          license.Features{},
+		})
+		ctx := testutil.Context(t, testutil.WaitLong)
+
+		res := requestAIFocusExport(ctx, t, admin, orgID, nil)
+		defer res.Body.Close()
+		require.Equal(t, http.StatusForbidden, res.StatusCode)
+	})
+
+	t.Run("RequiresOrgRead", func(t *testing.T) {
+		t.Parallel()
+		_, member, orgID := setupAIFocusExportTest(t, focusExportTestOptions{ExperimentEnabled: true})
+		ctx := testutil.Context(t, testutil.WaitLong)
+
+		res := requestAIFocusExport(ctx, t, member, orgID, nil)
+		defer res.Body.Close()
+		require.Equal(t, http.StatusForbidden, res.StatusCode)
+	})
+
+	t.Run("InvalidFormat", func(t *testing.T) {
+		t.Parallel()
+		admin, _, orgID := setupAIFocusExportTest(t, focusExportTestOptions{ExperimentEnabled: true})
+		ctx := testutil.Context(t, testutil.WaitLong)
+
+		res := requestAIFocusExport(ctx, t, admin, orgID, map[string]string{"format": "xml"})
+		defer res.Body.Close()
+		require.Equal(t, http.StatusBadRequest, res.StatusCode)
+	})
+
+	t.Run("InvalidGranularity", func(t *testing.T) {
+		t.Parallel()
+		admin, _, orgID := setupAIFocusExportTest(t, focusExportTestOptions{ExperimentEnabled: true})
+		ctx := testutil.Context(t, testutil.WaitLong)
+
+		res := requestAIFocusExport(ctx, t, admin, orgID, map[string]string{"granularity": "999999999"})
+		defer res.Body.Close()
+		require.Equal(t, http.StatusBadRequest, res.StatusCode)
+	})
+
+	t.Run("PeriodStartAndEndAreAccepted", func(t *testing.T) {
+		// Regression test: aiSpendExportPeriod and this handler used to build
+		// two independent query-param parsers, each rejecting the other's
+		// accepted params as "excess", so period_start/period_end always
+		// returned 400 alongside format/granularity.
+		t.Parallel()
+		admin, _, orgID := setupAIFocusExportTest(t, focusExportTestOptions{ExperimentEnabled: true})
+		ctx := testutil.Context(t, testutil.WaitLong)
+
+		now := time.Now().UTC()
+		periodStart := time.Date(now.Year(), now.Month(), 1, 0, 0, 0, 0, time.UTC)
+		periodEnd := periodStart.AddDate(0, 0, 1)
+
+		for name, params := range map[string]map[string]string{
+			"PeriodAlone": {
+				"period_start": periodStart.Format(time.RFC3339),
+				"period_end":   periodEnd.Format(time.RFC3339),
+			},
+			"PeriodWithFormat": {
+				"period_start": periodStart.Format(time.RFC3339),
+				"period_end":   periodEnd.Format(time.RFC3339),
+				"format":       "csv",
+			},
+			"PeriodWithGranularity": {
+				"period_start": periodStart.Format(time.RFC3339),
+				"period_end":   periodEnd.Format(time.RFC3339),
+				"granularity":  "0",
+			},
+			"PeriodWithFormatAndGranularity": {
+				"period_start": periodStart.Format(time.RFC3339),
+				"period_end":   periodEnd.Format(time.RFC3339),
+				"format":       "parquet",
+				"granularity":  "3600",
+			},
+		} {
+			t.Run(name, func(t *testing.T) {
+				res := requestAIFocusExport(ctx, t, admin, orgID, params)
+				defer res.Body.Close()
+				require.Equal(t, http.StatusOK, res.StatusCode)
+			})
+		}
+	})
+
+	t.Run("CrossOrgAdminCannotAccess", func(t *testing.T) {
+		// The highest-value missing test: an admin of one organization must not
+		// be able to read another organization's export by URL alone. This is
+		// the actual proof of the "organization-level administrator
+		// permissions" claim in the endpoint's docstring, which the
+		// RequiresOrgRead/RequiresLicenseFeature/DisabledByDefault cases above
+		// do not cover (they only prove a same-org member or a disabled
+		// gate is rejected).
+		t.Parallel()
+		dv := coderdtest.DeploymentValues(t)
+		dv.AI.BridgeConfig.Enabled = serpent.Bool(true)
+		dv.Experiments = []string{string(codersdk.ExperimentFOCUSExport)}
+		ownerClient, owner := coderdenttest.New(t, &coderdenttest.Options{
+			Options: &coderdtest.Options{DeploymentValues: dv},
+			LicenseOptions: &coderdenttest.LicenseOptions{Features: license.Features{
+				codersdk.FeatureTemplateRBAC:          1,
+				codersdk.FeatureAIBridge:              1,
+				codersdk.FeatureMultipleOrganizations: 1,
+			}},
+		})
+		ctx := testutil.Context(t, testutil.WaitLong)
+
+		// A second organization, with its own admin, distinct from owner's.
+		//nolint:gocritic // must be an owner, only owners can create orgs
+		otherOrg, err := ownerClient.CreateOrganization(ctx, codersdk.CreateOrganizationRequest{Name: "other-org"})
+		require.NoError(t, err)
+		otherOrgAdmin, _ := coderdtest.CreateAnotherUser(t, ownerClient, otherOrg.ID, rbac.RoleIdentifier{Name: rbac.RoleOrgAdmin(), OrganizationID: otherOrg.ID})
+
+		// otherOrgAdmin is an admin, just not of owner's organization. Coder's
+		// org-param middleware resolves "organization" through the
+		// authorization-wrapped store, so an org the actor cannot read comes
+		// back not-found rather than forbidden: this is the established,
+		// intentional convention (it does not confirm or deny that the
+		// organization exists to a non-member), matching every other
+		// organization-scoped endpoint, not a gap specific to this one.
+		res := requestAIFocusExport(ctx, t, otherOrgAdmin, owner.OrganizationID, nil)
+		defer res.Body.Close()
+		require.Equal(t, http.StatusNotFound, res.StatusCode)
+	})
+
+	t.Run("OrgAdminRoleIsSufficient", func(t *testing.T) {
+		// setupAIFocusExportTest's "admin" client actually holds RoleUserAdmin,
+		// a site-wide role, not the "organization-level administrator
+		// permissions" the docstring documents. This proves the documented
+		// role actually works, independent of RoleUserAdmin.
+		t.Parallel()
+		dv := coderdtest.DeploymentValues(t)
+		dv.AI.BridgeConfig.Enabled = serpent.Bool(true)
+		dv.Experiments = []string{string(codersdk.ExperimentFOCUSExport)}
+		ownerClient, owner := coderdenttest.New(t, &coderdenttest.Options{
+			Options: &coderdtest.Options{DeploymentValues: dv},
+			LicenseOptions: &coderdenttest.LicenseOptions{Features: license.Features{
+				codersdk.FeatureTemplateRBAC: 1,
+				codersdk.FeatureAIBridge:     1,
+			}},
+		})
+		ctx := testutil.Context(t, testutil.WaitLong)
+
+		orgAdmin, _ := coderdtest.CreateAnotherUser(t, ownerClient, owner.OrganizationID,
+			rbac.RoleIdentifier{Name: rbac.RoleOrgAdmin(), OrganizationID: owner.OrganizationID})
+
+		res := requestAIFocusExport(ctx, t, orgAdmin, owner.OrganizationID, nil)
+		defer res.Body.Close()
+		require.Equal(t, http.StatusOK, res.StatusCode)
+	})
+
+	t.Run("HappyPathCSVAndParquet", func(t *testing.T) {
+		t.Parallel()
+
+		db, _ := dbtestutil.NewDB(t)
+		admin, _, orgID := setupAIFocusExportTest(t, focusExportTestOptions{
+			ExperimentEnabled: true,
+			Database:          db,
+		})
+		ctx := testutil.Context(t, testutil.WaitLong)
+
+		// The org's group membership signal (effective_group_id) must point at
+		// a real group under orgID.
+		group, err := admin.CreateGroup(ctx, orgID, codersdk.CreateGroupRequest{Name: "focus-export-group"})
+		require.NoError(t, err)
+
+		user, err := admin.User(ctx, codersdk.Me)
+		require.NoError(t, err)
+		_, err = admin.PatchGroup(ctx, group.ID, codersdk.PatchGroupRequest{AddUsers: []string{user.ID.String()}})
+		require.NoError(t, err)
+
+		provider := dbgen.AIProvider(t, db, database.AIProvider{Type: database.AIProviderTypeAnthropic, Name: "anthropic"})
+
+		now := time.Now().UTC()
+		periodStart := time.Date(now.Year(), now.Month(), 1, 0, 0, 0, 0, time.UTC)
+		at := periodStart.Add(time.Hour)
+
+		interception := dbgen.AIBridgeInterception(t, db, database.InsertAIBridgeInterceptionParams{
+			InitiatorID: user.ID, Provider: "anthropic", ProviderName: provider.Name, Model: "claude-haiku-4-5",
+			StartedAt: at,
+		}, ptrTo(at.Add(time.Second)))
+		dbgen.AIBridgeTokenUsage(t, db, database.InsertAIBridgeTokenUsageParams{
+			InterceptionID: interception.ID, InputTokens: 100, OutputTokens: 50,
+			CreatedAt:        at.Add(time.Second),
+			EffectiveGroupID: uuid.NullUUID{UUID: group.ID, Valid: true},
+			InputPriceMicros: sql.NullInt64{Int64: 1_000_000, Valid: true},
+		})
+
+		t.Run("CSV", func(t *testing.T) {
+			res := requestAIFocusExport(ctx, t, admin, orgID, map[string]string{"format": "csv", "granularity": "0"})
+			defer res.Body.Close()
+			require.Equal(t, http.StatusOK, res.StatusCode)
+			require.NotEmpty(t, res.Header.Get("X-Coder-Focus-Checksum-Sha256"))
+			require.Equal(t, focus.FocusVersion, res.Header.Get("X-Coder-Focus-Version"))
+			require.Equal(t, focus.MappingVersion, res.Header.Get("X-Coder-Focus-Mapping-Version"))
+			require.Equal(t, "0", res.Header.Get("X-Coder-Focus-Granularity-Seconds"))
+
+			r := csv.NewReader(res.Body)
+			records, err := r.ReadAll()
+			require.NoError(t, err)
+			require.Equal(t, focus.Header, records[0])
+			require.Equal(t, "2", res.Header.Get("X-Coder-Focus-Row-Count"))
+			require.Len(t, records, 3) // header + input + output rows
+		})
+
+		t.Run("Parquet", func(t *testing.T) {
+			res := requestAIFocusExport(ctx, t, admin, orgID, map[string]string{"format": "parquet", "granularity": "0"})
+			defer res.Body.Close()
+			require.Equal(t, http.StatusOK, res.StatusCode)
+			require.Equal(t, "application/vnd.apache.parquet", res.Header.Get("Content-Type"))
+
+			var buf bytes.Buffer
+			_, err := buf.ReadFrom(res.Body)
+			require.NoError(t, err)
+			rows, err := parquet.Read[focus.Row](bytes.NewReader(buf.Bytes()), int64(buf.Len()))
+			require.NoError(t, err)
+			require.Len(t, rows, 2)
+		})
+
+		t.Run("HourlyRollupFoldsToOneRow", func(t *testing.T) {
+			res := requestAIFocusExport(ctx, t, admin, orgID, map[string]string{"format": "csv", "granularity": "3600"})
+			defer res.Body.Close()
+			require.Equal(t, http.StatusOK, res.StatusCode)
+
+			r := csv.NewReader(res.Body)
+			records, err := r.ReadAll()
+			require.NoError(t, err)
+			// Still fans out per non-zero token type (input + output), but
+			// both from the single hourly bucket.
+			require.Len(t, records, 3)
+		})
+	})
+}
+
+func ptrTo[T any](v T) *T { return &v }

--- a/go.mod
+++ b/go.mod
@@ -421,7 +421,7 @@ require (
 	github.com/outcaste-io/ristretto v0.2.3 // indirect
 	github.com/pelletier/go-toml/v2 v2.3.1 // indirect
 	github.com/philhofer/fwd v1.2.0 // indirect
-	github.com/pierrec/lz4/v4 v4.1.18 // indirect
+	github.com/pierrec/lz4/v4 v4.1.21 // indirect
 	github.com/pion/transport/v2 v2.2.10 // indirect
 	github.com/pion/transport/v3 v3.0.7 // indirect
 	github.com/pkg/errors v0.9.1 // indirect
@@ -547,6 +547,7 @@ require (
 	github.com/nats-io/nats-server/v2 v2.14.2
 	github.com/nats-io/nats.go v1.53.1
 	github.com/openai/openai-go/v3 v3.50.0
+	github.com/parquet-go/parquet-go v0.32.0
 	github.com/scim2/filter-parser/v2 v2.3.1
 	github.com/shopspring/decimal v1.4.0
 	github.com/smallstep/pkcs7 v0.2.1
@@ -556,6 +557,12 @@ require (
 	gonum.org/v1/gonum v0.17.0
 	gopkg.in/dnaeon/go-vcr.v4 v4.0.6
 	mvdan.cc/sh/v3 v3.14.0
+)
+
+require (
+	github.com/parquet-go/bitpack v1.0.0 // indirect
+	github.com/parquet-go/jsonlite v1.0.0 // indirect
+	github.com/twpayne/go-geom v1.6.1 // indirect
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -125,8 +125,8 @@ github.com/agnivade/levenshtein v1.2.1 h1:EHBY3UOn1gwdy/VbFwgo4cxecRznFk7fKWN1KO
 github.com/agnivade/levenshtein v1.2.1/go.mod h1:QVVI16kDrtSuwcpd0p1+xMC6Z/VfhtCyDIjcwga4/DU=
 github.com/akutz/memconn v0.1.0 h1:NawI0TORU4hcOMsMr11g7vwlCdkYeLKXBcxWu2W/P8A=
 github.com/akutz/memconn v0.1.0/go.mod h1:Jo8rI7m0NieZyLI5e2CDlRdRqRRB4S7Xp77ukDjH+Fw=
-github.com/alecthomas/assert/v2 v2.6.0 h1:o3WJwILtexrEUk3cUVal3oiQY2tfgr/FHWiz/v2n4FU=
-github.com/alecthomas/assert/v2 v2.6.0/go.mod h1:Bze95FyfUr7x34QZrjL+XP+0qgp/zg8yS+TtBj1WA3k=
+github.com/alecthomas/assert/v2 v2.10.0 h1:jjRCHsj6hBJhkmhznrCzoNpbA3zqy0fYiUcYZP/GkPY=
+github.com/alecthomas/assert/v2 v2.10.0/go.mod h1:Bze95FyfUr7x34QZrjL+XP+0qgp/zg8yS+TtBj1WA3k=
 github.com/alecthomas/chroma v0.10.0 h1:7XDcGkCQopCNKjZHfYrNLraA+M7e0fMiJ/Mfikbfjek=
 github.com/alecthomas/chroma v0.10.0/go.mod h1:jtJATyUxlIORhUOFNA9NZDWGAQ8wpxQQqNSB4rjA/1s=
 github.com/alecthomas/repr v0.4.0 h1:GhI2A8MACjfegCPVq9f1FLvIBS+DrQ2KQBFZP1iFzXc=
@@ -1009,6 +1009,12 @@ github.com/outcaste-io/ristretto v0.2.3 h1:AK4zt/fJ76kjlYObOeNwh4T3asEuaCmp26pOv
 github.com/outcaste-io/ristretto v0.2.3/go.mod h1:W8HywhmtlopSB1jeMg3JtdIhf+DYkLAr0VN/s4+MHac=
 github.com/package-url/packageurl-go v0.1.3 h1:4juMED3hHiz0set3Vq3KeQ75KD1avthoXLtmE3I0PLs=
 github.com/package-url/packageurl-go v0.1.3/go.mod h1:nKAWB8E6uk1MHqiS/lQb9pYBGH2+mdJ2PJc2s50dQY0=
+github.com/parquet-go/bitpack v1.0.0 h1:AUqzlKzPPXf2bCdjfj4sTeacrUwsT7NlcYDMUQxPcQA=
+github.com/parquet-go/bitpack v1.0.0/go.mod h1:XnVk9TH+O40eOOmvpAVZ7K2ocQFrQwysLMnc6M/8lgs=
+github.com/parquet-go/jsonlite v1.0.0 h1:87QNdi56wOfsE5bdgas0vRzHPxfJgzrXGml1zZdd7VU=
+github.com/parquet-go/jsonlite v1.0.0/go.mod h1:nDjpkpL4EOtqs6NQugUsi0Rleq9sW/OtC1NnZEnxzF0=
+github.com/parquet-go/parquet-go v0.32.0 h1:NWDqTUHfrCS4cJP/Fj2HlxvqsrVedWG3sayMkf+znzM=
+github.com/parquet-go/parquet-go v0.32.0/go.mod h1:navtkAYr2LGoJVp141oXPlO/sxLvaOe3la2JEoD8+rg=
 github.com/pb33f/ordered-map/v2 v2.3.1 h1:5319HDO0aw4DA4gzi+zv4FXU9UlSs3xGZ40wcP1nBjY=
 github.com/pb33f/ordered-map/v2 v2.3.1/go.mod h1:qxFQgd0PkVUtOMCkTapqotNgzRhMPL7VvaHKbd1HnmQ=
 github.com/pbnjay/memory v0.0.0-20210728143218-7b4eea64cf58 h1:onHthvaw9LFnH4t2DcNVpwGmV9E1BkGknEliJkfwQj0=
@@ -1022,8 +1028,8 @@ github.com/petermattis/goid v0.0.0-20260226131333-17d1149c6ac6 h1:rh2lKw/P/EqHa7
 github.com/petermattis/goid v0.0.0-20260226131333-17d1149c6ac6/go.mod h1:pxMtw7cyUw6B2bRH0ZBANSPg+AoSud1I1iyJHI69jH4=
 github.com/philhofer/fwd v1.2.0 h1:e6DnBTl7vGY+Gz322/ASL4Gyp1FspeMvx1RNDoToZuM=
 github.com/philhofer/fwd v1.2.0/go.mod h1:RqIHx9QI14HlwKwm98g9Re5prTQ6LdeRQn+gXJFxsJM=
-github.com/pierrec/lz4/v4 v4.1.18 h1:xaKrnTkyoqfh1YItXl56+6KJNVYWlEEPuAQW9xsplYQ=
-github.com/pierrec/lz4/v4 v4.1.18/go.mod h1:gZWDp/Ze/IJXGXf23ltt2EXimqmTUXEy0GFuRQyBid4=
+github.com/pierrec/lz4/v4 v4.1.21 h1:yOVMLb6qSIDP67pl/5F7RepeKYu/VmTyEXvuMI5d9mQ=
+github.com/pierrec/lz4/v4 v4.1.21/go.mod h1:gZWDp/Ze/IJXGXf23ltt2EXimqmTUXEy0GFuRQyBid4=
 github.com/pion/logging v0.2.2/go.mod h1:k0/tDVsRCX2Mb2ZEmTqNa7CWsQPc+YYCB7Q+5pahoms=
 github.com/pion/transport/v2 v2.0.0/go.mod h1:HS2MEBJTwD+1ZI2eSXSvHJx/HnzQqRy2/LXxt6eVMHc=
 github.com/pion/transport/v2 v2.2.10 h1:ucLBLE8nuxiHfvkFKnkDQRYWYfp8ejf4YBOPfaQpw6Q=
@@ -1212,6 +1218,8 @@ github.com/tmaxmax/go-sse v0.11.0 h1:nogmJM6rJUoOLoAwEKeQe5XlVpt9l7N82SS1jI7lWFg
 github.com/tmaxmax/go-sse v0.11.0/go.mod h1:u/2kZQR1tyngo1lKaNCj1mJmhXGZWS1Zs5yiSOD+Eg8=
 github.com/trailofbits/go-mutexasserts v0.0.0-20250514102930-c1f3d2e37561 h1:qqa3P9AtNn6RMe90l/lxd3eJWnIRxjI4eb5Rx8xqCLA=
 github.com/trailofbits/go-mutexasserts v0.0.0-20250514102930-c1f3d2e37561/go.mod h1:GA3+Mq3kt3tYAfM0WZCu7ofy+GW9PuGysHfhr+6JX7s=
+github.com/twpayne/go-geom v1.6.1 h1:iLE+Opv0Ihm/ABIcvQFGIiFBXd76oBIar9drAwHFhR4=
+github.com/twpayne/go-geom v1.6.1/go.mod h1:Kr+Nly6BswFsKM5sd31YaoWS5PeDDH2NftJTK7Gd028=
 github.com/u-root/gobusybox/src v0.0.0-20240225013946-a274a8d5d83a h1:eg5FkNoQp76ZsswyGZ+TjYqA/rhKefxK8BW7XOlQsxo=
 github.com/u-root/gobusybox/src v0.0.0-20240225013946-a274a8d5d83a/go.mod h1:e/8TmrdreH0sZOw2DFKBaUV7bvDWRq6SeM9PzkuVM68=
 github.com/u-root/u-root v0.14.0 h1:Ka4T10EEML7dQ5XDvO9c3MBN8z4nuSnGjcd1jmU2ivg=

--- a/site/src/api/typesGenerated.ts
+++ b/site/src/api/typesGenerated.ts
@@ -5012,6 +5012,7 @@ export type Experiment =
 	| "chat-advisor"
 	| "chat-virtual-desktop"
 	| "example"
+	| "focus-export"
 	| "mcp-server-http"
 	| "mcp-tool-search"
 	| "nats_pubsub"
@@ -5028,6 +5029,7 @@ export const Experiments: Experiment[] = [
 	"chat-advisor",
 	"chat-virtual-desktop",
 	"example",
+	"focus-export",
 	"mcp-server-http",
 	"mcp-tool-search",
 	"nats_pubsub",


### PR DESCRIPTION
# aibridge: add experimental FOCUS-format AI Gateway spend export

## Summary

Implements Phase 1 of [FOCUS-format Export Mode for AI Gateway logs](https://app.notion.com/p/coderhq/FOCUS-format-Export-Mode-for-AI-Gateway-logs-3b2d579be5928032a32eecea6c906be0) ([ENG-3125](https://linear.app/codercom/issue/ENG-3125/rfc-focus-format-export-mode-for-ai-gateway-logs)), per the linked [Phase One Draft](https://app.notion.com/p/3c1d579be592816daa8fd5ffd5f70de1).

Adds a new, additive, experimental endpoint:

```
GET /api/experimental/organizations/{organization}/ai/spend/export/focus
```

that exports AI Gateway usage and cost data in a [FOCUS v1.2](https://focus.finops.org/docs/specification/v1-2/sections/introduction/)-shaped CSV or Parquet document, alongside the existing stable `/api/v2/.../ai/spend/export` endpoint (unchanged, unaffected). Gated behind `FeatureAIBridge` (existing license gate) **and** a new `focus-export` experiment (`CODER_EXPERIMENTS=focus-export`), off by default — two independent signals, neither a Coder-controlled kill switch, matching the RFC's stated approach for keeping this out of documented, supported surface area until Phase 2's config/UI work lands.

## What's implemented

- New AGPL package `coderd/aibridge/focus`: `UsageRecord`/`Row` DTOs, vendor and billing-account resolution, SKU building, CSV writer (with the existing export's formula-injection escaping duplicated per the license-boundary convention already established for that endpoint), and a Parquet writer (`github.com/parquet-go/parquet-go`, gzip codec).
- Two new SQL queries (`GetOrganizationAIFOCUSUsage`, `GetOrganizationAIFOCUSUsageRollup`), scoped to the organization via the same `effective_group_id → groups.organization_id` tenant-isolation signal the existing export already relies on.
- The new handler mirrors `exportOrganizationAISpend`'s authorization check (`rbac.ResourceGroupMember.InOrg`), period-parsing convention (`period_start`/`period_end`, UTC, 31-day max), and download-filename convention.
- Response headers in place of a full Phase-2 `manifest.json`: `X-Coder-Focus-Version`, `-Mapping-Version`, `-Generated-At`, `-Row-Count`, `-Checksum-Sha256`, plus `-Granularity-Seconds` (see deviation below).
- Tests: vendor/publisher/billing-account/SKU resolution and row-mapping unit tests against the RFC's four worked examples, CSV escaping, Parquet round-tripping, a reflection-based test pinning `Row` field order against the CSV header and Parquet tags, database-backed query tests (tenant isolation for both raw and rollup grains, soft-deleted-provider-name reuse, hourly rollup folding and its inverse, billing-period correctness at a month boundary, `ResourceId` determinism/collision/rename-stability), and HTTP-level tests (feature/experiment/org-read gating, format/granularity validation, cross-org access, real org-admin role, happy path for both formats).

## Deviations from the RFC / Phase One Draft — please read

**1. Granularity is a Phase-1 feature, not deferred to Phase 2.** Both documents scope Phase 1 to the finest, unrolled per-response grain only, with configurable rollup explicitly deferred to Phase 2's admin configuration surface. Per product direction, this PR ships a `granularity` query parameter (seconds; `0` = raw per-response grain, default `3600`/hourly, max `86400`/one day) with full rollup support now. Rollup groups by every FOCUS-reportable dimension (nothing is summed across a column the export must report distinctly); response-level identifiers collapse to null when a bucket folds more than one distinct underlying value; rolled-up rows get a deterministic synthetic `ResourceId`.

   One consequence worth flagging for FOCUS-conformance purposes: the RFC's declared capability profile states "Data Granularity: Supported... `ResourceId` is `token_usages.id`, unique per priced response" — true only at `granularity=0`. At `granularity>0`, `ResourceId` is the synthetic rollup UUID instead. Not a bug, just something to account for if/when this gets run through the FOCUS conformance validator.

**2. New third-party dependency: `github.com/parquet-go/parquet-go`.** Pure Go (`CGO_ENABLED=0` compatible), Apache-2.0 licensed, actively maintained fork of the archived `segmentio/parquet-go`. Its own footprint is close to free (four of its dependencies were already in this repo's tree); it adds:
   - `github.com/parquet-go/bitpack`, `github.com/parquet-go/jsonlite` (both MIT/Apache-2.0, first-party helper modules of the same project)
   - `github.com/twpayne/go-geom` (BSD-2-Clause) — a geometry library pulled in transitively for Parquet's geospatial logical types, **entirely unused by this code**
   - a bump of the existing indirect `github.com/pierrec/lz4/v4` from v4.1.18 → v4.1.21

   All four are permissively licensed with no reciprocal obligation on either the AGPL or enterprise-licensed portions of this codebase. Flagging explicitly per the usual supply-chain sign-off, especially the unused `go-geom` transitive.

## Known limitations (Phase 1, by design — see RFC for full detail)

- `BilledCost` is always `"0"`; `ContractedCost`/`EffectiveCost` equal `ListCost` (no invoice-backed or negotiated-rate relationship exists in AI Gateway's data model).
- `BillingAccountId`/`SubAccountId` are fixed-default policy (flat deployment value / BYOK surrogate; budget group), not yet admin-configurable — Phase 2.
- No workspace/project/team attribution (AI Gateway's data model doesn't capture it yet; see the RFC's Attribution gaps section).
- `openai-compat` (including self-hosted models) remains a collapsed vendor bucket with no further discriminator.
- Vendor-type resolution is a live join at export time, not a snapshot — a provider instance reconfigured or deleted after the fact can produce a wrong/missing vendor identity for historical rows (RFC Open Question Q1, accepted as-is).
- The response is fully buffered in memory before any bytes are written (to compute `Content-Length`/checksum); at the endpoint's 31-day max window this is a real memory-pressure consideration, not just a file-size one. Streaming is a known Phase-2-or-later follow-up.
- No `manifest.json`, no file-drop delivery, no admin configuration UI — all Phase 2.

## Testing

- `go build ./...`
- `go vet ./coderd/aibridge/focus/... ./enterprise/coderd/... ./coderd/aibridgedserver/...`
- `golangci-lint run ./coderd/aibridge/focus/... ./enterprise/coderd/... ./coderd/aibridgedserver/...` — 0 issues
- `go test ./coderd/aibridge/focus/...` — 23 tests
- `go test ./enterprise/coderd/ -run TestExportOrganizationAIFocus` — feature/experiment/org-read gating, format/granularity validation, cross-org access, org-admin role, happy path (CSV + Parquet + hourly rollup)
- `go test ./coderd/database/dbauthz/... -run TestMethodTestSuite/TestAIBridge` — RBAC wiring for both new queries

## Not in this PR (tracked separately / Phase 2+)

Admin configuration surface, file-drop delivery, full `manifest.json`, FOCUS conformance test suite against the FinOps Foundation's validator, PII-focused test suite. See the RFC's Phases section.
