### PR TITLE
fix(site/src/components/MultiSelectCombobox): minimize scrolling when command list scrolls into view

### DIFF
--- a/site/src/components/MultiSelectCombobox/MultiSelectCombobox.tsx
+++ b/site/src/components/MultiSelectCombobox/MultiSelectCombobox.tsx
@@ -355,7 +355,7 @@ export const MultiSelectCombobox: React.FC<MultiSelectComboboxProps> = ({
 			return;
 		}
 
-		listRef.current.scrollIntoView({ behavior: "smooth" });
+		listRef.current.scrollIntoView({ block: "nearest", behavior: "smooth" });
 	}, [open]);
 
 	const CreatableItem = () => {
@@ -598,13 +598,14 @@ export const MultiSelectCombobox: React.FC<MultiSelectComboboxProps> = ({
 					</div>
 				</div>
 			</div>
-			<div className="relative" ref={listRef}>
+			<div className="relative">
 				{open && (
 					<CommandList
+						ref={listRef}
 						className={`absolute top-1 z-10 w-full rounded-md
 								border border-solid border-border
 								bg-surface-primary text-content-primary shadow-md outline-hidden
-								animate-in`}
+								animate-in scroll-mt-44 scroll-mb-10`}
 						onPointerLeave={() => {
 							setOnScrollbar(false);
 						}}


### PR DESCRIPTION
fixes DEVEX-711

The fix:

1. Add `block: "nearest"` to `scrollIntoView`'s options
    - This makes it so that when the combobox is scrolled into view, scrolling stops as soon as the combobox and its options are fully visible.
    - I also added some scroll margins so that the combobox label (above) / deployment banner (below) remain visible too
3. Move `listRef` to the `CommandList`, so that the command list's entire height is taken into account
    - `listRef` is the target element for `scrollIntoView`. If `listRef` is kept on `CommandList`'s parent div, then the options (command list) will overflow the screen when the page scrolls to the combobox

I had considered disabling `scrollIntoView`, but that would've reintroduced #18785. That would be a great bug to fix with anchor positioning--if its browser/Tailwind support were better 🥲

## screen recordings

before|after
---|---
https://github.com/user-attachments/assets/e1d1e2bf-b441-4c07-bbd8-f3672eb607e5 | https://github.com/user-attachments/assets/c0dca41a-811f-413a-8569-6aaeed2c7f3e

