### PR TITLE
chore(site): enable no-redeclare oxlint rule

### DIFF
--- a/site/.oxlintrc.jsonc
+++ b/site/.oxlintrc.jsonc
@@ -185,6 +185,7 @@
 		"new-for-builtins": "error",
 		"no-explicit-any": "error",
 		"no-irregular-whitespace": "error",
+		"no-redeclare": "error",
 		"no-use-before-define": [
 			"error",
 			{ "functions": false, "classes": false, "variables": false }
@@ -205,7 +206,6 @@
 		// ==========================================================
 		"no-autofocus": "off", // a11y/noAutofocus (large)
 		"no-invalid-void-type": "off", // suspicious/noConfusingVoidType (large)
-		"no-redeclare": "off", // suspicious/noRedeclare (medium: TS declaration merging)
 		"no-inferrable-types": "off", // style/noInferrableTypes (medium, coder error rule)
 		"jsx-curly-brace-presence": "off", // style/useConsistentCurlyBraces (medium, coder error rule)
 		"no-fallthrough": "off", // suspicious/noFallthroughSwitchClause (medium)

--- a/site/src/components/FullPageLayout/Sidebar.tsx
+++ b/site/src/components/FullPageLayout/Sidebar.tsx
@@ -55,11 +55,12 @@ export const SidebarCaption: FC<HTMLAttributes<HTMLSpanElement>> = (props) => {
 	);
 };
 
