### PR TITLE
chore(site): enable no-inferrable-types oxlint rule

### DIFF
--- a/site/.oxlintrc.jsonc
+++ b/site/.oxlintrc.jsonc
@@ -134,6 +134,7 @@
 		"one-var": ["error", "never"],
 		"prefer-number-properties": ["error", { "checkInfinity": true }],
 		"no-else-return": ["error", { "allowElseIf": false }],
+		"no-inferrable-types": "error",
 
 		// --- suspicious ---
 		"no-cond-assign": "error",
@@ -206,7 +207,6 @@
 		"no-autofocus": "off", // a11y/noAutofocus (large)
 		"no-invalid-void-type": "off", // suspicious/noConfusingVoidType (large)
 		"no-redeclare": "off", // suspicious/noRedeclare (medium: TS declaration merging)
-		"no-inferrable-types": "off", // style/noInferrableTypes (medium, coder error rule)
 		"jsx-curly-brace-presence": "off", // style/useConsistentCurlyBraces (medium, coder error rule)
 		"no-fallthrough": "off", // suspicious/noFallthroughSwitchClause (medium)
 		"click-events-have-key-events": "off", // a11y/useKeyWithClickEvents (small)

--- a/site/src/api/queries/templates.ts
+++ b/site/src/api/queries/templates.ts
@@ -149,7 +149,7 @@ export const templateExamples = () => {
 	};
 };
 
-export const templateVersionRoot: string = "templateVersion";
+export const templateVersionRoot = "templateVersion";
 
 export const templateVersion = (versionId: string) => {
 	return {

--- a/site/src/testHelpers/entities.ts
+++ b/site/src/testHelpers/entities.ts
@@ -662,7 +662,7 @@ export const MockImportedUserSecrets: TypesGen.UserSecret[] = [
 	},
 ];
 
-export const MockAIGatewayEnabled: boolean = true;
+export const MockAIGatewayEnabled = true;
 
 export const MockOrganizationMember: TypesGen.OrganizationMemberWithUserData = {
 	organization_id: MockOrganization.id,


### PR DESCRIPTION
Moves [no-inferrable-types](https://oxc.rs/docs/guide/usage/linter/rules/typescript/no-inferrable-types.html) out of the Oxlint migration backlog and sets it to `error`.

Verified with:
- `pnpm oxlint --deny-warnings`
- `pnpm biome lint --error-on-warnings`
- `pnpm tsc -p .`