### PR TITLE
chore(site): enable no-irregular-whitespace oxlint rule

### DIFF
--- a/site/.oxlintrc.jsonc
+++ b/site/.oxlintrc.jsonc
@@ -184,6 +184,7 @@
 		"no-export": "error",
 		"new-for-builtins": "error",
 		"no-explicit-any": "error",
+		"no-irregular-whitespace": "error",
 		"no-use-before-define": [
 			"error",
 			{ "functions": false, "classes": false, "variables": false }
@@ -205,7 +206,6 @@
 		"no-autofocus": "off", // a11y/noAutofocus (large)
 		"no-invalid-void-type": "off", // suspicious/noConfusingVoidType (large)
 		"no-redeclare": "off", // suspicious/noRedeclare (medium: TS declaration merging)
-		"no-irregular-whitespace": "off", // suspicious/noIrregularWhitespace (medium)
 		"no-inferrable-types": "off", // style/noInferrableTypes (medium, coder error rule)
 		"jsx-curly-brace-presence": "off", // style/useConsistentCurlyBraces (medium, coder error rule)
 		"no-fallthrough": "off", // suspicious/noFallthroughSwitchClause (medium)

--- a/site/src/utils/invisibleUnicode.test.ts
+++ b/site/src/utils/invisibleUnicode.test.ts
@@ -36,6 +36,7 @@ describe("countInvisibleCharacters", () => {
 	});
 
 	it("handles text with interleaved ZWS", () => {
+		// oxlint-disable-next-line eslint/no-irregular-whitespace
 		// "h​e​l​l​o" — 4 ZWS between visible chars.
 		expect(countInvisibleCharacters("h\u200be\u200bl\u200bl\u200bo")).toBe(4);
 	});


### PR DESCRIPTION
Moves [no-irregular-whitespace](https://oxc.rs/docs/guide/usage/linter/rules/eslint/no-irregular-whitespace.html) out of the Oxlint migration backlog and sets it to `error`.

Just 1 test file was affected; zero-width spaces (`\u200`) are necessary for a test assertion, so I disabled Oxlint for that line.

Verified with:
- `pnpm oxlint --deny-warnings`
- `pnpm biome lint --error-on-warnings`
- `pnpm tsc -p .`