-interface SidebarIconButton extends ComponentProps<typeof TopbarIconButton> {
+interface SidebarIconButtonProps
+	extends ComponentProps<typeof TopbarIconButton> {
 	isActive: boolean;
 }
 
-export const SidebarIconButton: FC<SidebarIconButton> = ({
+export const SidebarIconButton: FC<SidebarIconButtonProps> = ({
 	isActive,
 	className,
 	...buttonProps

--- a/site/src/components/HelpPopover/HelpPopover.tsx
+++ b/site/src/components/HelpPopover/HelpPopover.tsx
@@ -104,12 +104,12 @@ export const HelpPopoverText: FC<HTMLAttributes<HTMLParagraphElement>> = ({
 	);
 };
 
-interface HelpPopoverLink {
+interface HelpPopoverLinkProps {
 	children?: ReactNode;
 	href: string;
 }
 
-export const HelpPopoverLink: FC<HelpPopoverLink> = ({ children, href }) => {
+export const HelpPopoverLink: FC<HelpPopoverLinkProps> = ({ children, href }) => {
 	return (
 		<a
 			href={href}

--- a/site/src/components/HelpPopover/HelpPopover.tsx
+++ b/site/src/components/HelpPopover/HelpPopover.tsx
@@ -109,7 +109,10 @@ interface HelpPopoverLinkProps {
 	href: string;
 }
 
-export const HelpPopoverLink: FC<HelpPopoverLinkProps> = ({ children, href }) => {
+export const HelpPopoverLink: FC<HelpPopoverLinkProps> = ({
+	children,
+	href,
+}) => {
 	return (
 		<a
 			href={href}

--- a/site/src/components/MultiUserSelect/MultiUserSelect.tsx
+++ b/site/src/components/MultiUserSelect/MultiUserSelect.tsx
@@ -83,7 +83,7 @@ export const MultiMemberSelect: FC<MemberAutocompleteProps> = ({
 	);
 };
 
-type UsersTable<T extends SelectedUser> = {
+type UsersTableProps<T extends SelectedUser> = {
 	error: unknown;
 	onChange: (user: T, checked: boolean) => void;
 	selected: readonly T[];
@@ -95,7 +95,7 @@ const UsersTable = <T extends SelectedUser>({
 	onChange,
 	selected,
 	users,
-}: UsersTable<T>) => {
+}: UsersTableProps<T>) => {
 	if (error) {
 		return (
 			<div className="p-3">

--- a/site/src/components/Timeline/TimelineDateRow.tsx
+++ b/site/src/components/Timeline/TimelineDateRow.tsx
@@ -3,11 +3,11 @@ import { TableCell, TableRow } from "#/components/Table/Table";
 import { formatDate } from "#/utils/time";
 import { createDisplayDate } from "./utils";
 
-export interface TimelineDateRow {
+interface TimelineDateRowProps {
 	date: Date;
 }
 
-export const TimelineDateRow: FC<TimelineDateRow> = ({ date }) => {
+export const TimelineDateRow: FC<TimelineDateRowProps> = ({ date }) => {
 	return (
 		<TableRow>
 			<TableCell

--- a/site/src/pages/TemplateSettingsPage/TemplateGeneralSettingsPage/TemplateSettingsForm.tsx
+++ b/site/src/pages/TemplateSettingsPage/TemplateGeneralSettingsPage/TemplateSettingsForm.tsx
@@ -66,7 +66,7 @@ export const validationSchema = Yup.object({
 	cors_behavior: Yup.string().oneOf(Object.values(CORSBehaviors)),
 });
 
-export interface TemplateSettingsForm {
+interface TemplateSettingsFormProps {
 	template: Template;
 	onSubmit: (data: UpdateTemplateMeta) => void;
 	onCancel: () => void;
@@ -79,7 +79,7 @@ export interface TemplateSettingsForm {
 	portSharingControlsEnabled: boolean;
 }
 
-export const TemplateSettingsForm: FC<TemplateSettingsForm> = ({
+export const TemplateSettingsForm: FC<TemplateSettingsFormProps> = ({
 	template,
 	onSubmit,
 	onCancel,

--- a/site/src/pages/TemplateSettingsPage/TemplateSchedulePage/TemplateScheduleForm.tsx
+++ b/site/src/pages/TemplateSettingsPage/TemplateSchedulePage/TemplateScheduleForm.tsx
@@ -61,7 +61,7 @@ const FAILURE_CLEANUP_DEFAULT = 7 * MS_DAY_CONVERSION;
 const INACTIVITY_CLEANUP_DEFAULT = 180 * MS_DAY_CONVERSION;
 const DORMANT_AUTODELETION_DEFAULT = 30 * MS_DAY_CONVERSION;
 
-export interface TemplateScheduleForm {
+interface TemplateScheduleFormProps {
 	template: Template;
 	onSubmit: (data: UpdateTemplateMeta) => void;
 	onCancel: () => void;
@@ -72,7 +72,7 @@ export interface TemplateScheduleForm {
 	initialTouched?: FormikTouched<UpdateTemplateMeta>;
 }
 
-export const TemplateScheduleForm: FC<TemplateScheduleForm> = ({
+export const TemplateScheduleForm: FC<TemplateScheduleFormProps> = ({
 	template,
 	onSubmit,
 	onCancel,

--- a/site/src/pages/TemplateSettingsPage/TemplateVariablesPage/TemplateVariablesForm.tsx
+++ b/site/src/pages/TemplateSettingsPage/TemplateVariablesPage/TemplateVariablesForm.tsx
@@ -21,7 +21,7 @@ import {
 	TemplateVariableField,
 } from "./TemplateVariableField";
 
-export interface TemplateVariablesForm {
+interface TemplateVariablesFormProps {
 	templateVersion: TemplateVersion;
 	templateVariables: TemplateVersionVariable[];
 	onSubmit: (data: CreateTemplateVersionRequest) => void;
@@ -31,7 +31,7 @@ export interface TemplateVariablesForm {
 	// Helpful to show field errors on Storybook
 	initialTouched?: FormikTouched<CreateTemplateVersionRequest>;
 }
-export const TemplateVariablesForm: FC<TemplateVariablesForm> = ({
+export const TemplateVariablesForm: FC<TemplateVariablesFormProps> = ({
 	templateVersion,
 	templateVariables,
 	onSubmit,

--- a/site/src/pages/WorkspacePage/WorkspaceNotifications/Notifications.tsx
+++ b/site/src/pages/WorkspacePage/WorkspaceNotifications/Notifications.tsx
@@ -10,7 +10,7 @@ import {
 } from "#/components/Popover/Popover";
 import type { ThemeRole } from "#/theme/roles";
 
-export type NotificationItem = {
+type Notification = {
 	title: string;
 	severity: AlertProps["severity"];
 	detail?: ReactNode;
@@ -20,7 +20,7 @@ export type NotificationItem = {
 type NotificationSeverity = "warning" | "info";
 
 type NotificationsProps = {
-	items: NotificationItem[];
+	items: Notification[];
 	severity: NotificationSeverity;
 	icon: ReactNode;
 };
@@ -131,7 +131,7 @@ const NotificationPill: FC<NotificationPillProps> = ({
 };
 
 interface NotificationItemProps {
-	notification: NotificationItem;
+	notification: Notification;
 }
 
 const NotificationItem: FC<NotificationItemProps> = ({ notification }) => {

--- a/site/src/pages/WorkspacePage/WorkspaceNotifications/Notifications.tsx
+++ b/site/src/pages/WorkspacePage/WorkspaceNotifications/Notifications.tsx
@@ -10,7 +10,7 @@ import {
 } from "#/components/Popover/Popover";
 import type { ThemeRole } from "#/theme/roles";
 
-type Notification = {
+export type Notification = {
 	title: string;
 	severity: AlertProps["severity"];
 	detail?: ReactNode;

--- a/site/src/pages/WorkspacePage/WorkspaceNotifications/WorkspaceNotifications.tsx
+++ b/site/src/pages/WorkspacePage/WorkspaceNotifications/WorkspaceNotifications.tsx
@@ -19,8 +19,8 @@ import { useQuery } from "react-query";
 import { formatDate } from "#/utils/time";
 import type { WorkspacePermissions } from "../../../modules/workspaces/permissions";
 import {
-	NotificationActionButton,
 	type Notification,
+	NotificationActionButton,
 	Notifications,
 } from "./Notifications";
 

--- a/site/src/pages/WorkspacePage/WorkspaceNotifications/WorkspaceNotifications.tsx
+++ b/site/src/pages/WorkspacePage/WorkspaceNotifications/WorkspaceNotifications.tsx
@@ -20,7 +20,7 @@ import { formatDate } from "#/utils/time";
 import type { WorkspacePermissions } from "../../../modules/workspaces/permissions";
 import {
 	NotificationActionButton,
-	type NotificationItem,
+	type Notification,
 	Notifications,
 } from "./Notifications";
 
@@ -43,7 +43,7 @@ export const WorkspaceNotifications: FC<WorkspaceNotificationsProps> = ({
 	onUpdateWorkspace,
 	onActivateWorkspace,
 }) => {
-	const notifications: NotificationItem[] = [];
+	const notifications: Notification[] = [];
 
 	// Outdated
 	const canAutostartQuery = useQuery(workspaceResolveAutostart(workspace.id));


### PR DESCRIPTION
Moves [no-redeclare](https://oxc.rs/docs/guide/usage/linter/rules/eslint/no-redeclare.html) out of the Oxlint migration backlog and sets it to `error`.

8 files were affected, all due to component props sharing their name with their component. I was able to remove unnecessary exports on 4 of these component props. 🙂 Previously Knip couldn't detect those interfaces as unused

Verified with:
- `pnpm oxlint --deny-warnings`
- `pnpm biome lint --error-on-warnings`
- `pnpm tsc -p .`