### PR TITLE
chore(site): enable consistent-type-imports oxlint rule

### DIFF
--- a/site/.oxlintrc.jsonc
+++ b/site/.oxlintrc.jsonc
@@ -122,6 +122,7 @@
 		// --- style (recommended) ---
 		"no-array-constructor": "error",
 		"prefer-exponentiation-operator": "error",
+		"consistent-type-imports": "error",
 		"consistent-type-exports": "error",
 		"prefer-literal-enum-member": "error",
 		"prefer-node-protocol": "error",
@@ -206,7 +207,6 @@
 		"no-redeclare": "off", // suspicious/noRedeclare (medium: TS declaration merging)
 		"no-irregular-whitespace": "off", // suspicious/noIrregularWhitespace (medium)
 		"no-inferrable-types": "off", // style/noInferrableTypes (medium, coder error rule)
-		"consistent-type-imports": "off", // style/useImportType (medium)
 		"jsx-curly-brace-presence": "off", // style/useConsistentCurlyBraces (medium, coder error rule)
 		"no-fallthrough": "off", // suspicious/noFallthroughSwitchClause (medium)
 		"click-events-have-key-events": "off", // a11y/useKeyWithClickEvents (small)

--- a/site/.storybook/main.ts
+++ b/site/.storybook/main.ts
@@ -1,3 +1,5 @@
+import type { StorybookConfig } from "@storybook/react-vite";
+
 export default {
 	stories: ["../src/**/*.stories.tsx"],
 
@@ -32,4 +34,4 @@ export default {
 		};
 		return config;
 	},
-} satisfies import("@storybook/react-vite").StorybookConfig;
+} satisfies StorybookConfig;

--- a/site/src/pages/AgentsPage/components/ChatConversation/useChatStore.ts
+++ b/site/src/pages/AgentsPage/components/ChatConversation/useChatStore.ts
@@ -22,7 +22,10 @@ import {
 } from "#/api/queries/chats";
 import type * as TypesGen from "#/api/typesGenerated";
 import type { OneWayMessageEvent } from "#/utils/OneWayWebSocket";
-import { createReconnectingWebSocket } from "#/utils/reconnectingWebSocket";
+import {
+	createReconnectingWebSocket,
+	type ReconnectSchedule,
+} from "#/utils/reconnectingWebSocket";
 import { type ChatDetailError, normalizeChatErrorPayload } from "./chatError";
 import {
 	type ChatStore,
@@ -743,9 +746,7 @@ export const useChatStore = (
 				historyResetPending = false;
 				historyReplacementBuf.length = 0;
 			},
-			onDisconnect(
-				reconnectState: import("#/utils/reconnectingWebSocket").ReconnectSchedule,
-			) {
+			onDisconnect(reconnectState: ReconnectSchedule) {
 				// Only surface reconnecting when the disconnect
 				// interrupted active response work. Idle watcher
 				// reconnects stay silent.

--- a/site/src/pages/AgentsPage/components/ChatElements/tools/Tool.stories.tsx
+++ b/site/src/pages/AgentsPage/components/ChatElements/tools/Tool.stories.tsx
@@ -5,6 +5,7 @@ import { chatModelKey } from "#/api/queries/chats";
 import { workspaceBuildLogs } from "#/api/queries/workspaceBuilds";
 import { workspaceByIdKey } from "#/api/queries/workspaces";
 import type * as TypesGen from "#/api/typesGenerated";
+import type { MCPServerConfig } from "#/api/typesGenerated";
 import { MockChatModel } from "#/testHelpers/chatModels";
 import { MockWorkspace, MockWorkspaceBuild } from "#/testHelpers/entities";
 import { ChatWorkspaceContext } from "../../../context/ChatWorkspaceContext";
@@ -1364,7 +1365,7 @@ const sampleMCPServers = [
 		created_at: "2025-01-01T00:00:00Z",
 		updated_at: "2025-01-01T00:00:00Z",
 	},
-] satisfies readonly import("#/api/typesGenerated").MCPServerConfig[];
+] satisfies MCPServerConfig[];
 
 export const MCPToolRunning: Story = {
 	args: {


### PR DESCRIPTION
Moves [consistent-type-imports](https://oxc.rs/docs/guide/usage/linter/rules/typescript/consistent-type-imports.html) out of the Oxlint migration backlog and sets it to `error`.

In the 3 affected files, replaces dynamic `import()` syntax with `import type { Whatever } from "...";`

Verified with:
- `pnpm oxlint --deny-warnings`
- `pnpm biome lint --error-on-warnings`
- `pnpm tsc -p .`