### PR TITLE
chore(site): enable jsx-curly-brace-presence oxlint rule

### DIFF
--- a/site/.oxlintrc.jsonc
+++ b/site/.oxlintrc.jsonc
@@ -134,6 +134,7 @@
 		"one-var": ["error", "never"],
 		"prefer-number-properties": ["error", { "checkInfinity": true }],
 		"no-else-return": ["error", { "allowElseIf": false }],
+		"jsx-curly-brace-presence": "error",
 
 		// --- suspicious ---
 		"no-cond-assign": "error",
@@ -207,7 +208,6 @@
 		"no-invalid-void-type": "off", // suspicious/noConfusingVoidType (large)
 		"no-redeclare": "off", // suspicious/noRedeclare (medium: TS declaration merging)
 		"no-inferrable-types": "off", // style/noInferrableTypes (medium, coder error rule)
-		"jsx-curly-brace-presence": "off", // style/useConsistentCurlyBraces (medium, coder error rule)
 		"no-fallthrough": "off", // suspicious/noFallthroughSwitchClause (medium)
 		"click-events-have-key-events": "off", // a11y/useKeyWithClickEvents (small)
 		"prefer-function-type": "off", // style/useShorthandFunctionType (small)

--- a/site/src/components/TagInput/TagInput.tsx
+++ b/site/src/components/TagInput/TagInput.tsx
@@ -83,7 +83,7 @@ export const TagInput: FC<TagInputProps> = ({
 			</div>
 
 			<p className="text-content-secondary text-xs mt-1">
-				{'Type "," to separate the values'}
+				Type "," to separate the values
 			</p>
 		</div>
 	);

--- a/site/src/modules/resources/AgentExternal.tsx
+++ b/site/src/modules/resources/AgentExternal.tsx
@@ -37,7 +37,7 @@ export const AgentExternal: FC<AgentExternalProps> = ({ agent, workspace }) => {
 				code={credentials?.command ?? ""}
 				secret={false}
 				redactPattern={/CODER_AGENT_TOKEN="([^"]+)"/g}
-				redactReplacement={`CODER_AGENT_TOKEN="********"`}
+				redactReplacement='CODER_AGENT_TOKEN="********"'
 				showRevealButton
 			/>
 		</section>

--- a/site/src/pages/TemplatePage/TemplateInsightsPage/TemplateInsightsPage.tsx
+++ b/site/src/pages/TemplatePage/TemplateInsightsPage/TemplateInsightsPage.tsx
@@ -442,57 +442,55 @@ const TemplateUsagePanel: FC<TemplateUsagePanelProps> = ({
 				<PanelTitle>App & IDE Usage</PanelTitle>
 			</PanelHeader>
 			<PanelContent error={error} data={validUsage}>
-				{
-					<div className="flex flex-col gap-6">
-						{(validUsage || []).map((usage, i) => {
-							const percentage = (usage.seconds / totalInSeconds) * 100;
-							const colorStop =
-								usageCount <= 1 ? 0 : (i / (usageCount - 1)) * 100;
-							return (
-								<div key={usage.slug} className="flex items-center gap-6">
-									<div className="flex items-center gap-2">
-										<div className="flex justify-center items-center size-5">
-											<ExternalImage
-												src={usage.icon}
-												alt=""
-												className="h-full w-full object-contain"
-											/>
-										</div>
-										<div className="text-sm font-medium w-[200px]">
-											{usage.display_name}
-										</div>
+				<div className="flex flex-col gap-6">
+					{(validUsage || []).map((usage, i) => {
+						const percentage = (usage.seconds / totalInSeconds) * 100;
+						const colorStop =
+							usageCount <= 1 ? 0 : (i / (usageCount - 1)) * 100;
+						return (
+							<div key={usage.slug} className="flex items-center gap-6">
+								<div className="flex items-center gap-2">
+									<div className="flex justify-center items-center size-5">
+										<ExternalImage
+											src={usage.icon}
+											alt=""
+											className="h-full w-full object-contain"
+										/>
 									</div>
-									<Tooltip>
-										<TooltipTrigger asChild>
-											<div className="relative w-full h-2 rounded-full bg-surface-quaternary">
-												<div
-													className="absolute inset-y-0 left-0 rounded-full"
-													style={{
-														width: `${percentage}%`,
-														backgroundColor: `color-mix(in lch, var(--color-content-success), var(--color-content-warning) ${colorStop}%)`,
-													}}
-												/>
-											</div>
-										</TooltipTrigger>
-										<TooltipContent>
-											{Math.floor(percentage)}%
-											<TooltipArrow className="fill-border" />
-										</TooltipContent>
-									</Tooltip>
-									<div className="flex flex-col text-sm font-normal shrink-0 leading-normal text-content-secondary w-[120px]">
-										{formatTime(usage.seconds)}
-										{usage.times_used > 0 && (
-											<span className="text-[12px] text-content-disabled">
-												Opened {usage.times_used.toLocaleString()}{" "}
-												{usage.times_used === 1 ? "time" : "times"}
-											</span>
-										)}
+									<div className="text-sm font-medium w-[200px]">
+										{usage.display_name}
 									</div>
 								</div>
-							);
-						})}
-					</div>
-				}
+								<Tooltip>
+									<TooltipTrigger asChild>
+										<div className="relative w-full h-2 rounded-full bg-surface-quaternary">
+											<div
+												className="absolute inset-y-0 left-0 rounded-full"
+												style={{
+													width: `${percentage}%`,
+													backgroundColor: `color-mix(in lch, var(--color-content-success), var(--color-content-warning) ${colorStop}%)`,
+												}}
+											/>
+										</div>
+									</TooltipTrigger>
+									<TooltipContent>
+										{Math.floor(percentage)}%
+										<TooltipArrow className="fill-border" />
+									</TooltipContent>
+								</Tooltip>
+								<div className="flex flex-col text-sm font-normal shrink-0 leading-normal text-content-secondary w-[120px]">
+									{formatTime(usage.seconds)}
+									{usage.times_used > 0 && (
+										<span className="text-[12px] text-content-disabled">
+											Opened {usage.times_used.toLocaleString()}{" "}
+											{usage.times_used === 1 ? "time" : "times"}
+										</span>
+									)}
+								</div>
+							</div>
+						);
+					})}
+				</div>
 			</PanelContent>
 		</Panel>
 	);


### PR DESCRIPTION
Moves [jsx-curly-brace-presence](https://oxc.rs/docs/guide/usage/linter/rules/react/jsx-curly-brace-presence) out of the Oxlint migration backlog and sets it to `error`.

3 files affected. This one was auto-fixable ✨

Verified with:
- `pnpm oxlint --deny-warnings`
- `pnpm biome lint --error-on-warnings`
- `pnpm tsc -p .`